### PR TITLE
Config/FE/#8: build 버그 수정

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -2,7 +2,12 @@ import react from '@vitejs/plugin-react';
 import { defineConfig } from 'vite';
 import tsconfigPaths from 'vite-tsconfig-paths';
 
-// https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react(), tsconfigPaths()],
+
+  build: {
+    rollupOptions: {
+      external: new RegExp('@__mocks__/.*'),
+    },
+  },
 });


### PR DESCRIPTION

## 🤷‍♂️ Description
- frontend 폴더에서 build시 에러 발생

<!-- 구현 한 기능에 대해 작성해 주세요. -->

## 📝 Primary Commits

<!-- 세부 구현 사항을 리스트로 작성해주세요. -->

- [X] vite.config.ts파일에서 msw라이브러리가 사용되는 __mocks__폴더를 빌드시 제외하게 설정함
```ts
import react from '@vitejs/plugin-react';
import { defineConfig } from 'vite';
import tsconfigPaths from 'vite-tsconfig-paths';

export default defineConfig({
  plugins: [react(), tsconfigPaths()],

  build: {
    rollupOptions: {
      external: new RegExp('@__mocks__/.*'),
    },
  },
});
```

## 📷 Screenshots
- build 성공
![image](https://github.com/boostcampwm2023/web03-LockFestival/assets/82202370/d26e2069-0d0a-4495-bafb-6890010c80eb)


<!--스크린샷으로 보여줄 수 있는 이미지가 있다면 첨부해주세요!-->

<!--BE의 경우 API 테스트 결과를 첨부해주세요-->

<!--마지막으로 이슈 생성 시 우측의 옵션들을 체크했는지 확인해주세요!-->

closes #8

