### PR TITLE
Feature/BE/#26: 위치 기반 매장 테마 반환 API 개발

### DIFF
--- a/backend/src/modules/themeModules/theme/dtos/theme.location.dto.ts
+++ b/backend/src/modules/themeModules/theme/dtos/theme.location.dto.ts
@@ -1,0 +1,31 @@
+import { IsNumber, IsLatitude, IsLongitude } from 'class-validator';
+import { Transform } from 'class-transformer';
+
+const DEFAULT_BOUNDARY = 5 as const;
+const DEFAULT_COUNT = 10 as const;
+
+export class ThemeLocationDto {
+  @Transform(({ value }) => {
+    return parseFloat(value);
+  })
+  @IsLatitude()
+  x: number;
+
+  @Transform(({ value }) => {
+    return parseFloat(value);
+  })
+  @IsLongitude()
+  y: number;
+
+  @Transform(({ value }) => {
+    return parseInt(value);
+  })
+  @IsNumber()
+  count: number = DEFAULT_COUNT;
+
+  @Transform(({ value }) => {
+    return parseInt(value);
+  })
+  @IsNumber()
+  boundary: number = DEFAULT_BOUNDARY;
+}

--- a/backend/src/modules/themeModules/theme/theme.controller.ts
+++ b/backend/src/modules/themeModules/theme/theme.controller.ts
@@ -1,7 +1,8 @@
 import { Controller, Get, Query } from '@nestjs/common';
 import { ThemeService } from '@theme/theme.service';
 import { GenreThemesResponseDto } from './dtos/genre.themes.response.dto';
-
+import { ThemeResponseDto } from './dtos/theme.response.dto';
+import { ThemeLocationDto } from './dtos/theme.location.dto';
 @Controller('themes')
 export class ThemeController {
   constructor(private readonly themeService: ThemeService) {}
@@ -12,5 +13,9 @@ export class ThemeController {
     @Query('themeCount') themeCount: number = 10
   ): Promise<GenreThemesResponseDto[]> {
     return await this.themeService.getRandomGenresThemes(genreCount, themeCount);
+  }
+  @Get('/location')
+  async getLocationThemes(@Query() themeLocation: ThemeLocationDto): Promise<ThemeResponseDto[]> {
+    return await this.themeService.getLocationThemes(themeLocation);
   }
 }

--- a/backend/src/modules/themeModules/theme/theme.repository.ts
+++ b/backend/src/modules/themeModules/theme/theme.repository.ts
@@ -2,6 +2,10 @@ import { Repository, DataSource } from 'typeorm';
 import { Theme } from '@theme/entities/theme.entity';
 import { Injectable } from '@nestjs/common';
 import { ThemeResponseDto } from '@theme/dtos/theme.response.dto';
+import { Branch } from '../branch/entities/branch.entity';
+import { ThemeLocationDto } from './dtos/theme.location.dto';
+
+const KM = 1000;
 
 @Injectable()
 export class ThemeRepository extends Repository<Theme> {
@@ -20,5 +24,26 @@ export class ThemeRepository extends Repository<Theme> {
     return themes.map(({ posterImageUrl, name, id }): ThemeResponseDto => {
       return new ThemeResponseDto({ posterImageUrl, name, id });
     });
+  }
+
+  async getThemesByBoundary({ x, y, boundary, count }): Promise<ThemeResponseDto[]> {
+    const themes: ThemeResponseDto[] = await this.dataSource
+      .createQueryBuilder()
+      .select([
+        'theme.id as themeId',
+        'theme.name as name',
+        'theme.poster_image_url as posterImageUrl',
+      ])
+      .from(Theme, 'theme')
+      .innerJoin('theme.branch', 'branch')
+      .where('ST_Distance_Sphere(point(branch.y, branch.x), point(:y, :x)) <= :boundary', {
+        x,
+        y,
+        boundary: boundary * KM,
+      })
+      .limit(count)
+      .getRawMany();
+
+    return themes;
   }
 }

--- a/backend/src/modules/themeModules/theme/theme.service.ts
+++ b/backend/src/modules/themeModules/theme/theme.service.ts
@@ -5,6 +5,7 @@ import { GenreRepository } from '@theme/genre.repository';
 import { GenreDto } from '@src/modules/themeModules/theme/dtos/genre.dto';
 import { ThemeResponseDto } from './dtos/theme.response.dto';
 import { GenreThemesResponseDto } from './dtos/genre.themes.response.dto';
+import { ThemeLocationDto } from './dtos/theme.location.dto';
 
 @Injectable()
 export class ThemeService {
@@ -29,5 +30,8 @@ export class ThemeService {
         return { genre: genreDto.name, themes: themeDtos };
       })
     );
+  }
+  public async getLocationThemes(themeLocationDto: ThemeLocationDto): Promise<ThemeResponseDto[]> {
+    return await this.themeRepository.getThemesByBoundary(themeLocationDto);
   }
 }

--- a/backend/src/typeorm.config.ts
+++ b/backend/src/typeorm.config.ts
@@ -15,6 +15,7 @@ export class TypeormConfig implements TypeOrmOptionsFactory {
       database: this.configService.get<string>('DATABASE_DATABASE'),
       entities: [__dirname + '/**/*.entity{.ts,.js}'],
       synchronize: false,
+      logging: true,
     } as TypeOrmModuleOptions;
   }
 }


### PR DESCRIPTION
## 🤷‍♂️ Description
위치 기반 매장 테마 반환 API를 개발하였습니다.
```http
GET /themes/location
```

<!-- 구현 한 기능에 대해 작성해 주세요. -->

## 📝 Primary Commits

<!-- 세부 구현 사항을 리스트로 작성해주세요. -->

- [X] `GET /themes/location` API를 개발하였습니다.
  - request
    - query
      - boundary: int (default: 5) //  최대 거리(km 단위)
      - count: int (default: 10) // 가져올 테마의 수
      - x: double // 위도
      - y: double // 경도


## 📷 Screenshots
- 강남역 기준 쿼리 결과
  ![image](https://github.com/boostcampwm2023/web03-LockFestival/assets/44056518/30e7bc71-0594-4285-a5fe-5a48fdccd151)

<!--스크린샷으로 보여줄 수 있는 이미지가 있다면 첨부해주세요!-->

<!--BE의 경우 API 테스트 결과를 첨부해주세요-->

<!--마지막으로 이슈 생성 시 우측의 옵션들을 체크했는지 확인해주세요!-->

<!-- 이슈번호를 작성해주세요. -->
<!-- 여러 이슈를 입력시 comma(,) 단위로 구분해주세요 -->
<!-- ex) close #10, resolves #123 -->


<!-- ex) -->
<!-- closes #1 --> 

closes #26