### PR TITLE
Feature/FE/#75 랜덤으로 3개의 장르에 해당하는 테마를 불러오는 API 작성

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,14 @@
+import RootLayout from '@pages/Root/components/RootLayout';
+import tw, { styled } from 'twin.macro';
+
 function App() {
-  return <>Hello World</>;
+  return (
+    <Container>
+      <RootLayout />;
+    </Container>
+  );
 }
+
+const Container = styled.div([tw`bg-gray-dark h-screen`]);
+
 export default App;

--- a/frontend/src/__mocks__/browser.ts
+++ b/frontend/src/__mocks__/browser.ts
@@ -1,4 +1,5 @@
 import { setupWorker } from 'msw/browser';
 import profileHandlers from './handlers/profileHandlers';
+import themesByGenreHandler from './handlers/themesByRandomHandler';
 
-export const worker = setupWorker(...profileHandlers);
+export const worker = setupWorker(...profileHandlers, ...themesByGenreHandler);

--- a/frontend/src/__mocks__/genresTheme/themesByGenre.ts
+++ b/frontend/src/__mocks__/genresTheme/themesByGenre.ts
@@ -1,0 +1,142 @@
+export const themesByGenre = [
+  {
+    genre: '감성',
+    themes: [
+      {
+        themeId: 31,
+        name: 'US',
+        posterImageUrl: 'https://www.keyescape.co.kr/file/theme_info/31_a.jpg',
+      },
+      {
+        themeId: 49,
+        name: '홀리데이',
+        posterImageUrl: 'https://www.keyescape.co.kr/file/theme_info/22_a.jpg',
+      },
+      {
+        themeId: 34,
+        name: '엔제리오',
+        posterImageUrl: 'https://www.keyescape.co.kr/file/theme_info/27_a.jpg',
+      },
+      {
+        themeId: 37,
+        name: '그카지말라캤자나',
+        posterImageUrl: 'https://www.keyescape.co.kr/file/theme_info/7_a.jpg',
+      },
+      {
+        themeId: 28,
+        name: 'FILM BY EDDY',
+        posterImageUrl: 'https://www.keyescape.co.kr/file/theme_info/34_a.jpg',
+      },
+      {
+        themeId: 46,
+        name: '사라진 목격자',
+        posterImageUrl: 'https://www.keyescape.co.kr/file/theme_info/8_a.jpg',
+      },
+      {
+        themeId: 43,
+        name: '난쟁이의 장난-영문병행표기',
+        posterImageUrl: 'https://www.keyescape.co.kr/file/theme_info/10_a.jpg',
+      },
+      {
+        themeId: 40,
+        name: '난쟁이의 장난-영문병행표기',
+        posterImageUrl: 'https://www.keyescape.co.kr/file/theme_info/10_a.jpg',
+      },
+    ],
+  },
+  {
+    genre: '공포',
+    themes: [
+      {
+        themeId: 50,
+        name: '고백',
+        posterImageUrl: 'https://www.keyescape.co.kr/file/theme_info/23_a.jpg',
+      },
+      {
+        themeId: 38,
+        name: '정신병동',
+        posterImageUrl: 'https://www.keyescape.co.kr/file/theme_info/16_a.jpg',
+      },
+      {
+        themeId: 35,
+        name: '월야애담-영문병행표기',
+        posterImageUrl: 'https://www.keyescape.co.kr/file/theme_info/5_a.jpg',
+      },
+      {
+        themeId: 44,
+        name: '혜화잡화점',
+        posterImageUrl: 'https://www.keyescape.co.kr/file/theme_info/17_a.jpg',
+      },
+      {
+        themeId: 32,
+        name: 'WANNA GO HOME',
+        posterImageUrl: 'https://www.keyescape.co.kr/file/theme_info/31_a.jpg',
+      },
+      {
+        themeId: 41,
+        name: '셜록 죽음의 전화',
+        posterImageUrl: 'https://www.keyescape.co.kr/file/theme_info/11_a.jpg',
+      },
+      {
+        themeId: 47,
+        name: '살랑살랑연구소',
+        posterImageUrl: 'https://www.keyescape.co.kr/file/theme_info/6_a.jpg',
+      },
+      {
+        themeId: 29,
+        name: 'FILM BY STEVE',
+        posterImageUrl: 'https://www.keyescape.co.kr/file/theme_info/35_a.jpg',
+      },
+      {
+        themeId: 26,
+        name: 'BACK TO THE SCENE+',
+        posterImageUrl: 'https://www.keyescape.co.kr/file/theme_info/40_a.jpg',
+      },
+    ],
+  },
+  {
+    genre: '코믹',
+    themes: [
+      {
+        themeId: 45,
+        name: '월야애담-영문병행표기',
+        posterImageUrl: 'https://www.keyescape.co.kr/file/theme_info/5_a.jpg',
+      },
+      {
+        themeId: 42,
+        name: '신비의숲 고대마법의 비밀',
+        posterImageUrl: 'https://www.keyescape.co.kr/file/theme_info/9_a.jpg',
+      },
+      {
+        themeId: 48,
+        name: '삐릿-뽀',
+        posterImageUrl: 'https://www.keyescape.co.kr/file/theme_info/21_a.jpg',
+      },
+      {
+        themeId: 30,
+        name: 'FILM BY BOB',
+        posterImageUrl: 'https://www.keyescape.co.kr/file/theme_info/36_a.jpg',
+      },
+      {
+        themeId: 36,
+        name: '살랑살랑연구소',
+        posterImageUrl: 'https://www.keyescape.co.kr/file/theme_info/6_a.jpg',
+      },
+      {
+        themeId: 27,
+        name: '머니머니패키지',
+        posterImageUrl: 'https://www.keyescape.co.kr/file/theme_info/38_a.jpg',
+      },
+      {
+        themeId: 39,
+        name: '파파라치',
+        posterImageUrl: 'https://www.keyescape.co.kr/file/theme_info/18_a.jpg',
+      },
+      {
+        themeId: 33,
+        name: '네드',
+        posterImageUrl: 'https://www.keyescape.co.kr/file/theme_info/26_a.jpg',
+      },
+    ],
+  },
+];

