### PR TITLE
Feature/BE/#47: ERD에 설계된 entity를 typeorm에 적용

### DIFF
--- a/backend/src/entity/baseTime.entity.ts
+++ b/backend/src/entity/baseTime.entity.ts
@@ -1,0 +1,22 @@
+import { CreateDateColumn, UpdateDateColumn } from 'typeorm';
+
+export abstract class BaseTime {
+  @CreateDateColumn({
+    name: 'created_at',
+    type: 'timestamp',
+    default: () => {
+      return 'CURRENT_TIMESTAMP(6)';
+    },
+  })
+  createdAt: Date;
+
+  @UpdateDateColumn({
+    name: 'updated_at',
+    type: 'timestamp',
+    default: () => {
+      return 'CURRENT_TIMESTAMP(6)';
+    },
+    onUpdate: 'CURRENT_TIMESTAMP(6)',
+  })
+  updatedAt: Date;
+}

--- a/backend/src/entity/branch.entity.ts
+++ b/backend/src/entity/branch.entity.ts
@@ -1,0 +1,44 @@
+import { Entity, Column, PrimaryGeneratedColumn, JoinColumn, ManyToOne } from 'typeorm';
+import { BaseTime } from './baseTime.entity';
+import { Brand } from './brand.entity';
+
+@Entity()
+export class Branch extends BaseTime {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column()
+  website: string;
+
+  @Column({ name: 'phone_number' })
+  phoneNumber: string;
+
+  @Column({ name: 'branch_name' })
+  branchName: string;
+
+  @Column()
+  address: string;
+
+  //TODO: ENUM으로 바꾸기
+  @Column({ name: 'big_region' })
+  bigRegion: string;
+
+  //TODO: ENUM으로 바꾸기
+  @Column({ name: 'small_region' })
+  smallRegion: string;
+
+  @Column('decimal', { precision: 10, scale: 6 })
+  x: number;
+
+  @Column('decimal', { precision: 10, scale: 6 })
+  y: number;
+
+  @ManyToOne(
+    () => {
+      return Brand;
+    },
+    { nullable: false }
+  )
+  @JoinColumn({ name: 'brand_id', referencedColumnName: 'id' })
+  brand: Brand;
+}

--- a/backend/src/entity/brand.entity.ts
+++ b/backend/src/entity/brand.entity.ts
@@ -1,0 +1,10 @@
+import { Entity, Column, PrimaryGeneratedColumn } from 'typeorm';
+import { BaseTime } from './baseTime.entity';
+@Entity()
+export class Brand extends BaseTime {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column({ name: 'brand_name' })
+  brandName: string;
+}

--- a/backend/src/entity/diary.entity.ts
+++ b/backend/src/entity/diary.entity.ts
@@ -1,0 +1,40 @@
+import { Entity, Column, PrimaryGeneratedColumn, OneToOne, JoinColumn } from 'typeorm';
+import { Group } from './group.entity';
+import { BaseTime } from './baseTime.entity';
+import { User } from './user.entity';
+
+@Entity()
+export class Diary extends BaseTime {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column({ name: 'is_success', nullable: true })
+  isSuccess: boolean;
+
+  @Column({ name: 'left_time', nullable: true })
+  leftTime: number;
+
+  @Column({ name: 'used_hint_count', nullable: true })
+  usedHintCount: number;
+
+  @Column({ name: 'escape_image_url', nullable: true })
+  escapeImageUrl: string;
+
+  @OneToOne(
+    () => {
+      return Group;
+    },
+    { nullable: false }
+  )
+  @JoinColumn({ name: 'group_id', referencedColumnName: 'id' })
+  group: Group;
+
+  @OneToOne(
+    () => {
+      return User;
+    },
+    { nullable: false }
+  )
+  @JoinColumn({ name: 'creator_id', referencedColumnName: 'id' })
+  creator: User;
+}

--- a/backend/src/entity/diaryComment.entity.ts
+++ b/backend/src/entity/diaryComment.entity.ts
@@ -1,0 +1,30 @@
+import { Entity, Column, PrimaryGeneratedColumn, OneToOne, JoinColumn } from 'typeorm';
+import { BaseTime } from './baseTime.entity';
+import { User } from './user.entity';
+import { Diary } from './diary.entity';
+@Entity()
+export class DiaryComment extends BaseTime {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column('text')
+  comment: string;
+
+  @OneToOne(
+    () => {
+      return User;
+    },
+    { nullable: false }
+  )
+  @JoinColumn({ name: 'writer_id', referencedColumnName: 'id' })
+  writer: User;
+
+  @OneToOne(
+    () => {
+      return Diary;
+    },
+    { nullable: false }
+  )
+  @JoinColumn({ name: 'diary_id', referencedColumnName: 'id' })
+  diary: Diary;
+}

