### PR TITLE
Fix/BE/#16 : 백엔드 eslint 미적용 오류 해결

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -5,7 +5,6 @@
   "author": "",
   "private": true,
   "license": "UNLICENSED",
-  "type": "module",
   "scripts": {
     "build": "nest build",
     "format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\"",


### PR DESCRIPTION
## 🤷‍♂️ Description
eslint가 적용되지 않는 버그가 있습니다.

<!-- 구현 한 기능에 대해 작성해 주세요. -->

## 📝 Primary Commits

<!-- 세부 구현 사항을 리스트로 작성해주세요. -->

- nest.js의 구현체가 commonjs로 구성되어 eslint 충돌에러 발생
  - [X] package.json의 `"type":"module"` 제거
## 📷 Screenshots
- arrow-body-style 에 대한 오류 발생
  ![image](https://github.com/boostcampwm2023/web03-LockFestival/assets/44056518/949fa4e2-8e73-4234-a145-b6f263affe2f)





closes #16

