### PR TITLE
Feature/BE/#34: 랜덤 장르의 테마 반환 API 개발

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -6,9 +6,11 @@ import { DataSourceOptions, DataSource } from 'typeorm';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { TypeormConfig } from './typeorm.config';
+import { ThemeModule } from './modules/themeModules/theme/theme.module';
 
 @Module({
   imports: [
+    ThemeModule,
     ConfigModule.forRoot({
       isGlobal: true,
     }),

--- a/backend/src/modules/themeModules/branch/entities/branch.entity.ts
+++ b/backend/src/modules/themeModules/branch/entities/branch.entity.ts
@@ -27,10 +27,10 @@ export class Branch extends BaseTime {
   @Column({ name: 'small_region' })
   smallRegion: string;
 
-  @Column('decimal', { precision: 10, scale: 6 })
+  @Column('decimal', { precision: 10, scale: 7 })
   x: number;
 
-  @Column('decimal', { precision: 10, scale: 6 })
+  @Column('decimal', { precision: 10, scale: 7 })
   y: number;
 
   @ManyToOne(

--- a/backend/src/modules/themeModules/theme/dtos/genre.dto.ts
+++ b/backend/src/modules/themeModules/theme/dtos/genre.dto.ts
@@ -1,0 +1,4 @@
+export class GenreDto {
+  name: string;
+  id: number;
+}

--- a/backend/src/modules/themeModules/theme/dtos/genre.themes.response.dto.ts
+++ b/backend/src/modules/themeModules/theme/dtos/genre.themes.response.dto.ts
@@ -1,0 +1,6 @@
+import { ThemeResponseDto } from '@theme/dtos/theme.response.dto';
+
+export class GenreThemesResponseDto {
+  genre: string;
+  themes: ThemeResponseDto[];
+}

--- a/backend/src/modules/themeModules/theme/dtos/theme.response.dto.ts
+++ b/backend/src/modules/themeModules/theme/dtos/theme.response.dto.ts
@@ -1,0 +1,11 @@
+export class ThemeResponseDto {
+  posterImageUrl?: string;
+  name: string;
+  themeId: number;
+
+  constructor({ posterImageUrl, name, id }) {
+    this.posterImageUrl = posterImageUrl;
+    this.name = name;
+    this.themeId = id;
+  }
+}

--- a/backend/src/modules/themeModules/theme/entities/theme.entity.ts
+++ b/backend/src/modules/themeModules/theme/entities/theme.entity.ts
@@ -1,7 +1,7 @@
 import { Branch } from '@branch/entities/branch.entity';
 import { BaseTime } from '@src/entity/baseTime.entity';
 import { Genre } from '@theme/entities/genre.entity';
-import { Entity, Column, PrimaryGeneratedColumn, OneToOne, JoinColumn } from 'typeorm';
+import { Entity, Column, PrimaryGeneratedColumn, JoinColumn, ManyToOne } from 'typeorm';
 
 @Entity()
 export class Theme extends BaseTime {
@@ -23,8 +23,11 @@ export class Theme extends BaseTime {
   @Column({ name: 'time_limit' })
   timeLimit: number;
 
-  @Column({ name: 'difficulty', nullable: true })
+  @Column('decimal', { name: 'difficulty', nullable: true, precision: 2, scale: 1 })
   difficulty: number;
+
+  @Column('decimal', { name: 'horror', nullable: true, precision: 2, scale: 1 })
+  horror: number;
 
   //홈페이지 표기상의 장르
   @Column({ name: 'real_genre', nullable: true })
@@ -33,7 +36,7 @@ export class Theme extends BaseTime {
   @Column('text', { name: 'etc', nullable: true })
   etc: string;
 
-  @OneToOne(
+  @ManyToOne(
     () => {
       return Branch;
     },
@@ -43,7 +46,7 @@ export class Theme extends BaseTime {
   branch: Branch;
 
   //분류된 장르
-  @OneToOne(
+  @ManyToOne(
     () => {
       return Genre;
     },

--- a/backend/src/modules/themeModules/theme/genre.repository.ts
+++ b/backend/src/modules/themeModules/theme/genre.repository.ts
@@ -1,0 +1,21 @@
+import { Repository, DataSource } from 'typeorm';
+import { Genre } from '@theme/entities/genre.entity';
+import { Injectable } from '@nestjs/common';
+import { GenreDto } from '@theme/dtos/genre.dto';
+
+@Injectable()
+export class GenreRepository extends Repository<Genre> {
+  constructor(private dataSource: DataSource) {
+    super(Genre, dataSource.createEntityManager());
+  }
+  async getRandomGenreIds(count: number): Promise<GenreDto[]> {
+    const genres = await this.dataSource
+      .createQueryBuilder(Genre, 'genre')
+      .orderBy('Rand()')
+      .limit(count)
+      .getMany();
+    return genres.map(({ id, name }) => {
+      return { id, name };
+    });
+  }
+}

--- a/backend/src/modules/themeModules/theme/theme.controller.ts
+++ b/backend/src/modules/themeModules/theme/theme.controller.ts
@@ -1,0 +1,16 @@
+import { Controller, Get, Query } from '@nestjs/common';
+import { ThemeService } from '@theme/theme.service';
+import { GenreThemesResponseDto } from './dtos/genre.themes.response.dto';
+
+@Controller('themes')
+export class ThemeController {
+  constructor(private readonly themeService: ThemeService) {}
+
+  @Get('/random-genres')
+  async getRandomGenresThemes(
+    @Query('genreCount') genreCount: number = 3,
+    @Query('themeCount') themeCount: number = 10
+  ): Promise<GenreThemesResponseDto[]> {
+    return await this.themeService.getRandomGenresThemes(genreCount, themeCount);
+  }
+}

--- a/backend/src/modules/themeModules/theme/theme.module.ts
+++ b/backend/src/modules/themeModules/theme/theme.module.ts
@@ -3,6 +3,14 @@ import { BrandModule } from '@brand/brand.module';
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { Theme } from '@theme/entities/theme.entity';
+import { ThemeController } from '@theme/theme.controller';
+import { ThemeService } from '@theme/theme.service';
+import { ThemeRepository } from '@theme/theme.repository';
+import { GenreRepository } from '@theme/genre.repository';
 
-@Module({ imports: [TypeOrmModule.forFeature([Theme]), BrandModule, BranchModule] })
+@Module({
+  imports: [TypeOrmModule.forFeature([Theme]), BrandModule, BranchModule],
+  controllers: [ThemeController],
+  providers: [ThemeService, ThemeRepository, GenreRepository],
+})
 export class ThemeModule {}

--- a/backend/src/modules/themeModules/theme/theme.repository.ts
+++ b/backend/src/modules/themeModules/theme/theme.repository.ts
@@ -1,0 +1,24 @@
+import { Repository, DataSource } from 'typeorm';
+import { Theme } from '@theme/entities/theme.entity';
+import { Injectable } from '@nestjs/common';
+import { ThemeResponseDto } from '@theme/dtos/theme.response.dto';
+
+@Injectable()
+export class ThemeRepository extends Repository<Theme> {
+  constructor(private dataSource: DataSource) {
+    super(Theme, dataSource.createEntityManager());
+  }
+
+  async getRandomThemesByGenre(genreId: number, themeCount: number): Promise<ThemeResponseDto[]> {
+    const themes: Theme[] = await this.dataSource
+      .createQueryBuilder(Theme, 'theme')
+      .where('theme.genre_id = :genreId', { genreId })
+      .orderBy('Rand()')
+      .limit(themeCount)
+      .getMany();
+
+    return themes.map(({ posterImageUrl, name, id }): ThemeResponseDto => {
+      return new ThemeResponseDto({ posterImageUrl, name, id });
+    });
+  }
+}

--- a/backend/src/modules/themeModules/theme/theme.service.ts
+++ b/backend/src/modules/themeModules/theme/theme.service.ts
@@ -1,0 +1,33 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { ThemeRepository } from '@theme/theme.repository';
+import { GenreRepository } from '@theme/genre.repository';
+import { GenreDto } from '@src/modules/themeModules/theme/dtos/genre.dto';
+import { ThemeResponseDto } from './dtos/theme.response.dto';
+import { GenreThemesResponseDto } from './dtos/genre.themes.response.dto';
+
+@Injectable()
+export class ThemeService {
+  constructor(
+    @InjectRepository(ThemeRepository)
+    private readonly themeRepository: ThemeRepository,
+    @InjectRepository(GenreRepository)
+    private readonly genreRepository: GenreRepository
+  ) {}
+
+  public async getRandomGenresThemes(
+    genreCount: number = 3,
+    themeCount: number = 10
+  ): Promise<GenreThemesResponseDto[]> {
+    const genreDtos: GenreDto[] = await this.genreRepository.getRandomGenreIds(genreCount);
+    return await Promise.all(
+      genreDtos.map(async (genreDto: GenreDto): Promise<GenreThemesResponseDto> => {
+        const themeDtos = await this.themeRepository.getRandomThemesByGenre(
+          genreDto.id,
+          themeCount
+        );
+        return { genre: genreDto.name, themes: themeDtos };
+      })
+    );
+  }
+}


### PR DESCRIPTION
## 🤷‍♂️ Description
랜덤한 장르의 테마들을 반환하는 API를 개발하였습니다.

<!-- 구현 한 기능에 대해 작성해 주세요. -->

## 📝 Primary Commits

<!-- 세부 구현 사항을 리스트로 작성해주세요. -->

- database 수정
  - [X] theme.ddifficulty를 number -> decimal로 변경
    ```ts
    //기존
    @Column({ name: 'difficulty', nullable: true })
    difficulty: number;
    //수정
    @Column('decimal', { name: 'difficulty', nullable: true, precision: 2, scale: 1 })
    difficulty: number;
    ```
  - [x] theme와 branch, genre 사이의 관계를 OneToOne -> ManyToOne으로 변경

- 테마 관련 dto 추가
  - [x] GenreDto
    - genre db로부터 id, name만 가져오는 dto
  - [x] GenreThemesResponseDto
    - genre명, 테마 정보들을 가지는 dto
  - [x] ThemeResponseDto
    - theme db로부터 posterImageUrl, name, themeId만 가져오는 dto

- [x] GET themes/random-genres API 개발
  - request
    - query
      - genreCount: int (default: 3)/ 가져올 장르의 수
      - themeCount: int (default: 10)/ 가져올 테마의 수

## 📷 Screenshots
- 기본 반환
  ![image](https://github.com/boostcampwm2023/web03-LockFestival/assets/44056518/e0743e04-6c53-4360-983d-29de8a4f6efb)

- 쿼리 적용 반환(themeCount=3)
  ![image](https://github.com/boostcampwm2023/web03-LockFestival/assets/44056518/d5e93d97-f3ea-4df8-88d9-f8ae9ae5c4af)


<!--스크린샷으로 보여줄 수 있는 이미지가 있다면 첨부해주세요!-->

<!--BE의 경우 API 테스트 결과를 첨부해주세요-->

<!--마지막으로 이슈 생성 시 우측의 옵션들을 체크했는지 확인해주세요!-->

<!-- 이슈번호를 작성해주세요. -->
<!-- 여러 이슈를 입력시 comma(,) 단위로 구분해주세요 -->
<!-- ex) close #10, resolves #123 -->


<!-- ex) -->
<!-- closes #1 --> 
close #34 
