### PR TITLE
Feature/FE/#72: 헤더 컴포넌트-2

### DIFF
--- a/frontend/.env
+++ b/frontend/.env
@@ -1,0 +1,3 @@
+# jest에서 import.env를 사용할 수 없어서 작성
+# 실 배포에서는 DEV=false 변경할 것
+DEV=true

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -58,6 +58,7 @@
     "typescript": "^5.0.2",
     "undici": "^5.27.2",
     "vite": "^4.4.5",
+    "vite-plugin-environment": "^1.1.3",
     "vite-tsconfig-paths": "^4.2.1"
   },
   "babelMacros": {

--- a/frontend/src/__mocks__/browser.ts
+++ b/frontend/src/__mocks__/browser.ts
@@ -1,3 +1,4 @@
 import { setupWorker } from 'msw/browser';
+import profileHandlers from './handlers/profileHandlers';
 
-export const worker = setupWorker();
+export const worker = setupWorker(...profileHandlers);

--- a/frontend/src/__mocks__/handlers/profileHandlers.ts
+++ b/frontend/src/__mocks__/handlers/profileHandlers.ts
@@ -1,0 +1,17 @@
+import { http, HttpResponse } from 'msw';
+import { Profile } from 'types/profile';
+import { SERVER_URL } from '@config/server';
+
+const profileHandlers = [
+  http.get(SERVER_URL + '/users/profile', ({ cookies }) => {
+    //TODO: jwt 구현 후 미로그인 구현하기
+
+    return HttpResponse.json<Profile>({
+      nickname: '프엔',
+      isMoreInfo: true,
+      profileImageUrl: '',
+    });
+  }),
+];
+
+export default profileHandlers;

--- a/frontend/src/__mocks__/server.ts
+++ b/frontend/src/__mocks__/server.ts
@@ -1,3 +1,4 @@
 import { setupServer } from 'msw/node';
+import profileHandlers from './handlers/profileHandlers';
 
-export const server = setupServer();
+export const server = setupServer(...profileHandlers);

--- a/frontend/src/components/Header/Header.tsx
+++ b/frontend/src/components/Header/Header.tsx
@@ -1,38 +1,14 @@
 import tw, { css, styled } from 'twin.macro';
-import { useState } from 'react';
-import { NavMenu } from 'types/navMenu';
+
+import HeaderNav from './HeaderNav/HeaderNav';
+import HeaderRest from './HeaderRest/HeaderRest';
 
 const Header = () => {
-  const [selectedItem, setSelectedItem] = useState<NavMenu>('');
-
-  const handleSelectedItem = (item: NavMenu) => {
-    setSelectedItem(item);
-  };
-
   return (
     <HeaderContainer>
       <HeaderInnerContainer>
-        <HeaderLogo src="/src/assets/images/logo/Big-Dark.png" alt="logo" />
-        <NavContainer>
-          <NavItem
-            onClick={() => handleSelectedItem('recruitment')}
-            isSelected={selectedItem === 'recruitment'}
-          >
-            탈출러 모집
-          </NavItem>
-          <NavItem
-            onClick={() => handleSelectedItem('group-chat')}
-            isSelected={selectedItem === 'group-chat'}
-          >
-            그룹 채팅방
-          </NavItem>
-          <NavItem
-            onClick={() => handleSelectedItem('diary')}
-            isSelected={selectedItem === 'diary'}
-          >
-            탈출 일기
-          </NavItem>
-        </NavContainer>
+        <HeaderNav />
+        <HeaderRest />
       </HeaderInnerContainer>
     </HeaderContainer>
   );
@@ -40,7 +16,7 @@ const Header = () => {
 
 const HeaderContainer = styled.header([
   tw`font-dnfbit mx-auto text-white`,
-  tw`desktop:(w-[102.4rem] h-[6rem] text-l)`,
+  tw`desktop:(max-w-[102.4rem] w-full h-[6rem] text-l)`,
   tw`mobile:(w-full text-m)`,
 ]);
 
@@ -50,40 +26,8 @@ const HeaderInnerContainer = styled.div([
   css`
     display: flex;
     align-items: center;
+    justify-content: space-between;
   `,
 ]);
 
-const HeaderLogo = styled.img([
-  tw`desktop:(w-[18rem] h-[3.6rem])`,
-  tw`mobile:(w-[12rem] h-[2.4rem])`,
-  css`
-    cursor: pointer;
-  `,
-]);
-
-const NavContainer = styled.ul([
-  tw`font-dnfbit border border-white border-solid`,
-  tw`desktop:(w-[50rem] h-[3.3rem] mx-4 rounded-[4rem])`,
-  tw`mobile:(hidden)`,
-  css`
-    display: grid;
-    grid-template-columns: repeat(3, 1fr);
-    align-items: center;
-    background-color: #282828;
-  `,
-]);
-
-const NavItem = styled.li<{ isSelected: boolean }>(({ isSelected }) => [
-  isSelected ? tw`bg-gray border border-white border-solid` : tw`bg-gray-light`,
-  tw`
-    h-full px-5
-  `,
-  tw`desktop:(rounded-[4rem])`,
-  css`
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    cursor: pointer;
-  `,
-]);
 export default Header;

--- a/frontend/src/components/Header/HeaderNav/HeaderNav.tsx
+++ b/frontend/src/components/Header/HeaderNav/HeaderNav.tsx
@@ -1,0 +1,77 @@
+import tw, { css, styled } from 'twin.macro';
+import { useState } from 'react';
+import { NavMenu } from 'types/navMenu';
+
+const HeaderNav = () => {
+  const [selectedItem, setSelectedItem] = useState<NavMenu>('');
+
+  const handleSelectedItem = (item: NavMenu) => {
+    setSelectedItem(item);
+  };
+
+  return (
+    <Nav>
+      <HeaderLogo src="/src/assets/images/logo/Big-Dark.png" alt="logo" />
+      <NavContainer>
+        <NavItem
+          onClick={() => handleSelectedItem('recruitment')}
+          isSelected={selectedItem === 'recruitment'}
+        >
+          탈출러 모집
+        </NavItem>
+        <NavItem
+          onClick={() => handleSelectedItem('group-chat')}
+          isSelected={selectedItem === 'group-chat'}
+        >
+          그룹 채팅방
+        </NavItem>
+        <NavItem onClick={() => handleSelectedItem('diary')} isSelected={selectedItem === 'diary'}>
+          탈출 일기
+        </NavItem>
+      </NavContainer>
+    </Nav>
+  );
+};
+
+const Nav = styled.nav([
+  css`
+    display: flex;
+    align-items: center;
+  `,
+]);
+
+const HeaderLogo = styled.img([
+  tw`desktop:(w-[18rem] h-[3.6rem])`,
+  tw`mobile:(w-[12rem] h-[2.4rem])`,
+  css`
+    cursor: pointer;
+  `,
+]);
+
+const NavContainer = styled.ul([
+  tw`font-dnfbit border border-white border-solid`,
+  tw`desktop:(w-[50rem] h-[3.3rem] mx-4 rounded-[4rem])`,
+  tw`mobile:(hidden)`,
+  css`
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    align-items: center;
+    background-color: #282828;
+  `,
+]);
+
+const NavItem = styled.li<{ isSelected: boolean }>(({ isSelected }) => [
+  isSelected ? tw`bg-gray border border-white border-solid` : tw`bg-gray-light`,
+  tw`
+    h-full px-5
+  `,
+  tw`desktop:(rounded-[4rem])`,
+  css`
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+  `,
+]);
+
+export default HeaderNav;

--- a/frontend/src/components/Header/HeaderRest/HeaderRest.tsx
+++ b/frontend/src/components/Header/HeaderRest/HeaderRest.tsx
@@ -1,0 +1,108 @@
+import tw, { css, styled } from 'twin.macro';
+import Button from '@components/Button/Button';
+import { FaUser } from 'react-icons/fa6';
+import { FaSistrix } from 'react-icons/fa6';
+import { keyframes } from '@emotion/react';
+import { useState } from 'react';
+import useProfileQuery from '@hooks/useProfileQuery';
+import useInput from '@hooks/useInput';
+
+const HeaderRest = () => {
+  const { data, isSuccess, isError } = useProfileQuery();
+
+  const [isClickSearchButton, setIsClickSearchButton] = useState<boolean>(false);
+
+  const [searchInput, setSearchInput] = useInput('');
+
+  return (
+    <HeaderRestContainer>
+      <SearchContainer>
+        {isClickSearchButton ? (
+          <SearchInputForm>
+            <Button isIcon={true} width="3.6rem">
+              <FaSistrix />
+            </Button>
+            <SearchInput value={searchInput} onChange={setSearchInput} type="text" />
+          </SearchInputForm>
+        ) : (
+          <Button isIcon={true} onClick={() => setIsClickSearchButton(true)}>
+            <FaSistrix />
+          </Button>
+        )}
+      </SearchContainer>
+      <ProfileContainer>
+        {isSuccess && (
+          <>
+            <FaUser size={20} />
+            {data?.nickname}님
+          </>
+        )}
+        {isError && (
+          <Button size="l" font="dnfbit" isIcon={false}>
+            <>로그인</>
+          </Button>
+        )}
+      </ProfileContainer>
+    </HeaderRestContainer>
+  );
+};
+
+const HeaderRestContainer = styled.div([
+  css`
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  `,
+]);
+
+const widthAnimation = keyframes`
+  0% {
+    width: 30%;
+  }
+  100% {
+    width: 100%;
+  }
+`;
+
+const SearchContainer = styled.div([
+  tw`desktop:(w-[20rem])`,
+  tw`mobile:(w-[14rem])`,
+  css`
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+  `,
+]);
+
+const SearchInputForm = styled.div([
+  tw`font-gsans bg-gray-light`,
+  tw`desktop:(max-w-[16rem] w-[16rem] h-[3.6rem] rounded-[4rem])`,
+  tw`mobile:(w-[14rem] h-[2.4rem] rounded-[3rem])`,
+  css`
+    animation: 1s ${widthAnimation} forwards;
+    display: flex;
+    align-items: center;
+  `,
+]);
+
+const SearchInput = styled.input([
+  tw`(h-full bg-gray-light text-white rounded-[4rem])`,
+  tw`desktop:(max-w-[12rem] text-m)`,
+  tw`mobile:(max-w-[8rem] text-s)`,
+  css`
+    animation: 1s ${widthAnimation} forwards;
+    border: none;
+    outline: none;
+  `,
+]);
+
+const ProfileContainer = styled.div([
+  tw`desktop:(w-[10rem])`,
+  css`
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+  `,
+]);
+
+export default HeaderRest;

--- a/frontend/src/config/server.ts
+++ b/frontend/src/config/server.ts
@@ -1,0 +1,8 @@
+let SERVER_URL = 'http://localhost:3000';
+
+if (process.env.DEV === 'false') {
+  //TODO: 추후에 실제 서버 주소로 변경
+  SERVER_URL = 'http://localhost:8080';
+}
+
+export { SERVER_URL };

--- a/frontend/src/hooks/useInput.tsx
+++ b/frontend/src/hooks/useInput.tsx
@@ -1,0 +1,18 @@
+import { useState, useCallback } from 'react';
+
+const useInput = (initialValue: string) => {
+  const [inputValue, setInputValue] = useState<string>(initialValue);
+
+  const handleValue = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+      const { value } = e.target;
+
+      setInputValue(value);
+    },
+    []
+  );
+
+  return [inputValue, handleValue] as const;
+};
+
+export default useInput;

--- a/frontend/src/hooks/useProfileQuery.tsx
+++ b/frontend/src/hooks/useProfileQuery.tsx
@@ -1,0 +1,22 @@
+import { SERVER_URL } from '@config/server';
+import { useQuery } from '@tanstack/react-query';
+import axios from 'axios';
+import { Profile } from 'types/profile';
+
+const fetchUserProfile = async () => {
+  //TODO: axios 인스턴스 생성 후 리팩토링
+
+  return (await axios({ method: 'get', url: SERVER_URL + '/users/profile' })).data;
+};
+
+const useProfileQuery = () => {
+  const { data, isSuccess, isLoading, isError } = useQuery<Profile>({
+    queryKey: ['profile'],
+    queryFn: fetchUserProfile,
+    staleTime: 3600,
+  });
+
+  return { data, isSuccess, isLoading, isError };
+};
+
+export default useProfileQuery;

--- a/frontend/src/types/profile.ts
+++ b/frontend/src/types/profile.ts
@@ -1,0 +1,5 @@
+export interface Profile {
+  nickname: string;
+  profileImageUrl: string;
+  isMoreInfo: boolean;
+}

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -19,7 +19,7 @@
     /* Linting */
     "strict": true,
     "noUnusedLocals": true,
-    "noUnusedParameters": true,
+    "noUnusedParameters": false,
     "noFallthroughCasesInSwitch": true,
     "baseUrl": "src",
     "paths": {

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,6 +1,7 @@
 import react from '@vitejs/plugin-react';
 import { defineConfig } from 'vite';
 import tsconfigPaths from 'vite-tsconfig-paths';
+import EnvironmentPlugin from 'vite-plugin-environment';
 
 export default defineConfig({
   plugins: [
@@ -9,6 +10,7 @@ export default defineConfig({
         plugins: ['babel-plugin-macros', '@emotion/babel-plugin'],
       },
     }),
+    EnvironmentPlugin(['DEV']),
     tsconfigPaths(),
   ],
 });

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -6409,6 +6409,11 @@ v8-to-istanbul@^9.0.1:
     "@types/istanbul-lib-coverage" "^2.0.1"
     convert-source-map "^2.0.0"
 
+vite-plugin-environment@^1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/vite-plugin-environment/-/vite-plugin-environment-1.1.3.tgz#d01a04abb2f69730a4866c9c9db51d3dab74645b"
+  integrity sha512-9LBhB0lx+2lXVBEWxFZC+WO7PKEyE/ykJ7EPWCq95NEcCpblxamTbs5Dm3DLBGzwODpJMEnzQywJU8fw6XGGGA==
+
 vite-tsconfig-paths@^4.2.1:
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/vite-tsconfig-paths/-/vite-tsconfig-paths-4.2.1.tgz#e53b89096b91d31a6d1e26f75999ea8c336a89ed"


### PR DESCRIPTION
## 🤷‍♂️ Description
이번 PR이 이슈 해결 등으로 커졌네요.. 다음 PR때부터는 줄이겠습니다.

1. node 환경에서 import.meta 사용불가
server.ts에서 SERVER_URL을 개발 환경이면 3000번 포트로 설정하고 실제 배포면 8080번 포트로 설정했는데 jest에서 SERVER_URL을 불러올 수 없었어요.

<img width="871" alt="에러" src="https://github.com/boostcampwm2023/web03-LockFestival/assets/100738049/c6b5ec03-fd1e-42cb-a55b-027108f890c3">

그래서 vite-plugin-environment 설치 후 세팅해서 해결했어요. 사용법은 `노션-트러블슈팅`을 참고해주세요.

2. 프로필 mock API 생성 및 정의
로그인 여부에 따라 로그인 버튼을 보여주거나 이름을 보여줘야해서 mock API를 만들었어요.
이전에 msw를 세팅해서 추가만 해서 사용했어요. profile 타입은 서버와 협의 후 작성했어요.

3. useInput 커스텀 훅 생성
input에 작성할 일이 조금 많을 것 같아 커스텀 훅을 생성했어요. 앞으로 input을 사용하게 되면 해당 커스텀 훅을 사용해주세요!

4. useProfileQuery 커스텀 훅 생성
프로필을 불러올 때 useProfileQuery로 불러왔어요. 프로필은 자주 바뀌지 않으니 `staleTime `을 3600으로 설정했어요.

5. 헤더 검색 애니메이션 적용
- 헤더 검색바를 넷플릭스 처럼 애니메이션을 적용했어요. 추후에 애니메이션 라이브러리 도입을 논의해봐야할 것 같아요.

6. 나머지 헤더 컴포넌트 구성
- 검색, 로그인, 이름을 묶은 컴포넌트를 구성했어요.
- 현재 프로필 이미지 등록 기능을 보류했기 때문에 무조건 사람 아이콘을 보여주도록 했어요.


<!-- 구현 한 기능에 대해 작성해 주세요. -->

## 📝 Primary Commits

<!-- 세부 구현 사항을 리스트로 작성해주세요. -->

- [X] node에서 process.env 사용할 수 있도록 변경
- [X] useInput 커스텀 훅 생성
- [X] useProfileQuery 커스텀 훅 생성
- [X] 헤더 검색 애니메이션 적용
- [X] 헤더 나머지 부분 구성

## 📷 Screenshots

![녹화_2023_11_16_23_35_06_241](https://github.com/boostcampwm2023/web03-LockFestival/assets/100738049/a4171bd6-2bb1-433f-ae6a-50d78c665f25)

<!--스크린샷으로 보여줄 수 있는 이미지가 있다면 첨부해주세요!-->

<!--BE의 경우 API 테스트 결과를 첨부해주세요-->

<!--마지막으로 이슈 생성 시 우측의 옵션들을 체크했는지 확인해주세요!-->

<!-- 이슈번호를 작성해주세요. -->
<!-- 여러 이슈를 입력시 comma(,) 단위로 구분해주세요 -->
<!-- ex) close #10, resolves #123 -->


<!-- ex) -->
<!-- closes #1 --> 
closes #72 