--- a/frontend/src/__mocks__/handlers/themesByRandomHandler.ts
+++ b/frontend/src/__mocks__/handlers/themesByRandomHandler.ts
@@ -1,0 +1,16 @@
+import { http, HttpResponse } from 'msw';
+import { themesByGenre } from '../genresTheme/themesByGenre';
+import { SERVER_URL } from '@config/server';
+
+const START_INDEX = 0;
+const END_INDEX = 3;
+
+const themesByGenreHandler = [
+  http.get(SERVER_URL + '/themes/random-genres', () => {
+    const randomThemesByGenre = themesByGenre.slice(START_INDEX, END_INDEX);
+
+    return HttpResponse.json(randomThemesByGenre);
+  }),
+];
+
+export default themesByGenreHandler;

--- a/frontend/src/__mocks__/server.ts
+++ b/frontend/src/__mocks__/server.ts
@@ -1,4 +1,5 @@
 import { setupServer } from 'msw/node';
 import profileHandlers from './handlers/profileHandlers';
+import themesByGenreHandler from './handlers/themesByRandomHandler';
 
-export const server = setupServer(...profileHandlers);
+export const server = setupServer(...profileHandlers, ...themesByGenreHandler);

--- a/frontend/src/apis/fetchThemesByRandomGenres.ts
+++ b/frontend/src/apis/fetchThemesByRandomGenres.ts
@@ -1,0 +1,20 @@
+import { SERVER_URL } from '@config/server';
+import axios from 'axios';
+import { SimpleThemeCardData } from 'types/theme';
+
+interface FetchThemesByRandomGenres {
+  genre: string;
+  themes: Array<SimpleThemeCardData>;
+}
+
+const fetchThemesByRandomGenres = async () => {
+  //TODO: axios 인스턴스 개발 후 리팩토링
+  return (
+    await axios<Array<FetchThemesByRandomGenres>>({
+      method: 'get',
+      url: SERVER_URL + `/themes/random-genres`,
+    })
+  ).data;
+};
+
+export default fetchThemesByRandomGenres;

