### PR TITLE
Config/FE/#57: react-icons 설치

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -19,6 +19,7 @@
     "axios": "^1.6.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-icons": "^4.12.0",
     "react-router-dom": "^6.18.0",
     "recoil": "^0.7.7"
   },

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -5441,6 +5441,11 @@ react-dom@^18.2.0:
     loose-envify "^1.1.0"
     scheduler "^0.23.0"
 
+react-icons@^4.12.0:
+  version "4.12.0"
+  resolved "https://registry.yarnpkg.com/react-icons/-/react-icons-4.12.0.tgz#54806159a966961bfd5cdb26e492f4dafd6a8d78"
+  integrity sha512-IBaDuHiShdZqmfc/TwHu6+d6k2ltNCf3AszxNmjJc1KUfXdEeRJOKyNvLmAHaarhzGmTSVygNdyu8/opXv2gaw==
+
 react-is@^16.13.1, react-is@^16.7.0:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"


### PR DESCRIPTION
## 🤷‍♂️ Description
아이콘을 편리하게 사용하기 위해 react-icons를 설치했어요.
용량 문제로 fa6 아이콘만 사용하기로 했어요!

사용 방법은 아래와 같아요.

```typescript
import { FaRegBell } from 'react-icons/fa6';

function App() {
  return (
    <>
      <FaRegBell size={25} />
    </>
  );
}
export default App;

```

<!-- 구현 한 기능에 대해 작성해 주세요. -->

## 📝 Primary Commits

<!-- 세부 구현 사항을 리스트로 작성해주세요. -->

- [X] react-icons 설치


## 📷 Screenshots

<!--스크린샷으로 보여줄 수 있는 이미지가 있다면 첨부해주세요!-->

<!--BE의 경우 API 테스트 결과를 첨부해주세요-->

<!--마지막으로 이슈 생성 시 우측의 옵션들을 체크했는지 확인해주세요!-->

<!-- 이슈번호를 작성해주세요. -->
<!-- 여러 이슈를 입력시 comma(,) 단위로 구분해주세요 -->
<!-- ex) close #10, resolves #123 -->


<!-- ex) -->
<!-- closes #1 --> 

closes #57 