### PR TITLE
Feature/BE/#28: 테마 상세정보를 반환하는 API 개발

### DIFF
--- a/backend/src/modules/themeModules/theme/dtos/theme.detail.response.dto.ts
+++ b/backend/src/modules/themeModules/theme/dtos/theme.detail.response.dto.ts
@@ -1,0 +1,10 @@
+export class ThemeDeatailsResponseDto {
+  name: string;
+  branchName: string;
+  realGenre: string;
+  posterImageUrl: string;
+  difficulty: number;
+  minMember: number;
+  maxMember: number;
+  website: string;
+}

--- a/backend/src/modules/themeModules/theme/theme.controller.ts
+++ b/backend/src/modules/themeModules/theme/theme.controller.ts
@@ -3,12 +3,20 @@ import { ThemeService } from '@theme/theme.service';
 import { GenreThemesResponseDto } from '@theme/dtos/genre.themes.response.dto';
 import { ThemeResponseDto } from '@theme/dtos/theme.response.dto';
 import { ThemeLocationDto } from '@theme/dtos/theme.location.dto';
+import { ThemeDeatailsResponseDto } from '@theme/dtos/theme.detail.response.dto';
 
 const DEFAULT_THEME_COUNT = 10;
 
 @Controller('themes')
 export class ThemeController {
   constructor(private readonly themeService: ThemeService) {}
+
+  @Get(':themeId/details')
+  async getThemeDetails(
+    @Param('themeId', ParseIntPipe) themeId: number
+  ): Promise<ThemeDeatailsResponseDto> {
+    return await this.themeService.getThemeDetailsById(themeId);
+  }
 
   @Get('/random-genres')
   async getRandomGenresThemes(
@@ -17,6 +25,7 @@ export class ThemeController {
   ): Promise<GenreThemesResponseDto[]> {
     return await this.themeService.getRandomGenresThemes(genreCount, themeCount);
   }
+
   @Get('/location')
   async getLocationThemes(@Query() themeLocation: ThemeLocationDto): Promise<ThemeResponseDto[]> {
     return await this.themeService.getLocationThemes(themeLocation);

--- a/backend/src/modules/themeModules/theme/theme.repository.ts
+++ b/backend/src/modules/themeModules/theme/theme.repository.ts
@@ -1,7 +1,9 @@
 import { Repository, DataSource } from 'typeorm';
-import { Theme } from '@theme/entities/theme.entity';
 import { Injectable } from '@nestjs/common';
+import { Branch } from '@branch/entities/branch.entity';
+import { Theme } from '@theme/entities/theme.entity';
 import { ThemeResponseDto } from '@theme/dtos/theme.response.dto';
+import { ThemeDeatailsResponseDto } from '@theme/dtos/theme.detail.response.dto';
 
 const KM = 1000;
 
@@ -9,6 +11,27 @@ const KM = 1000;
 export class ThemeRepository extends Repository<Theme> {
   constructor(private dataSource: DataSource) {
     super(Theme, dataSource.createEntityManager());
+  }
+
+  async getThemeDetailsById(themeId: number): Promise<ThemeDeatailsResponseDto> {
+    const themeDetailsResponseDto: ThemeDeatailsResponseDto = await this.dataSource
+      .createQueryBuilder()
+      .select([
+        'theme.name as name',
+        'branch.branch_name as branchName',
+        'theme.real_genre as realGenre',
+        'theme.poster_image_url as posterImageUrl',
+        'theme.difficulty as difficulty',
+        'theme.min_member as minMember',
+        'theme.max_member as maxMember',
+        'branch.website as website',
+      ])
+      .from(Theme, 'theme')
+      .innerJoin(Branch, 'branch', 'theme.branch_id = branch.id')
+      .where('theme.id = :themeId', { themeId })
+      .getRawOne();
+
+    return themeDetailsResponseDto;
   }
 
   async getRandomThemesByGenre(genreId: number, themeCount: number): Promise<ThemeResponseDto[]> {

--- a/backend/src/modules/themeModules/theme/theme.service.ts
+++ b/backend/src/modules/themeModules/theme/theme.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, NotFoundException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { ThemeRepository } from '@theme/theme.repository';
 import { GenreRepository } from '@theme/genre.repository';
@@ -6,6 +6,7 @@ import { GenreDto } from '@theme/dtos/genre.dto';
 import { ThemeResponseDto } from '@theme/dtos/theme.response.dto';
 import { GenreThemesResponseDto } from '@theme/dtos/genre.themes.response.dto';
 import { ThemeLocationDto } from '@theme/dtos/theme.location.dto';
+import { ThemeDeatailsResponseDto } from '@theme/dtos/theme.detail.response.dto';
 
 @Injectable()
 export class ThemeService {
@@ -15,6 +16,16 @@ export class ThemeService {
     @InjectRepository(GenreRepository)
     private readonly genreRepository: GenreRepository
   ) {}
+
+  public async getThemeDetailsById(themeId: number): Promise<ThemeDeatailsResponseDto> {
+    const themeDeatailsResponseDto: ThemeDeatailsResponseDto =
+      await this.themeRepository.getThemeDetailsById(themeId);
+
+    if (!themeDeatailsResponseDto) {
+      throw new NotFoundException('Theme not found : themeId = ' + themeId.toString());
+    }
+    return themeDeatailsResponseDto;
+  }
 
   public async getRandomGenresThemes(
     genreCount: number = 3,


### PR DESCRIPTION
## 🤷‍♂️ Description
특정 테마의 상세정보를 반환하는 API를 개발하였습니다.
```http
GET /themes/:themeId/details
```

<!-- 구현 한 기능에 대해 작성해 주세요. -->

## 📝 Primary Commits

<!-- 세부 구현 사항을 리스트로 작성해주세요. -->

- [X] `GET /themes/:themeId/details`
  - param
    - themeId: int
  - 해당 id가 존재하지 않는 경우 `404 NOT FOUND`

## 📷 Screenshots
- 성공
  <img width="673" alt="image" src="https://github.com/boostcampwm2023/web03-LockFestival/assets/44056518/6955356f-01b1-45cb-90c5-7fff83d8aa63">
- 실패(`themeId` 1번은 존재하지 않습니다)
  <img width="491" alt="image" src="https://github.com/boostcampwm2023/web03-LockFestival/assets/44056518/e48b724f-83b6-452c-91fa-3ba1833161de">


<!--스크린샷으로 보여줄 수 있는 이미지가 있다면 첨부해주세요!-->

<!--BE의 경우 API 테스트 결과를 첨부해주세요-->

<!--마지막으로 이슈 생성 시 우측의 옵션들을 체크했는지 확인해주세요!-->

<!-- 이슈번호를 작성해주세요. -->
<!-- 여러 이슈를 입력시 comma(,) 단위로 구분해주세요 -->
<!-- ex) close #10, resolves #123 -->


<!-- ex) -->
<!-- closes #1 --> 
closes #28