### PR TITLE
Chore/FE/#79: 폰트 변경 및 헤더 스타일 수정

### DIFF
--- a/frontend/src/__tests__/Button/Button.test.tsx
+++ b/frontend/src/__tests__/Button/Button.test.tsx
@@ -20,13 +20,19 @@ describe('버튼 컴포넌트 테스트', () => {
 
   it('버튼에 사이즈를 지정했을때, 설정한 폰트, 넓이가 적용되는지 테스트', () => {
     render(
-      <Button children={<>test</>} isIcon={false} font="jua" width="20rem" onClick={handler} />
+      <Button
+        children={<>test</>}
+        isIcon={false}
+        font="pretendard"
+        width="20rem"
+        onClick={handler}
+      />
     );
     const myButton = screen.getByText(/test/i);
 
     const computedStyle = window.getComputedStyle(myButton);
 
-    expect(computedStyle.fontFamily).toBe('BMJUA');
+    expect(computedStyle.fontFamily).toBe('Pretendard-Regular');
     expect(computedStyle.width).toBe('20rem');
   });
 });

--- a/frontend/src/components/Card/SimpleThemeCard/SimpleThemeCard.tsx
+++ b/frontend/src/components/Card/SimpleThemeCard/SimpleThemeCard.tsx
@@ -11,7 +11,7 @@ const SimpleThemeCard = ({ themeId, name, posterImageUrl }: SimpleThemeCardData)
 };
 
 const CardContainer = styled.div([
-  tw`font-gsans text-white bg-gray`,
+  tw`font-pretendard text-white bg-gray`,
   tw`desktop:(text-s h-[30.4rem] w-[19.2rem] rounded-[2rem])`,
   tw`mobile:(text-xs h-[20.3rem] w-[12.8rem] rounded-[1.4rem])`,
   css`

--- a/frontend/src/components/Header/Header.tsx
+++ b/frontend/src/components/Header/Header.tsx
@@ -15,14 +15,14 @@ const Header = () => {
 };
 
 const HeaderContainer = styled.header([
-  tw`font-dnfbit mx-auto text-white`,
-  tw`desktop:(max-w-[102.4rem] w-full h-[6rem] text-l)`,
-  tw`mobile:(w-full text-m)`,
+  tw`font-maplestory mx-auto text-white`,
+  tw`desktop:(max-w-[102.4rem] w-full h-[6rem] text-l-bold)`,
+  tw`mobile:(w-full text-m-bold)`,
 ]);
 
 const HeaderInnerContainer = styled.div([
   tw`desktop:(mx-4 h-[6rem])`,
-  tw`mobile:(mx-2 h-[4rem])`,
+  tw`mobile:(mx-2 h-[5rem])`,
   css`
     display: flex;
     align-items: center;

--- a/frontend/src/components/Header/HeaderNav/HeaderNav.tsx
+++ b/frontend/src/components/Header/HeaderNav/HeaderNav.tsx
@@ -42,15 +42,15 @@ const Nav = styled.nav([
 
 const HeaderLogo = styled.img([
   tw`desktop:(w-[18rem] h-[3.6rem])`,
-  tw`mobile:(w-[12rem] h-[2.4rem])`,
+  tw`mobile:(w-[18rem] h-[3.2rem])`,
   css`
     cursor: pointer;
   `,
 ]);
 
 const NavContainer = styled.ul([
-  tw`font-dnfbit border border-white border-solid`,
-  tw`desktop:(w-[50rem] h-[3.3rem] mx-4 rounded-[4rem])`,
+  tw`border border-white border-solid`,
+  tw`desktop:(w-[50rem] h-[3.6rem] mx-4 rounded-[4rem])`,
   tw`mobile:(hidden)`,
   css`
     display: grid;

--- a/frontend/src/components/Header/HeaderRest/HeaderRest.tsx
+++ b/frontend/src/components/Header/HeaderRest/HeaderRest.tsx
@@ -19,13 +19,13 @@ const HeaderRest = () => {
       <SearchContainer>
         {isClickSearchButton ? (
           <SearchInputForm>
-            <Button isIcon={true} width="3.6rem">
+            <Button isIcon={true} size="l">
               <FaSistrix />
             </Button>
             <SearchInput value={searchInput} onChange={setSearchInput} type="text" />
           </SearchInputForm>
         ) : (
-          <Button isIcon={true} onClick={() => setIsClickSearchButton(true)}>
+          <Button isIcon={true} size="l" onClick={() => setIsClickSearchButton(true)}>
             <FaSistrix />
           </Button>
         )}
@@ -38,7 +38,7 @@ const HeaderRest = () => {
           </>
         )}
         {isError && (
-          <Button size="l" font="dnfbit" isIcon={false}>
+          <Button size="l" font="maplestory" isIcon={false}>
             <>로그인</>
           </Button>
         )}
@@ -66,7 +66,7 @@ const widthAnimation = keyframes`
 
 const SearchContainer = styled.div([
   tw`desktop:(w-[20rem])`,
-  tw`mobile:(w-[14rem])`,
+  tw`mobile:(w-[12.4rem])`,
   css`
     display: flex;
     align-items: center;
@@ -75,9 +75,9 @@ const SearchContainer = styled.div([
 ]);
 
 const SearchInputForm = styled.div([
-  tw`font-gsans bg-gray-light`,
-  tw`desktop:(max-w-[16rem] w-[16rem] h-[3.6rem] rounded-[4rem])`,
-  tw`mobile:(w-[14rem] h-[2.4rem] rounded-[3rem])`,
+  tw`bg-gray-light`,
+  tw`desktop:(max-w-[16.4rem] w-[16.4rem] h-[3.6rem] rounded-[4rem])`,
+  tw`mobile:(w-[12.4rem] h-[3.2rem] rounded-[3rem])`,
   css`
     animation: 1s ${widthAnimation} forwards;
     display: flex;
@@ -86,9 +86,9 @@ const SearchInputForm = styled.div([
 ]);
 
 const SearchInput = styled.input([
-  tw`(h-full bg-gray-light text-white rounded-[4rem])`,
-  tw`desktop:(max-w-[12rem] text-m)`,
-  tw`mobile:(max-w-[8rem] text-s)`,
+  tw`(font-pretendard h-full pl-2 pr-3 bg-gray-light text-white rounded-[4rem])`,
+  tw`desktop:(max-w-[12.8rem] text-m)`,
+  tw`mobile:(max-w-[9.2rem] text-s)`,
   css`
     animation: 1s ${widthAnimation} forwards;
     border: none;

--- a/frontend/src/components/Modal/Modal.tsx
+++ b/frontend/src/components/Modal/Modal.tsx
@@ -26,7 +26,7 @@ const Modal = ({ children, onClose, closeOnExternalClick, isOpen }: ModalProps) 
 };
 
 const ModalBackground = styled.div([
-  tw`font-gsans text-white-60`,
+  tw`font-pretendard text-white-60`,
   css`
     position: fixed;
     top: 0;

--- a/frontend/src/constants/StyleMap/CommonStyleMap.ts
+++ b/frontend/src/constants/StyleMap/CommonStyleMap.ts
@@ -1,27 +1,38 @@
 import tw, { TwStyle } from 'twin.macro';
 
 const fontStyleMap: Record<string, TwStyle> = {
-  dnfbit: tw`font-dnfbit`,
-  jua: tw`font-jua`,
-  gsans: tw`font-gsans`,
-  default: tw`font-gsans`,
+  pretendard: tw`font-pretendard`,
+  maplestory: tw`font-maplestory`,
+  default: tw`font-pretendard`,
 };
 
 const sizeStyleMap: Record<string, TwStyle[]> = {
-  l: [
-    tw`mobile:(text-m px-2.5 py-1.5 h-[3.2rem]) desktop:(text-l px-3 py-2 h-[3.6rem])`,
+  'l': [
+    tw`mobile:(text-m px-2.5 h-[3.2rem]) desktop:(text-l px-3 h-[3.6rem])`,
     { svg: tw`mobile:(w-[1.8rem] h-[1.8rem]) desktop:(w-[2rem] h-[2rem])` },
   ],
-  m: [
-    tw`mobile:(text-s px-2 py-1 h-[2.8rem]) desktop:(text-m px-2.5 py-1.5) h-[3.2rem]`,
+  'l-bold': [
+    tw`mobile:(text-m-bold px-2.5 h-[3.2rem]) desktop:(text-l-bold px-3 h-[3.6rem])`,
+    { svg: tw`mobile:(w-[1.8rem] h-[1.8rem]) desktop:(w-[2rem] h-[2rem])` },
+  ],
+  'm': [
+    tw`mobile:(text-s px-2 h-[2.8rem]) desktop:(text-m px-2.5) h-[3.2rem]`,
     { svg: tw`mobile:(w-[1.5rem] h-[1.5rem]) desktop:(w-[1.8rem] h-[1.8rem])` },
   ],
-  s: [
-    tw`mobile:(text-xs px-1.5 py-0.5 h-[2.4rem]) desktop:(text-s px-2 py-1 h-[2.8rem])`,
+  'm-bold': [
+    tw`mobile:(text-s-bold px-2 h-[2.8rem]) desktop:(text-m-bold px-2.5) h-[3.2rem]`,
+    { svg: tw`mobile:(w-[1.5rem] h-[1.5rem]) desktop:(w-[1.8rem] h-[1.8rem])` },
+  ],
+  's': [
+    tw`mobile:(text-xs px-1.5 h-[2.4rem]) desktop:(text-s px-2 h-[2.8rem])`,
     { svg: tw`mobile:(w-[1.2rem] h-[1.2rem]) desktop:(w-[1.5rem] h-[1.5rem])` },
   ],
-  default: [
-    tw`mobile:(text-s px-2 py-1 h-[2.8rem]) desktop:(text-m px-2.5 py-1.5 h-[3.2rem])`,
+  's-bold': [
+    tw`mobile:(text-xs-bold px-1.5 h-[2.4rem]) desktop:(text-s-bold px-2 h-[2.8rem])`,
+    { svg: tw`mobile:(w-[1.2rem] h-[1.2rem]) desktop:(w-[1.5rem] h-[1.5rem])` },
+  ],
+  'default': [
+    tw`mobile:(text-s px-2 h-[2.8rem]) desktop:(text-m px-2.5 h-[3.2rem])`,
     { svg: tw`mobile:(w-[1.5rem] h-[1.5rem]) desktop:(w-[1.8rem] h-[1.8rem])` },
   ],
 };

--- a/frontend/src/constants/StyleMap/LabelStyleMap.ts
+++ b/frontend/src/constants/StyleMap/LabelStyleMap.ts
@@ -7,7 +7,7 @@ const LabelBaseStyle = (width: string | undefined): CSSInterpolation => css`
   display: flex;
   justify-content: space-between;
   align-items: center;
-  cursor: pointer;
+  cursor: default;
 `;
 
 const colorStyleMap: Record<string, TwStyle> = {

--- a/frontend/src/styles/GlobalStyles.tsx
+++ b/frontend/src/styles/GlobalStyles.tsx
@@ -131,23 +131,16 @@ const globalStyle = css`
   }
 
   @font-face {
-    font-family: 'DNFBitBitv2';
-    font-style: normal;
-    font-weight: 400;
-    src: url('//cdn.df.nexon.com/img/common/font/DNFBitBitv2.otf') format('opentype');
-  }
-
-  @font-face {
-    font-family: 'BMJUA';
-    src: url('https://cdn.jsdelivr.net/gh/projectnoonnu/noonfonts_one@1.0/BMJUA.woff')
+    font-family: 'Pretendard-Regular';
+    src: url('https://cdn.jsdelivr.net/gh/Project-Noonnu/noonfonts_2107@1.1/Pretendard-Regular.woff')
       format('woff');
-    font-weight: normal;
+    font-weight: 400;
     font-style: normal;
   }
 
   @font-face {
-    font-family: 'GmarketSansMedium';
-    src: url('https://cdn.jsdelivr.net/gh/projectnoonnu/noonfonts_2001@1.1/GmarketSansMedium.woff')
+    font-family: 'MaplestoryOTFLight';
+    src: url('https://cdn.jsdelivr.net/gh/projectnoonnu/noonfonts_20-04@2.1/MaplestoryOTFLight.woff')
       format('woff');
     font-weight: normal;
     font-style: normal;

--- a/frontend/src/types/button.ts
+++ b/frontend/src/types/button.ts
@@ -1,6 +1,6 @@
 export interface ButtonComponentProps {
-  font?: 'dnfbit' | 'jua' | 'gsans';
-  size?: 's' | 'm' | 'l';
+  font?: 'pretendard' | 'maplestory';
+  size?: 's' | 'm' | 'l' | 's-bold' | 'm-bold' | 'l-bold';
   width?: string;
   isIcon: boolean;
 }

--- a/frontend/src/types/label.ts
+++ b/frontend/src/types/label.ts
@@ -1,8 +1,8 @@
 export type BackgroundColor = 'white' | 'green-light' | 'green-dark' | 'transparent';
 
 export interface LabelComponentProps {
-  font?: 'dnfbit' | 'jua' | 'gsans';
-  size?: 's' | 'm' | 'l';
+  font?: 'pretendard' | 'maplestory';
+  size?: 's' | 'm' | 'l' | 's-bold' | 'm-bold' | 'l-bold';
   width?: string;
   backgroundColor?: BackgroundColor | string;
   isBorder: boolean;

--- a/frontend/tailwind.config.ts
+++ b/frontend/tailwind.config.ts
@@ -25,33 +25,60 @@ export default {
       desktop: '431px',
     },
     fontFamily: {
-      dnfbit: ['DNFBitBitv2'],
-      jua: ['BMJUA'],
-      gsans: ['GmarketSansMedium'],
+      pretendard: ['Pretendard-Regular'],
+      maplestory: ['MaplestoryOTFLight'],
     },
     fontSize: {
-      xs: [
+      'xs': [
         '1rem',
         {
           lineHeight: '1rem',
         },
       ],
-      s: [
+      'xs-bold': [
+        '1rem',
+        {
+          lineHeight: '1rem',
+          fontWeight: 900,
+        },
+      ],
+      's': [
         '1.2rem',
         {
           lineHeight: '1.2rem',
         },
       ],
-      m: [
+      's-bold': [
+        '1.2rem',
+        {
+          lineHeight: '1.2rem',
+          fontWeight: 900,
+        },
+      ],
+      'm': [
         '1.4rem',
         {
           lineHeight: '1.4rem',
         },
       ],
-      l: [
+      'm-bold': [
+        '1.4rem',
+        {
+          lineHeight: '1.4rem',
+          fontWeight: 900,
+        },
+      ],
+      'l': [
         '1.6rem',
         {
           lineHeight: '1.6rem',
+        },
+      ],
+      'l-bold': [
+        '1.6rem',
+        {
+          lineHeight: '1.6rem',
+          fontWeight: 900,
         },
       ],
     },


### PR DESCRIPTION
## 🤷‍♂️ Description
1. 기존의 폰트가 내장 padding이 서로 달라서, 폰트를 Pretendard, MapleStory로 변경했어요.
2. tailwind config를 수정했어요.
    - 기존에 s, m, l가 s, s-bold, m, m-bold, l, l-bold로 확장됐어요.
 3. 폰트 변경에 따른 타입, 기존 폰트를 사용하던 컴포넌트의 폰트를 새로운 폰트로 변경했어요.
 4. 헤더 넓이, 높이를 버튼 s, m, l 크기에 맞게 조정했어요.
 5. 헤더 검색 인풋에 패딩을 적용하고 Pretendard 폰트를 적용했어요.

<!-- 구현 한 기능에 대해 작성해 주세요. -->

## 📝 Primary Commits

<!-- 세부 구현 사항을 리스트로 작성해주세요. -->

- [X] 사용할 폰트 import 하기 (pretendard, 넥슨 메이플스토리)
- [X] tailiwnd.config 파일 수정
- [X] CommonStyleMap 수정
- [X] 기존 타이포그래피 시스템을 따르던 컴포넌트, 컴포넌트 타입 수정
- [X] 헤더 스타일 일부 변경

## 📷 Screenshots
1. 헤더
![image](https://github.com/boostcampwm2023/web03-LockFestival/assets/82202370/f795fab5-79f6-4900-97e5-b4b566c24ea3)

2. 버튼, 라벨 예시
    ```ts
      <Button isIcon={false} size="l">
        <>테스트</>
      </Button>
      <Button isIcon={false} size="l-bold">
        <>테스트</>
      </Button>
      <Label font="maplestory" isBorder={false} size="l">
        <>테스트</>
      </Label>
      <Label font="maplestory" isBorder={false} size="l-bold">
        <>테스트</>
      </Label>
    ```
    ![image](https://github.com/boostcampwm2023/web03-LockFestival/assets/82202370/9f751ae3-7fbd-4fd3-b17a-76dc5e3db70b)


<!-- ex) -->
<!-- closes #1 --> 
closes #79