--- a/frontend/src/constants/queryManagement.ts
+++ b/frontend/src/constants/queryManagement.ts
@@ -1,0 +1,10 @@
+import fetchThemesByRandomGenres from '@apis/fetchThemesByRandomGenres';
+
+const QUERY_MANAGEMENT = {
+  randomThemes: {
+    key: 'randomThemes',
+    fn: fetchThemesByRandomGenres,
+  },
+};
+
+export default QUERY_MANAGEMENT;

--- a/frontend/src/constants/themeGenres.ts
+++ b/frontend/src/constants/themeGenres.ts
@@ -1,0 +1,2 @@
+//TODO: 추후에 장르 추가
+export const themeGenres = ['공포', '코믹', '감성'];

--- a/frontend/src/hooks/useRandomThemesQuery.tsx
+++ b/frontend/src/hooks/useRandomThemesQuery.tsx
@@ -1,0 +1,14 @@
+import { useQuery } from '@tanstack/react-query';
+
+import QUERY_MANAGEMENT from '@constants/QueryManagement';
+
+const useRandomThemesQuery = () => {
+  const { data, isSuccess, isError, isLoading } = useQuery({
+    queryKey: [QUERY_MANAGEMENT['randomThemes'].key],
+    queryFn: QUERY_MANAGEMENT['randomThemes'].fn,
+  });
+
+  return { data, isSuccess, isError, isLoading };
+};
+
+export default useRandomThemesQuery;

--- a/frontend/src/hooks/useRandomThemesQuery.tsx
+++ b/frontend/src/hooks/useRandomThemesQuery.tsx
@@ -1,6 +1,5 @@
 import { useQuery } from '@tanstack/react-query';