--- a/backend/src/entity/genre.entity.ts
+++ b/backend/src/entity/genre.entity.ts
@@ -1,0 +1,10 @@
+import { Entity, Column, PrimaryGeneratedColumn } from 'typeorm';
+import { BaseTime } from './baseTime.entity';
+@Entity()
+export class Genre extends BaseTime {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column()
+  name: string;
+}

--- a/backend/src/entity/group.entity.ts
+++ b/backend/src/entity/group.entity.ts
@@ -18,7 +18,7 @@ export class Group extends BaseTime {
   @Column({ name: 'recruitment_members' })
   recruitmentMembers: number;
 
-  @Column({ name: 'recruitment_content' })
+  @Column({ name: 'recruitment_content', length: 50 })
   recruitmentContent: string;
 
   @Column({ name: 'recruitment_completed', default: false })

--- a/backend/src/entity/group.entity.ts
+++ b/backend/src/entity/group.entity.ts
@@ -1,0 +1,63 @@
+import { Entity, Column, PrimaryGeneratedColumn, JoinColumn, OneToOne, OneToMany } from 'typeorm';
+import { User } from './user.entity';
+import { Theme } from './theme.entity';
+import { BaseTime } from './baseTime.entity';
+import { UserGroup } from './userGroup.entity';
+
+@Entity()
+export class Group extends BaseTime {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column({ default: 1, name: 'current_members' })
+  currentMembers: number;
+
+  @Column({ default: false, name: 'diary_created' })
+  diaryCreated: boolean;
+
+  @Column({ name: 'recruitment_members' })
+  recruitmentMembers: number;
+
+  @Column({ name: 'recruitment_content' })
+  recruitmentContent: string;
+
+  @Column({ name: 'recruitment_completed', default: false })
+  recruitmentCompleted: boolean;
+
+  @Column({ nullable: true })
+  password: string;
+
+  @Column({ name: 'appointment_date' })
+  appointmentDate: Date;
+
+  @Column({ name: ' appointment_time', nullable: true })
+  appointmentTime: string;
+
+  @OneToOne(
+    () => {
+      return User;
+    },
+    { nullable: false }
+  )
+  @JoinColumn({ name: 'leader_id', referencedColumnName: 'id' })
+  leader: User;
+
+  @OneToOne(
+    () => {
+      return Theme;
+    },
+    { nullable: false }
+  )
+  @JoinColumn({ name: 'theme_id', referencedColumnName: 'id' })
+  theme: Theme;
+
+  @OneToMany(
+    () => {
+      return UserGroup;
+    },
+    (userGroups) => {
+      return userGroups.group;
+    }
+  )
+  userGroups: UserGroup[];
+}

--- a/backend/src/entity/theme.entity.ts
+++ b/backend/src/entity/theme.entity.ts
@@ -1,0 +1,54 @@
+import { Entity, Column, PrimaryGeneratedColumn, OneToOne, JoinColumn } from 'typeorm';
+import { Branch } from './branch.entity';
+import { Genre } from './genre.entity';
+import { BaseTime } from './baseTime.entity';
+
+@Entity()
+export class Theme extends BaseTime {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column()
+  name: string;
+
+  @Column({ name: 'poster_image_url' })
+  posterImageUrl: string;
+
+  @Column({ name: 'max_member' })
+  maxMember: number;
+
+  @Column({ name: 'min_member' })
+  minMember: number;
+
+  @Column({ name: 'time_limit' })
+  timeLimit: number;
+
+  @Column({ name: 'difficulty', nullable: true })
+  difficulty: number;
+
+  //홈페이지 표기상의 장르
+  @Column({ name: 'real_genre', nullable: true })
+  realGenre: string;
+
+  @Column('text', { name: 'etc', nullable: true })
+  etc: string;
+
+  @OneToOne(
+    () => {
+      return Branch;
+    },
+    { nullable: false }
+  )
+  @JoinColumn({ name: 'branch_id', referencedColumnName: 'id' })
+  branch: Branch;
+
+  //분류된 장르
+  @OneToOne(
+    () => {
+      return Genre;
+    },
+    { nullable: false }
+  )
+  @JoinColumn({ name: 'genre_id', referencedColumnName: 'id' })
+  genre: Genre;
+}

--- a/backend/src/entity/user.entity.ts
+++ b/backend/src/entity/user.entity.ts
@@ -1,0 +1,63 @@
+import { Entity, Column, PrimaryGeneratedColumn, OneToMany, ManyToMany, JoinTable } from 'typeorm';
+import { BaseTime } from './baseTime.entity';
+import { Gender } from '../enum/gender';
+import { UserGroup } from './userGroup.entity';
+import { Theme } from './theme.entity';
+import { Genre } from './genre.entity';
+
+@Entity()
+export class User extends BaseTime {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column({ unique: true })
+  email: string;
+
+  @Column({ length: 10 })
+  name: string;
+
+  @Column({ length: 20, unique: true })
+  nickname: string;
+
+  //format : 010-1234-5678
+  @Column({ name: 'phone_number', length: 13 })
+  phoneNumber: string;
+
+  @Column({ name: 'birth_year' })
+  birthYear: number;
+
+  // 남자 : M / 여자 : F
+  @Column({ type: 'enum', enum: Gender })
+  gender: Gender;
+
+  @Column({ name: 'profile_image_url', nullable: true })
+  profileImageUrl: string;
+
+  @Column({ name: 'diary_count', default: 0 })
+  diaryCount: number;
+
+  @Column({ default: false })
+  isMoreInfo: boolean;
+
+  @OneToMany(
+    () => {
+      return UserGroup;
+    },
+    (userGroups) => {
+      return userGroups.user;
+    }
+  )
+  userGroups: UserGroup[];
+
+  @ManyToMany(() => {
+    return Theme;
+  })
+  @JoinTable({ name: 'favorite_theme' })
+  favoriteThemes: Theme[];
+
+  @ManyToMany(() => {
+    return Genre;
+  })
+  @JoinTable({ name: 'favorite_genre' })
+  favoriteGenres: Genre[];
+}

--- a/backend/src/entity/userGroup.entity.ts
+++ b/backend/src/entity/userGroup.entity.ts
@@ -1,0 +1,37 @@
+import { Entity, Column, PrimaryGeneratedColumn, JoinColumn, ManyToOne } from 'typeorm';
+import { BaseTime } from './baseTime.entity';
+import { User } from './user.entity';
+import { Group } from './group.entity';
+
+@Entity()
+export class UserGroup extends BaseTime {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column({ name: 'has_written_comment' })
+  hasWrittenComment: boolean;
+
+  @ManyToOne(
+    () => {
+      return User;
+    },
+    (user) => {
+      return user.userGroups;
+    },
+    { nullable: false }
+  )
+  @JoinColumn({ name: 'user_id', referencedColumnName: 'id' })
+  user: User;
+
+  @ManyToOne(
+    () => {
+      return Group;
+    },
+    (group) => {
+      return group.userGroups;
+    },
+    { nullable: false }
+  )
+  @JoinColumn({ name: 'group_id', referencedColumnName: 'id' })
+  group: Group;
+}

--- a/backend/src/enum/gender.ts
+++ b/backend/src/enum/gender.ts
@@ -1,0 +1,5 @@
+// 남자 : M / 여자 : F
+export enum Gender {
+  M = 'M',
+  F = 'F',
+}


### PR DESCRIPTION
## 🤷‍♂️ Description
ERD에서 설계한 entity들을 모두 typeorm으로 작성하였습니다.

<!-- 구현 한 기능에 대해 작성해 주세요. -->

## 📝 Primary Commits

<!-- 세부 구현 사항을 리스트로 작성해주세요. -->

- [X] baseTime.entity.ts
  -  각 테이블에 생성일/수정일을 포함하기 위한 기본 추상 엔티티
    ```ts
    abstract class BaseTime {
      @CreateDateColumn({
        name: 'created_at',
        type: 'timestamp',
        default: () => {
          return 'CURRENT_TIMESTAMP(6)';
        },
      })
      createdAt: Date;
    
      @UpdateDateColumn({
        name: 'updated_at',
        type: 'timestamp',
        default: () => {
          return 'CURRENT_TIMESTAMP(6)';
        },
        onUpdate: 'CURRENT_TIMESTAMP(6)',
      })
      updatedAt: Date;
    }
    ```
- [x] branch.entity.ts
- [x] brand.entity.ts
- [x] diary.entity.ts
- [x] diaryComment.entity.ts
- [x] genre.entity.ts
- [x] group.entity.ts
- [x] theme.entity.ts
- [x] user.entity.ts
- [x] userGroup.entity.ts

## 📷 Screenshots
![image](https://github.com/boostcampwm2023/web03-LockFestival/assets/44056518/d6c235b4-9e60-4238-b424-27a36267e3fa)

<!--스크린샷으로 보여줄 수 있는 이미지가 있다면 첨부해주세요!-->

<!--BE의 경우 API 테스트 결과를 첨부해주세요-->

<!--마지막으로 이슈 생성 시 우측의 옵션들을 체크했는지 확인해주세요!-->

<!-- 이슈번호를 작성해주세요. -->
<!-- 여러 이슈를 입력시 comma(,) 단위로 구분해주세요 -->
<!-- ex) close #10, resolves #123 -->


<!-- ex) -->
<!-- closes #1 --> 

closes #47
