### PR TITLE
Feature/BE/#35: 특정 장르의 테마 반환하는 API 개발

### DIFF
--- a/backend/src/modules/themeModules/theme/theme.controller.ts
+++ b/backend/src/modules/themeModules/theme/theme.controller.ts
@@ -4,6 +4,8 @@ import { GenreThemesResponseDto } from '@theme/dtos/genre.themes.response.dto';
 import { ThemeResponseDto } from '@theme/dtos/theme.response.dto';
 import { ThemeLocationDto } from '@theme/dtos/theme.location.dto';
 
+const DEFAULT_THEME_COUNT = 10;
+
 @Controller('themes')
 export class ThemeController {
   constructor(private readonly themeService: ThemeService) {}
@@ -11,7 +13,7 @@ export class ThemeController {
   @Get('/random-genres')
   async getRandomGenresThemes(
     @Query('genreCount', new DefaultValuePipe(3), ParseIntPipe) genreCount: number,
-    @Query('themeCount', new DefaultValuePipe(10), ParseIntPipe) themeCount: number
+    @Query('themeCount', new DefaultValuePipe(DEFAULT_THEME_COUNT), ParseIntPipe) themeCount: number
   ): Promise<GenreThemesResponseDto[]> {
     return await this.themeService.getRandomGenresThemes(genreCount, themeCount);
   }
@@ -23,7 +25,7 @@ export class ThemeController {
   @Get('/genres/:genreId')
   async getGenreThemes(
     @Param('genreId', ParseIntPipe) genreId: number,
-    @Query('count', new DefaultValuePipe(10), ParseIntPipe) count: number
+    @Query('count', new DefaultValuePipe(DEFAULT_THEME_COUNT), ParseIntPipe) count: number
   ): Promise<Array<ThemeResponseDto>> {
     return await this.themeService.getGenreThemes(genreId, count);
   }

--- a/backend/src/modules/themeModules/theme/theme.controller.ts
+++ b/backend/src/modules/themeModules/theme/theme.controller.ts
@@ -1,8 +1,9 @@
-import { Controller, DefaultValuePipe, Get, ParseIntPipe, Query } from '@nestjs/common';
+import { Controller, DefaultValuePipe, Get, Param, ParseIntPipe, Query } from '@nestjs/common';
 import { ThemeService } from '@theme/theme.service';
 import { GenreThemesResponseDto } from '@theme/dtos/genre.themes.response.dto';
 import { ThemeResponseDto } from '@theme/dtos/theme.response.dto';
 import { ThemeLocationDto } from '@theme/dtos/theme.location.dto';
+
 @Controller('themes')
 export class ThemeController {
   constructor(private readonly themeService: ThemeService) {}
@@ -17,5 +18,13 @@ export class ThemeController {
   @Get('/location')
   async getLocationThemes(@Query() themeLocation: ThemeLocationDto): Promise<ThemeResponseDto[]> {
     return await this.themeService.getLocationThemes(themeLocation);
+  }
+
+  @Get('/genres/:genreId')
+  async getGenreThemes(
+    @Param('genreId', ParseIntPipe) genreId: number,
+    @Query('count', new DefaultValuePipe(10), ParseIntPipe) count: number
+  ): Promise<Array<ThemeResponseDto>> {
+    return await this.themeService.getGenreThemes(genreId, count);
   }
 }

--- a/backend/src/modules/themeModules/theme/theme.repository.ts
+++ b/backend/src/modules/themeModules/theme/theme.repository.ts
@@ -2,8 +2,6 @@ import { Repository, DataSource } from 'typeorm';
 import { Theme } from '@theme/entities/theme.entity';
 import { Injectable } from '@nestjs/common';
 import { ThemeResponseDto } from '@theme/dtos/theme.response.dto';
-import { Branch } from '@branch/entities/branch.entity';
-import { ThemeLocationDto } from '@theme/dtos/theme.location.dto';
 
 const KM = 1000;
 
@@ -45,6 +43,22 @@ export class ThemeRepository extends Repository<Theme> {
         y,
         boundary: boundary * KM,
       })
+      .limit(count)
+      .getRawMany();
+
+    return themes;
+  }
+
+  async getThemesByGenre(genreId: number, count: number): Promise<Array<ThemeResponseDto>> {
+    const themes: ThemeResponseDto[] = await this.dataSource
+      .createQueryBuilder()
+      .select([
+        'theme.id as themeId',
+        'theme.name as name',
+        'theme.poster_image_url as posterImageUrl',
+      ])
+      .from(Theme, 'theme')
+      .where('theme.genre_id = :genreId', { genreId })
       .limit(count)
       .getRawMany();
 

--- a/backend/src/modules/themeModules/theme/theme.service.ts
+++ b/backend/src/modules/themeModules/theme/theme.service.ts
@@ -34,4 +34,8 @@ export class ThemeService {
   public async getLocationThemes(themeLocationDto: ThemeLocationDto): Promise<ThemeResponseDto[]> {
     return await this.themeRepository.getThemesByBoundary(themeLocationDto);
   }
+
+  public async getGenreThemes(genreId: number, count: number): Promise<Array<ThemeResponseDto>> {
+    return await this.themeRepository.getThemesByGenre(genreId, count);
+  }
 }


### PR DESCRIPTION
## 🤷‍♂️ Description
특정 장르의 테마들을 반환하는 API를 개발하였습니다.
```http
GET /themes/genres/:genreId
```

<!-- 구현 한 기능에 대해 작성해 주세요. -->

## 📝 Primary Commits

<!-- 세부 구현 사항을 리스트로 작성해주세요. -->

- [X] `GET /themes/genres/:genreId`
  - request
    - param
       - genreId: int
    - query
      - count: int(default: 10) // 가져올 테마수 

## 📷 Screenshots
![image](https://github.com/boostcampwm2023/web03-LockFestival/assets/44056518/ca6338b3-f335-43e4-abf2-27058c508390)

<!--스크린샷으로 보여줄 수 있는 이미지가 있다면 첨부해주세요!-->

<!--BE의 경우 API 테스트 결과를 첨부해주세요-->

<!--마지막으로 이슈 생성 시 우측의 옵션들을 체크했는지 확인해주세요!-->

<!-- 이슈번호를 작성해주세요. -->
<!-- 여러 이슈를 입력시 comma(,) 단위로 구분해주세요 -->
<!-- ex) close #10, resolves #123 -->


<!-- ex) -->
<!-- closes #1 --> 

closes #35