### PR TITLE
Feature/BE/#78: 전체 장르 리스트를 반환하는 API

### DIFF
--- a/backend/src/modules/themeModules/theme/genre.repository.ts
+++ b/backend/src/modules/themeModules/theme/genre.repository.ts
@@ -19,7 +19,7 @@ export class GenreRepository extends Repository<Genre> {
     });
   }
 
-  async findAllGenres(): Promise<GenreDto[]> {
+  async getAllGenres(): Promise<GenreDto[]> {
     const genreDtos: GenreDto[] = await this.dataSource
       .createQueryBuilder()
       .select('genre.id', 'id')

--- a/backend/src/modules/themeModules/theme/genre.repository.ts
+++ b/backend/src/modules/themeModules/theme/genre.repository.ts
@@ -18,4 +18,15 @@ export class GenreRepository extends Repository<Genre> {
       return { id, name };
     });
   }
+
+  async findAllGenres(): Promise<GenreDto[]> {
+    const genreDtos: GenreDto[] = await this.dataSource
+      .createQueryBuilder()
+      .select('genre.id', 'id')
+      .addSelect('genre.name', 'name')
+      .from(Genre, 'genre')
+      .orderBy('genre.id')
+      .getRawMany();
+    return genreDtos;
+  }
 }

--- a/backend/src/modules/themeModules/theme/genre.service.ts
+++ b/backend/src/modules/themeModules/theme/genre.service.ts
@@ -1,0 +1,16 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { GenreRepository } from '@theme/genre.repository';
+import { GenreDto } from '@theme/dtos/genre.dto';
+
+@Injectable()
+export class GenreService {
+  constructor(
+    @InjectRepository(GenreRepository)
+    private readonly genreRepository: GenreRepository
+  ) {}
+
+  async getAllGenres(): Promise<GenreDto[]> {
+    return await this.genreRepository.findAllGenres();
+  }
+}

--- a/backend/src/modules/themeModules/theme/genre.service.ts
+++ b/backend/src/modules/themeModules/theme/genre.service.ts
@@ -11,6 +11,6 @@ export class GenreService {
   ) {}
 
   async getAllGenres(): Promise<GenreDto[]> {
-    return await this.genreRepository.findAllGenres();
+    return await this.genreRepository.getAllGenres();
   }
 }

--- a/backend/src/modules/themeModules/theme/theme.controller.ts
+++ b/backend/src/modules/themeModules/theme/theme.controller.ts
@@ -4,12 +4,17 @@ import { GenreThemesResponseDto } from '@theme/dtos/genre.themes.response.dto';
 import { ThemeResponseDto } from '@theme/dtos/theme.response.dto';
 import { ThemeLocationDto } from '@theme/dtos/theme.location.dto';
 import { ThemeDeatailsResponseDto } from '@theme/dtos/theme.detail.response.dto';
+import { GenreService } from '@theme/genre.service';
+import { GenreDto } from '@theme/dtos/genre.dto';
 
 const DEFAULT_THEME_COUNT = 10;
 
 @Controller('themes')
 export class ThemeController {
-  constructor(private readonly themeService: ThemeService) {}
+  constructor(
+    private readonly themeService: ThemeService,
+    private readonly genreService: GenreService
+  ) {}
 
   @Get(':themeId/details')
   async getThemeDetails(
@@ -37,5 +42,10 @@ export class ThemeController {
     @Query('count', new DefaultValuePipe(DEFAULT_THEME_COUNT), ParseIntPipe) count: number
   ): Promise<Array<ThemeResponseDto>> {
     return await this.themeService.getGenreThemes(genreId, count);
+  }
+
+  @Get('/genres')
+  async getGenres(): Promise<GenreDto[]> {
+    return await this.genreService.getAllGenres();
   }
 }

--- a/backend/src/modules/themeModules/theme/theme.module.ts
+++ b/backend/src/modules/themeModules/theme/theme.module.ts
@@ -7,10 +7,11 @@ import { ThemeController } from '@theme/theme.controller';
 import { ThemeService } from '@theme/theme.service';
 import { ThemeRepository } from '@theme/theme.repository';
 import { GenreRepository } from '@theme/genre.repository';
+import { GenreService } from '@theme/genre.service';
 
 @Module({
   imports: [TypeOrmModule.forFeature([Theme]), BrandModule, BranchModule],
   controllers: [ThemeController],
-  providers: [ThemeService, ThemeRepository, GenreRepository],
+  providers: [ThemeService, ThemeRepository, GenreRepository, GenreService],
 })
 export class ThemeModule {}


### PR DESCRIPTION
## 🤷‍♂️ Description
전체 분류용 장르들의 id, name을 반환하는 API를 개발하였습니다.
```http
GET /themes/genres
```

<!-- 구현 한 기능에 대해 작성해 주세요. -->

## 📝 Primary Commits

<!-- 세부 구현 사항을 리스트로 작성해주세요. -->

- themeModule
  - providers
    - GenreService 추가

- ThemeController
  - GET /themes/genres
    - request: X
    - response: GenreDto[]
      ```ts
      //genre.dto.ts
      class GenreDto {
        name: string;
        id: number;
      }
      ```

- GenreService
  - getAllGenres()
    - GenreRepository의  호출

- GenreRepository
  - getAllGenres()
    - 특정 브랜치에 해당하는 테마리스트 반환 쿼리
      ```sql
      SELECT genre.id AS id, genre.name AS name
        FROM genre
        ORDER BY genre.id ASC
      ```

## 성공 시 reponse 예시
`http://localhost:3000/themes/genres`
```json
[
    {
        "id": 1,
        "name": "공포"
    },
    {
        "id": 2,
        "name": "코믹"
    },
    {
        "id": 3,
        "name": "감성"
    }
]
```

## 📷 Screenshots
![image](https://github.com/boostcampwm2023/web03-LockFestival/assets/44056518/cccfd2b9-bc7d-4e3e-9e78-a911705a6ca3)

<!--스크린샷으로 보여줄 수 있는 이미지가 있다면 첨부해주세요!-->

<!--BE의 경우 API 테스트 결과를 첨부해주세요-->

<!--마지막으로 이슈 생성 시 우측의 옵션들을 체크했는지 확인해주세요!-->

<!-- 이슈번호를 작성해주세요. -->
<!-- 여러 이슈를 입력시 comma(,) 단위로 구분해주세요 -->
<!-- ex) close #10, resolves #123 -->


<!-- ex) -->
<!-- closes #1 --> 

closes #78 