### PR TITLE
Fix/FE/#12: msw 빌드 에러 해결 및 jsdom 사용

### DIFF
--- a/frontend/.eslintrc.cjs
+++ b/frontend/.eslintrc.cjs
@@ -39,5 +39,5 @@ module.exports = {
       },
     ],
   },
-  ignorePatterns: ['.eslintrc.cjs', 'vite.config.ts', 'jest.config.ts', 'setupTest.ts', 'public/'],
+  ignorePatterns: ['.eslintrc.cjs', 'vite.config.ts', 'jest.config.ts', 'jest.setup.ts', 'public/'],
 };

--- a/frontend/jest.config.ts
+++ b/frontend/jest.config.ts
@@ -1,11 +1,14 @@
 export default {
   testEnvironment: 'jsdom',
+  testEnvironmentOptions: {
+    customExportConditions: [''],
+  },
   transform: {
     '^.+\\.tsx?$': 'ts-jest',
   },
   testMatch: ['**/__tests__/**/*.+(ts|tsx|js)', '**/?(*.)+(spec|test).+(ts|tsx|js)'],
   transformIgnorePatterns: ['<rootDir>/node_modules/'],
-  setupFilesAfterEnv: ['<rootDir>/setupTest.ts'],
+  setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
   moduleNameMapper: {
     '^.+\\.svg$': 'jest-svg-transformer',
     '\\.(css|less|sass|scss)$': 'identity-obj-proxy',
@@ -20,4 +23,5 @@ export default {
     '^@utils/(.*)$': '<rootDir>/src/utils/$1',
     '^@types/(.*)$': '<rootDir>/src/@types/$1',
   },
+  setupFiles: ['./jest.polyfills.js'],
 };

--- a/frontend/jest.polyfills.js
+++ b/frontend/jest.polyfills.js
@@ -1,0 +1,29 @@
+// jest.polyfills.js
+/**
+ * @note The block below contains polyfills for Node.js globals
+ * required for Jest to function when running JSDOM tests.
+ * These HAVE to be require's and HAVE to be in this exact
+ * order, since "undici" depends on the "TextEncoder" global API.
+ *
+ * Consider migrating to a more modern test runner if
+ * you don't want to deal with this.
+ */
+
+const { TextDecoder, TextEncoder } = require('node:util');
+
+Object.defineProperties(globalThis, {
+  TextDecoder: { value: TextDecoder },
+  TextEncoder: { value: TextEncoder },
+});
+
+const { Blob } = require('node:buffer');
+const { fetch, Headers, FormData, Request, Response } = require('undici');
+
+Object.defineProperties(globalThis, {
+  fetch: { value: fetch, writable: true },
+  Blob: { value: Blob },
+  Headers: { value: Headers },
+  FormData: { value: FormData },
+  Request: { value: Request },
+  Response: { value: Response },
+});

--- a/frontend/jest.setup.ts
+++ b/frontend/jest.setup.ts
@@ -1,0 +1,7 @@
+import '@testing-library/jest-dom';
+import { server } from './src/__mocks__/server';
+import { beforeAll, afterAll, afterEach } from '@jest/globals';
+
+beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -44,6 +44,7 @@
     "ts-jest": "^29.1.1",
     "ts-node": "^10.9.1",
     "typescript": "^5.0.2",
+    "undici": "^5.27.2",
     "vite": "^4.4.5",
     "vite-tsconfig-paths": "^4.2.1"
   },

--- a/frontend/setupTest.ts
+++ b/frontend/setupTest.ts
@@ -1,1 +1,0 @@
-import '@testing-library/jest-dom';

--- a/frontend/src/__mocks__/index.ts
+++ b/frontend/src/__mocks__/index.ts
@@ -1,11 +1,6 @@
 const initMockAPI = async (): Promise<void> => {
-  if (typeof window === 'undefined') {
-    const { server } = await import('@__mocks__/server');
-    server.listen({ onUnhandledRequest: 'bypass' });
-  } else {
-    const { worker } = await import('@__mocks__/browser');
-    worker.start();
-  }
+  const { worker } = await import('@__mocks__/browser');
+  worker.start();
 };
 
 export default initMockAPI;

