### PR TITLE
Feature/FE/#40: SimpleThemeCard 컴포넌트

### DIFF
--- a/frontend/src/__tests__/Card/SimpleThemeCard/SimpleThemeCard.test.tsx
+++ b/frontend/src/__tests__/Card/SimpleThemeCard/SimpleThemeCard.test.tsx
@@ -1,0 +1,27 @@
+import { render, screen } from '@testing-library/react';
+import SimpleThemeCard from '@components/Card/SimpleThemeCard/SimpleThemeCard';
+import { SimpleThemeCardData } from 'types/theme';
+
+describe('SimpleThemeCard 컴포넌트 테스트', () => {
+  const tmpProps: SimpleThemeCardData = {
+    name: '삐릿-뽀',
+    posterImageUrl: 'a.png',
+    themeId: 1,
+  };
+
+  it('컴포넌트에 넘긴 테마명이 렌더링된다.', () => {
+    render(<SimpleThemeCard {...tmpProps} />);
+
+    const textEl = screen.getByText('삐릿-뽀');
+
+    expect(textEl).toBeInTheDocument();
+  });
+
+  it('컴포넌트에 이미지가 렌더링된다.', () => {
+    render(<SimpleThemeCard {...tmpProps} />);
+
+    const imgEl = screen.getByRole('img');
+
+    expect(imgEl).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/Card/SimpleThemeCard/SimpleThemeCard.tsx
+++ b/frontend/src/components/Card/SimpleThemeCard/SimpleThemeCard.tsx
@@ -3,7 +3,7 @@ import { SimpleThemeCardData } from 'types/theme';
 
 const SimpleThemeCard = ({ themeId, name, posterImageUrl }: SimpleThemeCardData) => {
   return (
-    <CardContainer>
+    <CardContainer key={themeId}>
       <CardImg alt="테마사진" src={posterImageUrl} />
       <CardText>{name}</CardText>
     </CardContainer>

--- a/frontend/src/components/Card/SimpleThemeCard/SimpleThemeCard.tsx
+++ b/frontend/src/components/Card/SimpleThemeCard/SimpleThemeCard.tsx
@@ -1,0 +1,40 @@
+import tw, { css, styled } from 'twin.macro';
+import { SimpleThemeCardData } from 'types/theme';
+
+const SimpleThemeCard = ({ themeId, name, posterImageUrl }: SimpleThemeCardData) => {
+  return (
+    <CardContainer>
+      <CardImg alt="테마사진" src={posterImageUrl} />
+      <CardText>{name}</CardText>
+    </CardContainer>
+  );
+};
+
+const CardContainer = styled.div([
+  tw`font-gsans text-white bg-gray`,
+  tw`desktop:(text-s h-[30.4rem] w-[19.2rem] rounded-[2rem])`,
+  tw`mobile:(text-xs h-[20.3rem] w-[12.8rem] rounded-[1.4rem])`,
+  css`
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-direction: column;
+  `,
+]);
+
+const CardImg = styled.img([
+  tw`mb-2`,
+  tw`desktop:(w-[16rem] h-[25.6rem])`,
+  tw`mobile:(w-[10rem] h-[16rem])`,
+]);
+const CardText = styled.span([
+  tw`w-[90%]`,
+  css`
+    text-align: center;
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+    word-break: break-all;
+  `,
+]);
+export default SimpleThemeCard;

--- a/frontend/src/types/theme.ts
+++ b/frontend/src/types/theme.ts
@@ -1,0 +1,5 @@
+export interface SimpleThemeCardData {
+  themeId: number;
+  name: string;
+  posterImageUrl: string;
+}


### PR DESCRIPTION
## 🤷‍♂️ Description
- 메인 페이지 및 다른 페이지에서 사용할 SimpleThemeCard 컴포넌트를 만들었어요.
- 이름은 백엔드 API에서 따왔어요.

font-size가 14라면 대부분의 테마 이름을 보여주기 힘들어서 12로 변경했어요.
모바일에선 12에서 10으로 변경했어요.

그래도 이름이 길다면 말 줄임표(...)으로 보여주고 있어요. 추후에 hover이벤트에 대한 디자인이 완료되면 hover했을 때 풀네임을 보여줄 수 있도록 할게요,


<!-- 구현 한 기능에 대해 작성해 주세요. -->

## 📝 Primary Commits

<!-- 세부 구현 사항을 리스트로 작성해주세요. -->

- [X] SimpleThemeCard 컴포넌트 생성
- [X] SimpleThemeCard 테스트코드 작성

## 📷 Screenshots
<img width="333" alt="예시" src="https://github.com/boostcampwm2023/web03-LockFestival/assets/100738049/43f1858c-1ee4-47f9-88e7-cb21192b199f">
<!--스크린샷으로 보여줄 수 있는 이미지가 있다면 첨부해주세요!-->

<!--BE의 경우 API 테스트 결과를 첨부해주세요-->

<!--마지막으로 이슈 생성 시 우측의 옵션들을 체크했는지 확인해주세요!-->

<!-- 이슈번호를 작성해주세요. -->
<!-- 여러 이슈를 입력시 comma(,) 단위로 구분해주세요 -->
<!-- ex) close #10, resolves #123 -->


<!-- ex) -->
closes #40 


