### PR TITLE
Feature/FE/#45: 로그인 모달, 회원가입 모달 구현 / 네아로 구현중 API 연동 필요

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,6 +4,11 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Lock Festival</title>
+    <script
+      type="text/javascript"
+      src="https://static.nid.naver.com/js/naveridlogin_js_sdk_2.0.0.js"
+      charset="utf-8"
+    ></script>
   </head>
   <body>
     <div id="root"></div>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,14 +1,7 @@
-import RootLayout from '@pages/Root/components/RootLayout';
-import tw, { styled } from 'twin.macro';
+import CustomRouter from '@components/Router/CustomRouter';
 
 function App() {
-  return (
-    <Container>
-      <RootLayout />;
-    </Container>
-  );
+  return <CustomRouter />;
 }
-
-const Container = styled.div([tw`bg-gray-dark h-screen`]);
 
 export default App;

--- a/frontend/src/__mocks__/handlers/loginHandlers.ts
+++ b/frontend/src/__mocks__/handlers/loginHandlers.ts
@@ -1,0 +1,17 @@
+import { http, HttpResponse } from 'msw';
+import { SERVER_URL } from '@config/server';
+
+const loginHandlers = [
+  http.get(SERVER_URL + '/auth/naver', ({ request }) => {
+    const url = new URL(request.url);
+    const code = url.searchParams.get('code');
+
+    if (!code) {
+      return new HttpResponse(null, { status: 404 });
+    }
+
+    return HttpResponse.json({ code });
+  }),
+];
+
+export default loginHandlers;

