### PR TITLE
Fix/BE/#81: 백엔드 CORS 설정

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -9,7 +9,7 @@
     "build": "nest build",
     "format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\"",
     "start": "nest start",
-    "start:dev": "nest build --tsc --webpack --webpackPath webpack-hmr.config.js --watch",
+    "start:dev": "nest start --tsc --webpack --webpackPath webpack-hmr.config.js --watch",
     "start:debug": "nest start --debug --watch",
     "start:prod": "node dist/main",
     "lint": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix",

--- a/backend/src/enum/http.method.ts
+++ b/backend/src/enum/http.method.ts
@@ -1,0 +1,7 @@
+export enum HTTP_ALLOWED_METHOD {
+  GET,
+  PUT,
+  PATCH,
+  POST,
+  DELETE,
+}

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -1,12 +1,20 @@
 import { NestFactory } from '@nestjs/core';
 import { ValidationPipe } from '@nestjs/common';
 import { AppModule } from './app.module';
+import { HTTP_ALLOWED_METHOD } from '@enum/http.method';
+import { ConfigService } from '@nestjs/config';
 
 declare const module: any;
 async function bootstrap() {
-  const app = await NestFactory.create(AppModule);
+  const app = await NestFactory.create(AppModule, {});
+  app.enableCors({
+    origin: app.get(ConfigService).get('FRONTEND_BASE_URL'),
+    methods: Object.keys(HTTP_ALLOWED_METHOD),
+    credentials: true,
+  });
+
   app.useGlobalPipes(new ValidationPipe({ transform: true }));
-  await app.listen(3000);
+  await app.listen(app.get(ConfigService).get('PORT') || 3000);
   if (module.hot) {
     module.hot.accept();
     module.hot.dispose(() => {


### PR DESCRIPTION
## 🤷‍♂️ Description
백엔드 서버에서 CORS를 설정하였습니다.
(공통으로 더 필요한 부분이 있을까 해서 전원 리뷰요청 드립니다..!)
<!-- 구현 한 기능에 대해 작성해 주세요. -->

## 📝 Primary Commits

<!-- 세부 구현 사항을 리스트로 작성해주세요. -->

- CORS 설정
  - expressjs의 cors 모듈 방식 사용
    ```ts
    app.enableCors({
      origin: app.get(ConfigService).get('FRONTEND_BASE_URL'),
      methods: Object.keys(HTTP_ALLOWED_METHOD),
      credentials: true,
    });
    ```
  - CorsOptions
  
    - origin : 어떤 도메인을 허용할 것인지
  
      - FRONTEND_BASE_URL -> .env로 관리
  
    - methods : 허용할 HTTP Method
  
      - HTTP_ALLOWED_METHOD 리스트
  
    - credentials : 프론트/백 통신 간 쿠키 사용을 허용할 것인가
  
      - 기획상 사용할 일은 없을 것으로 생각되지만, 추후 쓸 수 있으니 일단 `true`로 결정

- 트러블슈팅 일지 작성 - [바로가기](https://www.notion.so/CORS-7b7391aff916414e99bae9db67d616d8?pvs=4)

## 📷 Screenshots
정상적으로 preflight와 응답이 잘 도착함을 볼 수 있습니다!
![image](https://github.com/boostcampwm2023/web03-LockFestival/assets/44056518/24a181f2-b1d3-4a95-bbe8-a5925ac69d31)

> Reference
[NestJS-CORS Docs](https://docs.nestjs.com/security/cors)
[express/cors github](https://github.com/expressjs/cors#configuration-options)
[@fastify/cors github](https://github.com/fastify/fastify-cors)

closes #81