### PR TITLE
Feature/FE/#52: useModal 커스텀 훅 생성 및 사용

### DIFF
--- a/frontend/src/components/Modal/Modal.tsx
+++ b/frontend/src/components/Modal/Modal.tsx
@@ -41,12 +41,9 @@ const ModalBackground = styled.div([
 ]);
 
 const ModalContainer = styled.div([
-  tw`rounded-[2rem]`,
+  tw`rounded-[2rem] bg-gray-light`,
   tw`desktop:(min-w-[50rem] min-h-[40rem])`,
   tw`mobile:(min-w-[20rem] min-h-[16rem])`,
-  css`
-    background-color: #282828;
-  `,
 ]);
 
 export default Modal;

--- a/frontend/src/components/Modals/Modals.tsx
+++ b/frontend/src/components/Modals/Modals.tsx
@@ -1,0 +1,15 @@
+import useModal from '@hooks/useModal';
+
+const Modals = () => {
+  const { modals } = useModal();
+
+  return (
+    <>
+      {modals.map(({ Component, props }, index) => {
+        return <Component key={index} {...props} />;
+      })}
+    </>
+  );
+};
+
+export default Modals;

--- a/frontend/src/hooks/useModal.tsx
+++ b/frontend/src/hooks/useModal.tsx
@@ -1,0 +1,29 @@
+import { useRecoilState, atom } from 'recoil';
+import { ModalProps } from 'types/modal';
+import { FunctionComponent } from 'react';
+
+interface Modal {
+  Component: FunctionComponent<ModalProps>;
+  props: ModalProps;
+}
+
+const modalAtom = atom<Array<Modal>>({ key: 'modalList', default: [] });
+
+const useModal = () => {
+  const [modals, setModals] = useRecoilState(modalAtom);
+
+  const openModal = (
+    Component: FunctionComponent<ModalProps>,
+    props: Omit<ModalProps, 'isOpen'>
+  ) => {
+    setModals([...modals, { Component, props: { ...props, isOpen: true } }]);
+  };
+
+  const closeModal = (Component: FunctionComponent<ModalProps>) => {
+    setModals(modals.filter((modal) => modal.Component !== Component));
+  };
+
+  return { modals, openModal, closeModal };
+};
+
+export default useModal;

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -5,6 +5,8 @@ import initMockAPI from '@__mocks__/index.ts';
 import GlobalStyle from './styles/GlobalStyles.tsx';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
+import { RecoilRoot } from 'recoil';
+import Modals from '@components/Modals/Modals.tsx';
 
 async function deferRender() {
   if (!import.meta.env.DEV) {
@@ -19,11 +21,14 @@ const queryClient = new QueryClient();
 deferRender().then(() => {
   ReactDOM.createRoot(document.getElementById('root')!).render(
     <React.StrictMode>
-      <QueryClientProvider client={queryClient}>
-        <ReactQueryDevtools initialIsOpen={false} />
-        <GlobalStyle />
-        <App />
-      </QueryClientProvider>
+      <RecoilRoot>
+        <QueryClientProvider client={queryClient}>
+          <ReactQueryDevtools initialIsOpen={false} />
+          <GlobalStyle />
+          <Modals />
+          <App />
+        </QueryClientProvider>
+      </RecoilRoot>
     </React.StrictMode>
   );
 });


### PR DESCRIPTION
## 🤷‍♂️ Description
#38 에서 모달 컴포넌트를 생성했어요. 하지만 모달이 100개가 되면 isOpen state를 100개를 만들어야하는 단점이 있었어요.
따라서, 커스텀훅에서 전역적으로 관리하도록 했어요.

- renderHook 테스트를 작성해야하는데 아직 renderHook에 대한 학습이 부족해서 추후에 테스트 코드를 작성할게요.

`useModal`을 사용하는 방법은 아래와 같아요.

openModal 함수를 useModal로 부터 가져온 후 호출해요
openModal(모달 컴포넌트, {children, onClose, closeOnExternalClick})의 식으로 호출하면 돼요!

onClose에는 () => closeModal(오픈한 모달)로 작성하면 돼요!!

현재는 모달이 하나라서 `() => closeModal(Modal)`로 입력하면 돼요.

```typescript
function App() {
  const { openModal, closeModal } = useModal();

  return (
    <>
      <Btn
        onClick={() =>
          openModal(Modal, {
            children: (
              <>
                <BBton>
                  <button onClick={() => closeModal(Modal)}>닫기버튼</button>
                </BBton>
                <Div>외부 클릭으로 닫기 가능한 모달입니다.</Div>
              </>
            ),
            onClose: () => closeModal(Modal),
            closeOnExternalClick: true,
          })
        }
      >
        모달 오픈
      </Btn>
    </>
  );
}
export default App;
```


- Recoil을 사용하려면 상단에 RecoilRoot를 추가해야해서 추가했어요.
- Modal에서 color를 직접 타이핑 했는데 tw에서 설정한 값을 사용하도록 변경했어요.

<!-- 구현 한 기능에 대해 작성해 주세요. -->

## 📝 Primary Commits

<!-- 세부 구현 사항을 리스트로 작성해주세요. -->

- [x] useModal 커스텀 훅 생성
- [x] RecoilRoot 추가
- [x] 색상 tailwind 설정 사용

## 📷 Screenshots

- closeOnExternalClick가 true인 모달

![모달외부닫기가능](https://github.com/boostcampwm2023/web03-LockFestival/assets/100738049/4a665d3f-9135-43e3-b1ad-e47438d81bec)

- closeOnExternalClick가 false인 모달

![모달외부닫기불가](https://github.com/boostcampwm2023/web03-LockFestival/assets/100738049/9d0f2988-7689-4169-aeea-ddc55ff52903)

<!--스크린샷으로 보여줄 수 있는 이미지가 있다면 첨부해주세요!-->

<!--BE의 경우 API 테스트 결과를 첨부해주세요-->

<!--마지막으로 이슈 생성 시 우측의 옵션들을 체크했는지 확인해주세요!-->

<!-- 이슈번호를 작성해주세요. -->
<!-- 여러 이슈를 입력시 comma(,) 단위로 구분해주세요 -->
<!-- ex) close #10, resolves #123 -->


<!-- ex) -->
<!-- closes #1 --> 

