### PR TITLE
Feature/FE/#18 : reset css 작성

### DIFF
--- a/frontend/src/GlobalStyles.tsx
+++ b/frontend/src/GlobalStyles.tsx
@@ -1,0 +1,139 @@
+import { Global, css } from '@emotion/react';
+
+const globalStyle = css`
+  html {
+    font-size: 62.5%;
+  }
+  html,
+  body,
+  div,
+  span,
+  applet,
+  object,
+  iframe,
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6,
+  p,
+  blockquote,
+  pre,
+  a,
+  abbr,
+  acronym,
+  address,
+  big,
+  cite,
+  code,
+  del,
+  dfn,
+  em,
+  img,
+  ins,
+  kbd,
+  q,
+  s,
+  samp,
+  small,
+  strike,
+  strong,
+  sub,
+  sup,
+  tt,
+  var,
+  b,
+  u,
+  i,
+  center,
+  dl,
+  dt,
+  dd,
+  ol,
+  ul,
+  li,
+  fieldset,
+  form,
+  label,
+  legend,
+  table,
+  caption,
+  tbody,
+  tfoot,
+  thead,
+  tr,
+  th,
+  td,
+  article,
+  aside,
+  canvas,
+  details,
+  embed,
+  figure,
+  figcaption,
+  footer,
+  header,
+  hgroup,
+  menu,
+  nav,
+  output,
+  ruby,
+  section,
+  summary,
+  time,
+  mark,
+  audio,
+  button,
+  video {
+    margin: 0;
+    padding: 0;
+    border: 0;
+    vertical-align: baseline;
+  }
+  /* HTML5 display-role reset for older browsers */
+  article,
+  aside,
+  details,
+  figcaption,
+  figure,
+  footer,
+  header,
+  hgroup,
+  menu,
+  nav,
+  section {
+    display: block;
+  }
+  body {
+    line-height: 1;
+  }
+  ol,
+  ul {
+    list-style: none;
+  }
+  blockquote,
+  q {
+    quotes: none;
+  }
+  blockquote:before,
+  blockquote:after,
+  q:before,
+  q:after {
+    content: '';
+    content: none;
+  }
+  table {
+    border-collapse: collapse;
+    border-spacing: 0;
+  }
+  * {
+    box-sizing: border-box;
+  }
+`;
+
+const GlobalStyle = () => {
+  return <Global styles={globalStyle}></Global>;
+};
+
+export default GlobalStyle;

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App.tsx';
 import initMockAPI from '@__mocks__/index.ts';
+import GlobalStyle from 'GlobalStyles.tsx';
 
 async function deferRender() {
   if (!import.meta.env.DEV) {
@@ -14,6 +15,7 @@ async function deferRender() {
 deferRender().then(() => {
   ReactDOM.createRoot(document.getElementById('root')!).render(
     <React.StrictMode>
+      <GlobalStyle />
       <App />
     </React.StrictMode>
   );


### PR DESCRIPTION


## 🤷‍♂️ Description

- 브라우저별 동일한 디자인을 위해 디폴트 속성을 제거했어요.
- emotion의 Global을 사용해서 reset 속성을 적용했어요.
- reset.css의 내용은 https://meyerweb.com/eric/tools/css/reset/ 를 참고했습니다.
    - 추가적으로 rem 작업의 편리를 위해 html의 font-size를 62.5%로 설정했습니다. 
    - 또, 버튼의 기본 margin, padding 또한 0으로 설정했습니다.


- 10px은 1rem으로 작성할 수 있습니다!
- 추후에 사용할 폰트가 확정되면 GlobalStyle에 추가 작성할 수 있습니다
## 📝 Primary Commits

<!-- 세부 구현 사항을 리스트로 작성해주세요. -->

- [x] GlobalStyle 작성
- [x] GlobalStyle 적용

## 📷 Screenshots

<!--스크린샷으로 보여줄 수 있는 이미지가 있다면 첨부해주세요!-->

<!--BE의 경우 API 테스트 결과를 첨부해주세요-->

<!--마지막으로 이슈 생성 시 우측의 옵션들을 체크했는지 확인해주세요!-->

<!-- 이슈번호를 작성해주세요. -->
<!-- 여러 이슈를 입력시 comma(,) 단위로 구분해주세요 -->
<!-- ex) close #10, resolves #123 -->


<!-- ex) -->
<!-- closes #1 --> 

closes #18 