--- a/frontend/src/__mocks__/handlers/profileHandlers.ts
+++ b/frontend/src/__mocks__/handlers/profileHandlers.ts
@@ -3,14 +3,21 @@ import { Profile } from 'types/profile';
 import { SERVER_URL } from '@config/server';
 
 const profileHandlers = [
-  http.get(SERVER_URL + '/users/profile', ({ cookies }) => {
-    //TODO: jwt 구현 후 미로그인 구현하기
-
-    return HttpResponse.json<Profile>({
-      nickname: '프엔',
-      isMoreInfo: true,
-      profileImageUrl: '',
-    });
+  http.get(SERVER_URL + '/users/profile', () => {
+    if (localStorage.getItem('com.naver.nid.access_token')) {
+      return HttpResponse.json<Profile>({
+        nickname: '프엔',
+        isMoreInfo: true,
+        profileImageUrl: '',
+      });
+    } else {
+      return new HttpResponse('Not found', {
+        status: 404,
+        headers: {
+          'Content-Type': 'text/plain',
+        },
+      });
+    }
   }),
 ];
 

--- a/frontend/src/__mocks__/server.ts
+++ b/frontend/src/__mocks__/server.ts
@@ -1,5 +1,6 @@
 import { setupServer } from 'msw/node';
 import profileHandlers from './handlers/profileHandlers';
 import themesByGenreHandler from './handlers/themesByRandomHandler';
+import loginHandlers from './handlers/loginHandlers';
 
-export const server = setupServer(...profileHandlers, ...themesByGenreHandler);
+export const server = setupServer(...profileHandlers, ...themesByGenreHandler, ...loginHandlers);

--- a/frontend/src/components/Button/Button.tsx
+++ b/frontend/src/components/Button/Button.tsx
@@ -1,4 +1,4 @@
-import tw, { TwStyle, styled } from 'twin.macro';
+import tw, { TwStyle, styled, css } from 'twin.macro';
 import { ButtonComponentProps, ButtonProps } from 'types/button';
 import {
   iconButtonBaseStyle,
@@ -24,6 +24,12 @@ const ButtonComponent = styled.button<ButtonComponentProps>(({ font, size, width
     tw`
 rounded-default bg-gray-light text-white
 `,
+    css`
+      :disabled {
+        cursor: default;
+        opacity: 60%;
+      }
+    `,
   ];
 
   const fontStyle = font ? fontStyleMap[font] : fontStyleMap.default;

--- a/frontend/src/components/Header/HeaderRest/HeaderRest.tsx
+++ b/frontend/src/components/Header/HeaderRest/HeaderRest.tsx
@@ -9,6 +9,7 @@ import useInput from '@hooks/useInput';
 import useModal from '@hooks/useModal';
 import Modal from '@components/Modal/Modal';
 import LoginModal from '@components/LoginModal/LoginModal';
+import JoinModal from '@components/JoinModal/JoinModal';
 
 const HeaderRest = () => {
   const { openModal, closeModal } = useModal();
@@ -47,10 +48,19 @@ const HeaderRest = () => {
       </SearchContainer>
       <ProfileContainer>
         {isSuccess && (
-          <>
-            <FaUser size={20} />
-            {data?.nickname}님
-          </>
+          <Button
+            size="l"
+            onClick={() => {
+              localStorage.clear();
+              window.location.replace('/');
+            }}
+            isIcon={false}
+          >
+            <>
+              <FaUser size={20} />
+              {data?.nickname}님
+            </>
+          </Button>
         )}
         {isError && (
           <Button
@@ -68,6 +78,20 @@ const HeaderRest = () => {
             <>로그인</>
           </Button>
         )}
+        <Button
+          size="l"
+          font="maplestory"
+          isIcon={false}
+          onClick={() =>
+            openModal(Modal, {
+              children: JoinModal(modalCloseCallback),
+              onClose: modalCloseCallback,
+              closeOnExternalClick: false,
+            })
+          }
+        >
+          <>회원가입</>
+        </Button>
       </ProfileContainer>
     </HeaderRestContainer>
   );
@@ -91,7 +115,7 @@ const widthAnimation = keyframes`
 `;
 
 const SearchContainer = styled.div([
-  tw`desktop:(w-[20rem])`,
+  tw`desktop:(w-[15rem])`,
   tw`mobile:(w-[12.4rem])`,
   css`
     display: flex;
@@ -123,7 +147,7 @@ const SearchInput = styled.input([
 ]);
 
 const ProfileContainer = styled.div([
-  tw`desktop:(w-[10rem])`,
+  tw`desktop:(w-[15rem])`,
   css`
     display: flex;
     align-items: center;

--- a/frontend/src/components/Header/HeaderRest/HeaderRest.tsx
+++ b/frontend/src/components/Header/HeaderRest/HeaderRest.tsx
@@ -6,13 +6,22 @@ import { keyframes } from '@emotion/react';
 import { useState } from 'react';
 import useProfileQuery from '@hooks/useProfileQuery';
 import useInput from '@hooks/useInput';
+import useModal from '@hooks/useModal';
+import Modal from '@components/Modal/Modal';
+import LoginModal from '@components/LoginModal/LoginModal';
 
 const HeaderRest = () => {
+  const { openModal, closeModal } = useModal();
   const { data, isSuccess, isError } = useProfileQuery();
 
   const [isClickSearchButton, setIsClickSearchButton] = useState<boolean>(false);
+  const [searchInput, setSearchInput, resetSearchInput] = useInput('');
 
-  const [searchInput, setSearchInput] = useInput('');
+  const handleBlur = () => {
+    setIsClickSearchButton(false);
+    resetSearchInput();
+  };
+  const modalCloseCallback = () => closeModal(Modal);
 
   return (
     <HeaderRestContainer>
@@ -22,7 +31,13 @@ const HeaderRest = () => {
             <Button isIcon={true} size="l">
               <FaSistrix />
             </Button>
-            <SearchInput value={searchInput} onChange={setSearchInput} type="text" />
+            <SearchInput
+              value={searchInput}
+              onChange={setSearchInput}
+              onBlur={handleBlur}
+              autoFocus
+              type="text"
+            />
           </SearchInputForm>
         ) : (
           <Button isIcon={true} size="l" onClick={() => setIsClickSearchButton(true)}>
@@ -38,7 +53,18 @@ const HeaderRest = () => {
           </>
         )}
         {isError && (
-          <Button size="l" font="maplestory" isIcon={false}>
+          <Button
+            size="l"
+            font="maplestory"
+            isIcon={false}
+            onClick={() =>
+              openModal(Modal, {
+                children: LoginModal(modalCloseCallback),
+                onClose: modalCloseCallback,
+                closeOnExternalClick: true,
+              })
+            }
+          >
             <>로그인</>
           </Button>
         )}

--- a/frontend/src/components/JoinModal/JoinModal.tsx
+++ b/frontend/src/components/JoinModal/JoinModal.tsx
@@ -1,0 +1,12 @@
+import { ModalProps } from 'types/modal';
+import JoinModalComponent from './JoinModalComponent/JoinModalComponent';
+
+function JoinModal(onClose: ModalProps['onClose']) {
+  return (
+    <>
+      <JoinModalComponent onClose={onClose} />
+    </>
+  );
+}
+
+export default JoinModal;

--- a/frontend/src/components/JoinModal/JoinModalComponent/JoinModalComponent.tsx
+++ b/frontend/src/components/JoinModal/JoinModalComponent/JoinModalComponent.tsx
@@ -1,0 +1,56 @@
+import { useState } from 'react';
+import { ModalProps } from 'types/modal';
+
+import useInput from '@hooks/useInput';
+import StepOneContent from './StepOneContent/StepOneContent';
+import StepTwoContent from './StepTwoContent/StepTwoContent';
+
+interface JoinModalProps {
+  onClose: ModalProps['onClose'];
+}
+
+function JoinModalComponent({ onClose }: JoinModalProps) {
+  const STEP1 = 0;
+  const STEP2 = 1;
+  const [step, setStep] = useState<number>(STEP1);
+  const [nameInput, setNameInput] = useInput('');
+  const [selectGenre, setSelectGenre] = useState<Set<number>>(new Set());
+
+  const selectGenreHandler = (idx: number) => {
+    setSelectGenre((prevSet) => {
+      const newSet = new Set(prevSet);
+      if (newSet.has(idx)) {
+        newSet.delete(idx);
+      } else {
+        newSet.add(idx);
+      }
+
+      return newSet;
+    });
+  };
+
+  const nextStep = () => {
+    setStep(step + 1);
+  };
+
+  return (
+    <>
+      {step === STEP1 && (
+        <StepOneContent nameInput={nameInput} setNameInput={setNameInput} nextStep={nextStep} />
+      )}
+      {step === STEP2 && (
+        <StepTwoContent
+          selectGenre={selectGenre}
+          setSelectGenre={selectGenreHandler}
+          onClose={() => {
+            //TODO: 회원가입 API 호출
+            console.log(nameInput, selectGenre);
+            onClose();
+          }}
+        />
+      )}
+    </>
+  );
+}
+
+export default JoinModalComponent;

--- a/frontend/src/components/JoinModal/JoinModalComponent/StepOneContent/StepOneContent.tsx
+++ b/frontend/src/components/JoinModal/JoinModalComponent/StepOneContent/StepOneContent.tsx
@@ -1,0 +1,102 @@
+import Button from '@components/Button/Button';
+import { ChangeEventHandler, MouseEventHandler } from 'react';
+import tw, { styled, css } from 'twin.macro';
+
+interface StepOneContentProps {
+  nameInput: string;
+  setNameInput: ChangeEventHandler;
+  nextStep: MouseEventHandler;
+}
+
+function StepOneContent({ nameInput, setNameInput, nextStep }: StepOneContentProps) {
+  const checkDuplicated = () => {
+    //TODO: 닉네임 중복확인 API 호출
+  };
+
+  return (
+    <>
+      <TopWrapper>
+        <JoinModalInfo>Lock Festival에서 사용하실 닉네임을 입력하세요.</JoinModalInfo>
+        <NameInput value={nameInput} onChange={setNameInput} type="text" />
+        <InputButtonWrapper>
+          <Button size="l" isIcon={false} onClick={checkDuplicated}>
+            <>중복확인</>
+          </Button>
+        </InputButtonWrapper>
+        <WarningText isValid={true}>사용가능한 닉네임입니다!</WarningText>
+      </TopWrapper>
+
+      <ButtonWrapper>
+        <Button isIcon={false} onClick={nextStep} disabled={!nameInput}>
+          <>NEXT</>
+        </Button>
+      </ButtonWrapper>
+    </>
+  );
+}
+
+export default StepOneContent;
+
+const TopWrapper = styled.div([
+  css`
+    position: relative;
+    display: flex;
+    gap: 4rem;
+    margin-top: 6.4rem;
+    height: 27.2rem;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+  `,
+]);
+
+const JoinModalInfo = styled.div([tw`font-maplestory text-l text-white`]);
+
+const NameInput = styled.input([
+  tw`font-pretendard text-m bg-white rounded-default pl-5 pr-[8.8rem]`,
+  css`
+    width: 32rem;
+    height: 3.6rem;
+    border: 0;
+  `,
+]);
+
+const InputButtonWrapper = styled.div([
+  css`
+    position: absolute;
+    top: 12.9rem;
+    left: 33rem;
+  `,
+]);
+
+const ButtonWrapper = styled.div([
+  css`
+    display: flex;
+    width: 100%;
+    justify-content: flex-end;
+  `,
+  tw`
+    p-4
+  `,
+]);
+
+interface WarningTextProps {
+  isValid: boolean;
+}
+
+const WarningText = styled.div<WarningTextProps>(({ isValid }) => {
+  const warningTextStyle = [
+    tw`font-pretendard text-m `,
+    css`
+      margin-top: -2rem;
+    `,
+  ];
+
+  if (isValid) {
+    warningTextStyle.push(tw`text-green-light`);
+  } else {
+    warningTextStyle.push(tw`text-red-dark`);
+  }
+
+  return warningTextStyle;
+});

--- a/frontend/src/components/JoinModal/JoinModalComponent/StepTwoContent/StepTwoContent.tsx
+++ b/frontend/src/components/JoinModal/JoinModalComponent/StepTwoContent/StepTwoContent.tsx
@@ -1,0 +1,74 @@
+import tw, { styled, css } from 'twin.macro';
+import Button from '@components/Button/Button';
+import { genreList } from '@constants/themeGenres';
+import { ModalProps } from 'types/modal';
+import ThemeButton from './ThemeButton/ThemeButton';
+
+interface StepTwoContentProps {
+  selectGenre: Set<number>;
+  setSelectGenre: (idx: number) => void;
+  onClose: ModalProps['onClose'];
+}
+
+function StepTwoContent({ selectGenre, setSelectGenre, onClose }: StepTwoContentProps) {
+  const NOT_SELECT = 0;
+
+  return (
+    <>
+      <TopWrapper>
+        <JoinModalInfo>선호하시는 테마를 전부 선택해주세요.</JoinModalInfo>
+        <ThemeButtonsContainer>
+          {genreList.map((item, idx) => (
+            <ThemeButton
+              item={item}
+              idx={idx}
+              buttonHandler={setSelectGenre}
+              isSelected={selectGenre.has(idx)}
+            />
+          ))}
+        </ThemeButtonsContainer>
+      </TopWrapper>
+      <ButtonWrapper>
+        <Button isIcon={false} onClick={onClose} disabled={selectGenre.size === NOT_SELECT}>
+          <>완료</>
+        </Button>
+      </ButtonWrapper>
+    </>
+  );
+}
+
+export default StepTwoContent;
+
+const TopWrapper = styled.div([
+  css`
+    display: flex;
+    gap: 4rem;
+    margin-top: 6.4rem;
+    width: 54.2rem;
+    height: 40rem;
+    flex-direction: column;
+    align-items: center;
+    justify-content: flex-start;
+  `,
+]);
+
+const JoinModalInfo = styled.div([tw`font-maplestory text-l text-white`]);
+
+const ButtonWrapper = styled.div([
+  css`
+    display: flex;
+    width: 100%;
+    justify-content: flex-end;
+  `,
+  tw`
+    p-4
+  `,
+]);
+
+const ThemeButtonsContainer = styled.div([
+  css`
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
+    gap: 1rem;
+  `,
+]);

--- a/frontend/src/components/JoinModal/JoinModalComponent/StepTwoContent/StepTwoContent.tsx
+++ b/frontend/src/components/JoinModal/JoinModalComponent/StepTwoContent/StepTwoContent.tsx
@@ -16,7 +16,7 @@ function StepTwoContent({ selectGenre, setSelectGenre, onClose }: StepTwoContent
   return (
     <>
       <TopWrapper>
-        <JoinModalInfo>선호하시는 테마를 전부 선택해주세요.</JoinModalInfo>
+        <JoinModalInfo>선호하시는 장르를 전부 선택해주세요.</JoinModalInfo>
         <ThemeButtonsContainer>
           {genreList.map((item, idx) => (
             <ThemeButton

--- a/frontend/src/components/JoinModal/JoinModalComponent/StepTwoContent/ThemeButton/ThemeButton.tsx
+++ b/frontend/src/components/JoinModal/JoinModalComponent/StepTwoContent/ThemeButton/ThemeButton.tsx
@@ -1,0 +1,70 @@
+import tw, { styled, css } from 'twin.macro';
+
+interface ThemeButtonProps {
+  item: { thumbnail: string; genre: string };
+  idx: number;
+  buttonHandler: (idx: number) => void;
+  isSelected: boolean;
+}
+
+function ThemeButton({ item, idx, buttonHandler, isSelected }: ThemeButtonProps) {
+  return (
+    <ThemeButtonWrapper key={idx} onClick={() => buttonHandler(idx)} isSelected={isSelected}>
+      <SelectedState isSelected={isSelected}></SelectedState>
+      <ThemeImg src={item.thumbnail} alt="genreImg" />
+      <ThemeGenre isSelected={isSelected}>{item.genre}</ThemeGenre>
+    </ThemeButtonWrapper>
+  );
+}
+
+export default ThemeButton;
+
+const ThemeButtonWrapper = styled.div<Pick<ThemeButtonProps, 'isSelected'>>(({ isSelected }) => {
+  const backgroundColor = isSelected ? tw`bg-gray-dark` : tw`bg-white`;
+  return [
+    backgroundColor,
+    tw`rounded-[2rem]`,
+    css`
+      position: relative;
+      display: flex;
+      flex-direction: column;
+      justify-content: center;
+      align-items: center;
+      gap: 1rem;
+      width: 11.8rem;
+      height: 16rem;
+      cursor: pointer;
+    `,
+  ];
+});
+
+const ThemeImg = styled.img([
+  tw`rounded-[2rem]`,
+  css`
+    width: 9rem;
+    height: 10rem;
+    margin-top: 1rem;
+  `,
+]);
+
+const SelectedState = styled.div<Pick<ThemeButtonProps, 'isSelected'>>(({ isSelected }) => {
+  const backgroundColor = isSelected ? tw`bg-green-light` : tw`bg-white`;
+
+  return [
+    backgroundColor,
+    tw`rounded-[50%]`,
+    css`
+      position: absolute;
+      width: 1.2rem;
+
+      height: 1.2rem;
+      top: 1rem;
+      right: 1rem;
+    `,
+  ];
+});
+
+const ThemeGenre = styled.div<Pick<ThemeButtonProps, 'isSelected'>>(({ isSelected }) => {
+  const fontColor = isSelected ? tw`text-white` : tw`text-gray-dark`;
+  return [fontColor, tw`font-pretendard text-s-bold`];
+});

--- a/frontend/src/components/LoginModal/LoginModal.tsx
+++ b/frontend/src/components/LoginModal/LoginModal.tsx
@@ -1,0 +1,48 @@
+import { ModalProps } from 'types/modal';
+import Button from '@components/Button/Button';
+import { FaXmark } from 'react-icons/fa6';
+import NaverLogin from '@components/LoginModal/NaverLogin/NaverLogin';
+import tw, { css, styled } from 'twin.macro';
+
+function LoginModal(onClose: ModalProps['onClose']) {
+  return (
+    <>
+      <ButtonWrapper>
+        <Button isIcon={true} onClick={onClose}>
+          <>
+            <FaXmark />
+          </>
+        </Button>
+      </ButtonWrapper>
+      <BottomWrapper>
+        Lock Festival 로그인
+        <NaverLogin />
+      </BottomWrapper>
+    </>
+  );
+}
+
+export default LoginModal;
+
+const ButtonWrapper = styled.div([
+  css`
+    display: flex;
+    width: 100%;
+    justify-content: flex-end;
+  `,
+  tw`
+    p-4
+  `,
+]);
+
+const BottomWrapper = styled.div([
+  tw`font-maplestory text-l text-white m-5`,
+  css`
+    display: flex;
+    height: 25rem;
+    gap: 5rem;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+  `,
+]);

--- a/frontend/src/components/LoginModal/NaverLogin/NaverLogin.tsx
+++ b/frontend/src/components/LoginModal/NaverLogin/NaverLogin.tsx
@@ -1,6 +1,4 @@
-import { useEffect, useState } from 'react';
-import { SERVER_URL } from '@config/server';
-import axios from 'axios';
+import { useEffect } from 'react';
 
 declare global {
   interface Window {

--- a/frontend/src/components/LoginModal/NaverLogin/NaverLogin.tsx
+++ b/frontend/src/components/LoginModal/NaverLogin/NaverLogin.tsx
@@ -1,0 +1,37 @@
+import { useEffect, useState } from 'react';
+import { SERVER_URL } from '@config/server';
+import axios from 'axios';
+
+declare global {
+  interface Window {
+    naver: any;
+  }
+}
+
+function NaverLogin() {
+  const NAVER_CLIENT_ID = import.meta.env.VITE_NAVER_CLIENT_ID;
+  const NAVER_CALLBACK_URL = import.meta.env.VITE_NAVER_REDIRECT_URI;
+
+  const { naver } = window;
+  const naverLogin = new naver.LoginWithNaverId({
+    clientId: NAVER_CLIENT_ID,
+    callbackUrl: NAVER_CALLBACK_URL,
+    isPopup: false,
+    loginButton: { color: 'green', type: 3, height: 36 },
+    callbackHandle: false,
+  });
+
+  useEffect(() => {
+    naverLogin.init();
+  }, []);
+
+  return (
+    <>
+      <div>
+        <div id="naverIdLogin"></div>
+      </div>
+    </>
+  );
+}
+
+export default NaverLogin;

--- a/frontend/src/components/Router/CustomRouter.tsx
+++ b/frontend/src/components/Router/CustomRouter.tsx
@@ -5,6 +5,7 @@ import Diary from '@pages/Diary/Diary';
 import MyPage from '@pages/Mypage/Mypage';
 import GroupChat from '@pages/GroupChat/GroupChat';
 import Recruitment from '@pages/Recruitment/Recruitment';
+import AuthHandler from '@utils/auth/authHandler';
 
 import { BrowserRouter, Routes, Route } from 'react-router-dom';
 
@@ -19,6 +20,7 @@ const CustomRouter = () => {
           <Route path="/group-chat" element={<GroupChat />}></Route>
           <Route path="/mypage" element={<MyPage />}></Route>
           <Route path="/diary" element={<Diary />}></Route>
+          <Route path="/auth" element={<AuthHandler />}></Route>
         </Route>
       </Routes>
     </BrowserRouter>

--- a/frontend/src/constants/themeGenres.ts
+++ b/frontend/src/constants/themeGenres.ts
@@ -1,2 +1,39 @@
 //TODO: 추후에 장르 추가
 export const themeGenres = ['공포', '코믹', '감성'];
+
+export const genreList = [
+  {
+    genre: '공포',
+    thumbnail:
+      'https://i.postimg.cc/B6ktkgKh/theme-Kakao-Talk-Photo-2019-03-05-17-11-51-4-B-13-1313.jpg',
+  },
+  {
+    genre: '코믹',
+    thumbnail: 'https://i.postimg.cc/DyP5kj2p/theme-XX.png',
+  },
+  {
+    genre: 'SF',
+    thumbnail: 'https://i.postimg.cc/8zv36BDh/theme.jpg',
+  },
+  {
+    genre: '판타지',
+    thumbnail:
+      'https://i.postimg.cc/Bvv6vy5Y/theme-Kakao-Talk-Photo-2019-03-05-17-11-51-3-MONSTER-10800.jpg',
+  },
+  {
+    genre: '드라마',
+    thumbnail: 'https://i.postimg.cc/2yBJ74hR/theme.jpg',
+  },
+  {
+    genre: '로맨스',
+    thumbnail: 'https://i.postimg.cc/cHJGwgF0/theme-BANK-RUPT.jpg',
+  },
+  {
+    genre: '스릴러',
+    thumbnail: 'https://www.xphobia.net/data/item/Split_illustration_600px.png',
+  },
+  {
+    genre: '추리',
+    thumbnail: 'https://i.postimg.cc/nrv2LTqz/theme-Tester.jpg',
+  },
+];

--- a/frontend/src/hooks/useInput.tsx
+++ b/frontend/src/hooks/useInput.tsx
@@ -12,7 +12,11 @@ const useInput = (initialValue: string) => {
     []
   );
 
-  return [inputValue, handleValue] as const;
+  const resetValue = useCallback(() => {
+    setInputValue('');
+  }, []);
+
+  return [inputValue, handleValue, resetValue] as const;
 };
 
 export default useInput;

--- a/frontend/src/hooks/useProfileQuery.tsx
+++ b/frontend/src/hooks/useProfileQuery.tsx
@@ -14,6 +14,8 @@ const useProfileQuery = () => {
     queryKey: ['profile'],
     queryFn: fetchUserProfile,
     staleTime: 3600,
+    refetchOnMount: true,
+    retry: false,
   });
 
   return { data, isSuccess, isLoading, isError };

--- a/frontend/src/utils/auth/authHandler.tsx
+++ b/frontend/src/utils/auth/authHandler.tsx
@@ -1,0 +1,27 @@
+import axios from 'axios';
+import { SERVER_URL } from '@config/server';
+import { useEffect } from 'react';
+
+function AuthHandler() {
+  const getUser = async () => {
+    const token = window.location.href.split('=')[1].split('&')[0];
+    const loginAPI = axios({
+      method: 'get',
+      url: SERVER_URL + `/auth/login/naver?code=${token}`,
+    });
+    try {
+      const response = await loginAPI;
+      window.history.back();
+    } catch (error) {
+      // Handle the error as needed
+    }
+  };
+
+  useEffect(() => {
+    getUser();
+  }, []);
+
+  return <>hello</>;
+}
+
+export default AuthHandler;

--- a/frontend/src/utils/auth/authHandler.tsx
+++ b/frontend/src/utils/auth/authHandler.tsx
@@ -11,6 +11,7 @@ function AuthHandler() {
     });
     try {
       const response = await loginAPI;
+      console.log(response);
       window.history.back();
     } catch (error) {
       // Handle the error as needed


### PR DESCRIPTION
## 🤷‍♂️ Description
<!-- 구현 한 기능에 대해 작성해 주세요. -->
- 임시로 회원가입 버튼을 만들었어요.
- 네이버 로그인 API는 완벽하게 연동은 되어있지 않고, msw로도 안되는 상황이에요. 오류는 나지 않아서 일단 합쳐서 같이 해결할 예정이에요.
- 회원가입 모달은 닉네임 중복확인, 회원가입 요청 API만 연동되어 있지 않고 나머지 기능은 완료한 상태에요.
- 버튼 컴포넌트에 disabled일때의 스타일을 추가했어요.
- 추가 설명은 Screenshots에서 할게요.

## 📝 Primary Commits

<!-- 세부 구현 사항을 리스트로 작성해주세요. -->

- [x] 검색 바 블러 이벤트 적용
- [X] 로그인 모달 마크업 및 네이버 로그인 API 일부 구현
- [x] 회원가입 모달 구현 (API 연동 x)

## 📷 Screenshots
1. 로그인 로그아웃
    - 로그인시 한번에 프로필 사진이 바뀌지 않아요.
    - 프로필 클릭하면 로그아웃되게 일단 구현했어요.

https://github.com/boostcampwm2023/web03-LockFestival/assets/82202370/6d37eea0-32ac-4b1f-b35e-ec6c4affacc9

2. 회원가입 모달
    - 테마 사진 렌더링이 느려요.
    - 중복확인, 완료에 API 연동 안되어있어요.
    - 닉네임을 입력하지 않거나 선호하는 카테고리를 선택하지 않는 경우 NEXT, 완료 버튼이 비활성화 되게 했어요.

https://github.com/boostcampwm2023/web03-LockFestival/assets/82202370/6c818a9d-55be-4708-9968-6cb6c985ce42

3. 검색바 블러 이벤트

https://github.com/boostcampwm2023/web03-LockFestival/assets/82202370/3f772256-2ae9-4d36-8e71-775a53f856e3



<!-- 이슈번호를 작성해주세요. -->
<!-- 여러 이슈를 입력시 comma(,) 단위로 구분해주세요 -->
<!-- ex) close #10, resolves #123 -->


<!-- ex) -->
<!-- closes #1 --> 

closes #45 