--- a/frontend/src/__mocks__/server.ts
+++ b/frontend/src/__mocks__/server.ts
@@ -1,4 +1,3 @@
-// src/mocks/node.js
 import { setupServer } from 'msw/node';
 
 export const server = setupServer();

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -4,10 +4,4 @@ import tsconfigPaths from 'vite-tsconfig-paths';
 
 export default defineConfig({
   plugins: [react(), tsconfigPaths()],
-
-  build: {
-    rollupOptions: {
-      external: new RegExp('@__mocks__/.*'),
-    },
-  },
 });

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -605,6 +605,11 @@
   resolved "https://registry.yarnpkg.com/@eslint/js/-/js-8.53.0.tgz#bea56f2ed2b5baea164348ff4d5a879f6f81f20d"
   integrity sha512-Kn7K8dx/5U6+cT1yEhpX1w4PCSg0M+XyRILPgvwcEBjerFWCwQj5sbr3/VmxqV0JGHCBCzyd6LxypEuehypY1w==
 
+"@fastify/busboy@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@fastify/busboy/-/busboy-2.0.0.tgz#f22824caff3ae506b18207bad4126dbc6ccdb6b8"
+  integrity sha512-JUFJad5lv7jxj926GPgymrWQxxjPYuJNiNjNMzqT+HiuP6Vl3dk5xzG+8sTX96np0ZAluvaMzPsjhHZ5rNuNQQ==
+
 "@humanwhocodes/config-array@^0.11.13":
   version "0.11.13"
   resolved "https://registry.yarnpkg.com/@humanwhocodes/config-array/-/config-array-0.11.13.tgz#075dc9684f40a531d9b26b0822153c1e832ee297"
@@ -5220,6 +5225,13 @@ undici-types@~5.26.4:
   version "5.26.5"
   resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-5.26.5.tgz#bcd539893d00b56e964fd2657a4866b221a65617"
   integrity sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==
+
+undici@^5.27.2:
+  version "5.27.2"
+  resolved "https://registry.yarnpkg.com/undici/-/undici-5.27.2.tgz#a270c563aea5b46cc0df2550523638c95c5d4411"
+  integrity sha512-iS857PdOEy/y3wlM3yRp+6SNQQ6xU0mmZcwRSriqk+et/cwWAtwmIGf6WkoDN2EK/AMdCO/dfXzIwi+rFMrjjQ==
+  dependencies:
+    "@fastify/busboy" "^2.0.0"
 
 universalify@^0.2.0:
   version "0.2.0"


### PR DESCRIPTION
## 🤷‍♂️ Description

initMockAPI에서 server.ts를 import해서 빌드가 불가능한 문제를 해결했어요.
- 기존에 initMockAPI에서 server.ts 또한 import하였는데 server.ts의 경우 테스트 환경에서만 사용하므로 import를 제거했어요.
- 대신 jest.setup.ts에 server.ts를 불러오는 로직을 추가했어요.

msw에서 jsdom을 사용할 수 있도록 변경했어요.
- 현재로써는 react-testing-library가 사용이 되는데 만약에 더 많은 이슈가 발생하면 msw를 version 1으로 변경해야할 것 같아요

- msw가 version 2로 변경되면서 jsdom과 크고 작은 이슈가 많았는데 해당 이슈와 사용법을 아래 블로그에 정리했어요.

[MSW 포스팅](https://velog.io/@navyjeongs/MSW-%EB%B0%B1%EC%97%94%EB%93%9C%EA%B0%80-api%EB%A5%BC-%EB%A7%8C%EB%93%A4%EC%96%B4%EC%A3%BC%EC%A7%80-%EC%95%8A%EC%95%84%EC%9A%94...-%EA%B7%B8%EB%9F%B0-%EB%8B%B9%EC%8B%A0%EC%9D%84-%EC%9C%84%ED%95%9C-MSW)

## 📝 Primary Commits


- [X] initMockAPI에서 server.ts를 import해서 빌드가 불가능한 문제를 해결
- [X] msw에서 jsdom을 사용할 수 있도록 변경

## 📷 Screenshots


빌드성공

<img width="450" alt="nmbnm" src="https://github.com/boostcampwm2023/web03-LockFestival/assets/100738049/eb1afc1c-96c8-401d-b3a1-22f0da5d98c0">

react-testing-library 사용 성공

<img width="507" alt="6" src="https://github.com/boostcampwm2023/web03-LockFestival/assets/100738049/b6ae59d5-1ff6-4712-8728-32d21eaf3f75">


<!--스크린샷으로 보여줄 수 있는 이미지가 있다면 첨부해주세요!-->

<!--BE의 경우 API 테스트 결과를 첨부해주세요-->

<!--마지막으로 이슈 생성 시 우측의 옵션들을 체크했는지 확인해주세요!-->

<!-- 이슈번호를 작성해주세요. -->
<!-- 여러 이슈를 입력시 comma(,) 단위로 구분해주세요 -->
<!-- ex) close #10, resolves #123 -->


<!-- ex) -->
closes #12 
