### PR TITLE
Feature/BE/#30: 회원 프로필 조회 API 

### DIFF
--- a/backend/src/modules/userModules/user/dtos/user.profile.dto.ts
+++ b/backend/src/modules/userModules/user/dtos/user.profile.dto.ts
@@ -1,0 +1,5 @@
+export class UserProfileDto {
+  nickname: string;
+  profileImageUrl: string;
+  isMoreInfo: boolean;
+}

--- a/backend/src/modules/userModules/user/user.controller.ts
+++ b/backend/src/modules/userModules/user/user.controller.ts
@@ -1,7 +1,18 @@
-import { Controller } from '@nestjs/common';
+import { Controller, Get, Req, UseGuards } from '@nestjs/common';
+import { TokenAuthGuard } from '@src/modules/authModules/auth/auth.guard';
 import { UserService } from '@user/user.service';
+import { UserProfileDto } from './dtos/user.profile.dto';
 
-@Controller('user')
+@Controller('users')
 export class UserController {
   constructor(private userService: UserService) {}
+
+  @Get('/profile')
+  @UseGuards(TokenAuthGuard)
+  async getUserProfile(@Req() { user }): Promise<UserProfileDto> {
+    const userProfileDto: UserProfileDto = await this.userService.getUserProfileByNickname(
+      user.nickname
+    );
+    return userProfileDto;
+  }
 }

--- a/backend/src/modules/userModules/user/user.controller.ts
+++ b/backend/src/modules/userModules/user/user.controller.ts
@@ -1,7 +1,7 @@
 import { Controller, Get, Req, UseGuards } from '@nestjs/common';
 import { TokenAuthGuard } from '@src/modules/authModules/auth/auth.guard';
 import { UserService } from '@user/user.service';
-import { UserProfileDto } from './dtos/user.profile.dto';
+import { UserProfileDto } from '@user/dtos/user.profile.dto';
 
 @Controller('users')
 export class UserController {

--- a/backend/src/modules/userModules/user/user.repository.ts
+++ b/backend/src/modules/userModules/user/user.repository.ts
@@ -3,6 +3,7 @@ import { Injectable } from '@nestjs/common';
 import { User } from '@user/entities/user.entity';
 import { UserNaverDto } from '@user/dtos/user.naver.dto';
 import { Gender } from '@enum/gender';
+import { UserProfileDto } from './dtos/user.profile.dto';
 
 @Injectable()
 export class UserRepository extends Repository<User> {
@@ -20,7 +21,15 @@ export class UserRepository extends Repository<User> {
       birthYear: Number(data.birthyear),
     });
   }
+
   async findUserByEmail(email: string) {
     return await this.findOneBy({ email });
+  }
+
+  async findUserProfileByNickname(nickname: string): Promise<UserProfileDto> {
+    return await this.findOne({
+      select: ['nickname', 'profileImageUrl', 'isMoreInfo'],
+      where: { nickname },
+    });
   }
 }

--- a/backend/src/modules/userModules/user/user.repository.ts
+++ b/backend/src/modules/userModules/user/user.repository.ts
@@ -3,7 +3,7 @@ import { Injectable } from '@nestjs/common';
 import { User } from '@user/entities/user.entity';
 import { UserNaverDto } from '@user/dtos/user.naver.dto';
 import { Gender } from '@enum/gender';
-import { UserProfileDto } from './dtos/user.profile.dto';
+import { UserProfileDto } from '@user/dtos/user.profile.dto';
 
 @Injectable()
 export class UserRepository extends Repository<User> {

--- a/backend/src/modules/userModules/user/user.service.ts
+++ b/backend/src/modules/userModules/user/user.service.ts
@@ -3,7 +3,7 @@ import { UserRepository } from '@user/user.repository';
 import { InjectRepository } from '@nestjs/typeorm';
 import { UserNaverDto } from '@user/dtos/user.naver.dto';
 import { User } from '@user/entities/user.entity';
-import { UserProfileDto } from './dtos/user.profile.dto';
+import { UserProfileDto } from '@user/dtos/user.profile.dto';
 
 @Injectable()
 export class UserService {

--- a/backend/src/modules/userModules/user/user.service.ts
+++ b/backend/src/modules/userModules/user/user.service.ts
@@ -3,6 +3,7 @@ import { UserRepository } from '@user/user.repository';
 import { InjectRepository } from '@nestjs/typeorm';
 import { UserNaverDto } from '@user/dtos/user.naver.dto';
 import { User } from '@user/entities/user.entity';
+import { UserProfileDto } from './dtos/user.profile.dto';
 
 @Injectable()
 export class UserService {
@@ -21,5 +22,9 @@ export class UserService {
     } catch (error) {
       throw new HttpException('Login failed.', HttpStatus.INTERNAL_SERVER_ERROR);
     }
+  }
+
+  async getUserProfileByNickname(nickname: string): Promise<UserProfileDto> {
+    return this.userRepository.findUserProfileByNickname(nickname);
   }
 }


### PR DESCRIPTION
## 🤷‍♂️ Description
상단바에 표기될 회원 프로필 정보 조회 API를 개발합니다.
```http
GET /users/profile
```
<!-- 구현 한 기능에 대해 작성해 주세요. -->

## 📝 Primary Commits

<!-- 세부 구현 사항을 리스트로 작성해주세요. -->

- UserController
  - `GET /users/profile`
    - headers
      - Authorization: accessToken을 담은 header
 
  - `@UseGuards(TokenAuthGuard)`
    - JWT Token을 헤더로부터 파싱하고 request의 user로 주입합니다.

  - `@Req() { user }`
    - `UseGuards` 로부터 주입된 user를  가져오는 방법입니다.
  - 최종 소스코드
    ```ts
    @Get('/profile')
    @UseGuards(TokenAuthGuard)
    async getUserProfile(@Req() { user }): Promise<UserProfileDto> {
      const userProfileDto: UserProfileDto = await this.userService.getUserProfileByNickname(
        user.nickname
      );
      return userProfileDto;
    }
    ```

- UserService
  - getUserProfileByNickname(nickname)
    - UserRepository의 findUserProfileByNickname 호출

- UserRepository 
  - findUserProfileByNickname(nickname)
    - TypeOrm의 findOne 함수를 통해 구현
      - findOptions을 추가하여 select 추가
    - 기존 queryBuilder의 경우 쿼리 결과가 무조건 string 으로 반환되는 문제가 있어서 문제가 발생했습니다.
      그래서 위의 방식대로 구현하였습니다.
      ![image](https://github.com/boostcampwm2023/web03-LockFestival/assets/44056518/788c02ad-8daf-406c-b63f-a4050460c4a8)
      - [트러블 슈팅 일지 바로가기](https://www.notion.so/string-2f2abe3b957548a29e335dcc4d15b4f6?pvs=4)

## 📷 Screenshots
- 성공
  ![image](https://github.com/boostcampwm2023/web03-LockFestival/assets/44056518/f41486a8-e7ed-477a-b026-bd8fdd8f0aaa)

<!--스크린샷으로 보여줄 수 있는 이미지가 있다면 첨부해주세요!-->

<!--BE의 경우 API 테스트 결과를 첨부해주세요-->

<!--마지막으로 이슈 생성 시 우측의 옵션들을 체크했는지 확인해주세요!-->

<!-- 이슈번호를 작성해주세요. -->
<!-- 여러 이슈를 입력시 comma(,) 단위로 구분해주세요 -->
<!-- ex) close #10, resolves #123 -->

> Reference
[TypeOrm-find-options Docs](https://typeorm.io/find-options)


<!-- ex) -->
<!-- closes #1 --> 

closes #30