-
-import QUERY_MANAGEMENT from '@constants/QueryManagement';
+import QUERY_MANAGEMENT from '@constants/queryManagement';
 
 const useRandomThemesQuery = () => {
   const { data, isSuccess, isError, isLoading } = useQuery({

--- a/frontend/src/pages/Root/Root.tsx
+++ b/frontend/src/pages/Root/Root.tsx
@@ -1,0 +1,6 @@
+import RootLayout from './components/RootLayout';
+
+const Root = () => {
+  return <RootLayout />;
+};
+export default Root;

--- a/frontend/src/pages/Root/components/RandomThemeListContainer.tsx
+++ b/frontend/src/pages/Root/components/RandomThemeListContainer.tsx
@@ -1,0 +1,33 @@
+import tw, { styled } from 'twin.macro';
+import Label from '@components/Label/Label';
+import useRandomThemesQuery from '@hooks/useRandomThemesQuery';
+import SimpleThemeCardList from '@components/List/SimpleThemeCardList/SimpleThemeCardList';
+
+const RandomThemeListContainer = () => {
+  const { data } = useRandomThemesQuery();
+
+  if (!data) {
+    return <div>error</div>;
+  }
+
+  return (
+    <>
+      {data.map((ele) => {
+        return (
+          <>
+            <Label isBorder={true} font="maplestory" size="l">
+              <>{ele.genre}</>
+            </Label>
+            <SimpleCardContainer>
+              <SimpleThemeCardList themes={ele.themes} />
+            </SimpleCardContainer>
+          </>
+        );
+      })}
+    </>
+  );
+};
+
+const SimpleCardContainer = styled.div([tw`my-2`]);
+
+export default RandomThemeListContainer;

--- a/frontend/src/pages/Root/components/RootLayout.tsx
+++ b/frontend/src/pages/Root/components/RootLayout.tsx
@@ -1,0 +1,14 @@
+import tw, { styled } from 'twin.macro';
+import RandomThemeListContainer from './RandomThemeListContainer';
+
+const RootLayout = () => {
+  return (
+    <Container>
+      <RandomThemeListContainer />
+    </Container>
+  );
+};
+
+const Container = styled.div([tw`w-full mx-auto`, tw`desktop:(max-w-[102.4rem])`]);
+
+export default RootLayout;

--- a/frontend/src/utils/pickRandomNumber.ts
+++ b/frontend/src/utils/pickRandomNumber.ts
@@ -1,0 +1,20 @@
+const MIDDLE_NUMBER = 0.5;
+const START_INDEX = 0;
+/**
+ * 랜덤 숫자 뽑기
+ * @param n 1 ~ n까지의 수 중에서
+ * @param k k개 뽑기 (n >=k)
+ */
+const pickRandomNumber = (n: number, k: number): Array<number> => {
+  if (k > n) {
+    throw new Error('asd');
+  }
+
+  const numbersArray = Array.from({ length: n }, (_, index) => index + 1).sort(
+    () => Math.random() - MIDDLE_NUMBER
+  );
+
+  return numbersArray.slice(START_INDEX, k);
+};
+
+export default pickRandomNumber;


### PR DESCRIPTION
## 🤷‍♂️ Description
랜덤으로 3개의 장르에 해당하는 테마를 불러오는 API를 만들었어요.

원래는 장르에서 3개를 뽑아서 서버에 각각 요청하려고 util 함수를 만들었는데 오히려 비효율적일것같아서 그냥 서버에서 랜덤으로 장르를뽑아서 반환하는 api를 사용했어요

또, 멘토 피드백으로 queryKey와 queyFn을 효율적으로 관리하기 위해 queryManagement.ts를 만들었어요. 아래와 같은 형식으로 사용하면 돼요.

```typescript
const QUERY_MANAGEMENT = {
  randomThemes: {
    key: 'randomThemes', // 키 이름
    fn: fetchThemesByRandomGenres, // 함수 이름
  },
};
```

또, mock data와 api를 handler에 등록해서 메인페이지에서 불러오도록했어요.
나중에 위치 기반 테마 리스트와 로그인 이후 취향 테마 리스트를 불러온 후 디자인을 마무리 하도록할게요. 현재는 간단한 디자인만 했습니다!

라우팅 관리는 다른 이슈에서 한번에 만들게요!

마지막으로, 특정 페이지에서 사용되는 컴포넌트는 pages/특정 페이지/components에서 관리하는 게 좋을 것 같아서 해당 위치에 두었어요!!


<!-- 구현 한 기능에 대해 작성해 주세요. -->

## 📝 Primary Commits

<!-- 세부 구현 사항을 리스트로 작성해주세요. -->

- [X] 랜덤으로 3개의 장르에 해당하는 테마를 불러오는 API 작성
- [X] 해당 API를 사용하는 커스텀 훅 생성
- [X] 메인페이지에서 렌더링

## 📷 Screenshots
<img width="792" alt="1" src="https://github.com/boostcampwm2023/web03-LockFestival/assets/100738049/041acc16-b038-4afb-baad-09ba54340911">
<!--스크린샷으로 보여줄 수 있는 이미지가 있다면 첨부해주세요!-->

<!--BE의 경우 API 테스트 결과를 첨부해주세요-->

<!--마지막으로 이슈 생성 시 우측의 옵션들을 체크했는지 확인해주세요!-->

<!-- 이슈번호를 작성해주세요. -->
<!-- 여러 이슈를 입력시 comma(,) 단위로 구분해주세요 -->
<!-- ex) close #10, resolves #123 -->


<!-- ex) -->
<!-- closes #1 --> 
closes #75 
