### PR TITLE
Feature/FE/#128 검색 리팩토링 및 페이지 이동

### DIFF
--- a/frontend/src/components/Header/HeaderRest/HeaderRest.tsx
+++ b/frontend/src/components/Header/HeaderRest/HeaderRest.tsx
@@ -3,28 +3,25 @@ import Button from '@components/Button/Button';
 import { FaUser } from 'react-icons/fa6';
 import { FaSistrix } from 'react-icons/fa6';
 import { keyframes } from '@emotion/react';
-import { useState, useEffect } from 'react';
+import { useEffect } from 'react';
 import useProfileQuery from '@hooks/useProfileQuery';
-import useInput from '@hooks/useInput';
 import useModal from '@hooks/useModal';
 import Modal from '@components/Modal/Modal';
 import LoginModal from '@components/LoginModal/LoginModal';
 import JoinModal from '@components/JoinModal/JoinModal';
-import { useLocation } from 'react-router-dom';
+import useHeaderSearchInput from '@hooks/useHeaderSearchInput';
 
 const HeaderRest = () => {
-  const location = useLocation();
-
   const { openModal, closeModal } = useModal();
   const { data, isSuccess, isLoading, isError } = useProfileQuery();
 
-  const [isClickSearchButton, setIsClickSearchButton] = useState<boolean>(false);
-  const [searchInput, setSearchInput, resetSearchInput] = useInput('');
-
-  const handleBlur = () => {
-    setIsClickSearchButton(false);
-    resetSearchInput();
-  };
+  const {
+    searchInput,
+    handleSearchInput,
+    isClickSearchButton,
+    handleBlur,
+    setIsClickSearchButton,
+  } = useHeaderSearchInput();
 
   const handleLogin = () => {
     localStorage.setItem('lastVisited', location.pathname);
@@ -64,7 +61,7 @@ const HeaderRest = () => {
             </Button>
             <SearchInput
               value={searchInput}
-              onChange={setSearchInput}
+              onChange={handleSearchInput}
               onBlur={handleBlur}
               autoFocus
               type="text"
@@ -110,7 +107,7 @@ const HeaderRestContainer = styled.div([
 
 const widthAnimation = keyframes`
   0% {
-    width: 30%;
+    width: 40%;
   }
   100% {
     width: 100%;
@@ -130,7 +127,7 @@ const SearchInputForm = styled.div([
   tw`desktop:(max-w-[16.4rem] w-[16.4rem] h-[3.6rem] rounded-[4rem])`,
   tw`mobile:(w-[12.4rem] h-[3.2rem] rounded-[3rem])`,
   css`
-    animation: 1s ${widthAnimation} forwards;
+    animation: 0.6s ${widthAnimation} forwards;
     display: flex;
     align-items: center;
   `,

--- a/frontend/src/components/Router/CustomRouter.tsx
+++ b/frontend/src/components/Router/CustomRouter.tsx
@@ -8,7 +8,7 @@ import Recruitment from '@pages/Recruitment/Recruitment';
 import Auth from '@pages/Auth/Auth';
 import MyPage from '@pages/Mypage/Mypage';
 import Root from '@pages/Root/Root';
-import Search from '@pages/Search/search';
+import Search from '@pages/Search/Search';
 
 const CustomRouter = () => {
   return (

--- a/frontend/src/components/Router/CustomRouter.tsx
+++ b/frontend/src/components/Router/CustomRouter.tsx
@@ -8,6 +8,7 @@ import Recruitment from '@pages/Recruitment/Recruitment';
 import Auth from '@pages/Auth/Auth';
 import MyPage from '@pages/Mypage/Mypage';
 import Root from '@pages/Root/Root';
+import Search from '@pages/Search/search';
 
 const CustomRouter = () => {
   return (
@@ -20,6 +21,7 @@ const CustomRouter = () => {
           <Route path="/group-chat" element={<GroupChat />}></Route>
           <Route path="/diary" element={<Diary />}></Route>
           <Route path="/auth" element={<Auth />}></Route>
+          <Route path="/search" element={<Search />}></Route>
         </Route>
       </Routes>
     </BrowserRouter>

--- a/frontend/src/hooks/useHeaderSearchInput.tsx
+++ b/frontend/src/hooks/useHeaderSearchInput.tsx
@@ -1,0 +1,43 @@
+import { useEffect, useState } from 'react';
+import useInput from './useInput';
+import { useLocation, useNavigate } from 'react-router-dom';
+
+const useHeaderSearchInput = () => {
+  const navigate = useNavigate();
+  const location = useLocation();
+
+  const [searchInput, setSearchInput] = useInput('');
+  const [urlBeforeSearch, setUrlBeforeSearch] = useState<string>('/');
+  const [isClickSearchButton, setIsClickSearchButton] = useState<boolean>(false);
+
+  const handleSearchInput = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+    if (searchInput === '') {
+      setUrlBeforeSearch(location.pathname);
+    }
+    setSearchInput(e);
+  };
+
+  const handleBlur = () => {
+    if (searchInput === '') {
+      setIsClickSearchButton(false);
+    }
+  };
+
+  useEffect(() => {
+    if (searchInput === '') {
+      navigate(urlBeforeSearch);
+      return;
+    }
+    navigate(`/search?query=${searchInput}`);
+  }, [searchInput]);
+
+  return {
+    searchInput,
+    handleSearchInput,
+    isClickSearchButton,
+    handleBlur,
+    setIsClickSearchButton,
+  };
+};
+
+export default useHeaderSearchInput;

--- a/frontend/src/pages/Search/Search.tsx
+++ b/frontend/src/pages/Search/Search.tsx
@@ -1,0 +1,5 @@
+const Search = () => {
+  return <div>검색 페이지</div>;
+};
+
+export default Search;


### PR DESCRIPTION
## 🤷‍♂️ Description
기존 검색관련 비즈니스 로직이 헤더에 있어서 훅으로 분리했어요.
훅에서는 검색 버튼을 눌렀는지와 검색어를 저장하고 있어요.

만약 검색어가 없으면서 blur 이벤트가 발생하면 input을 닫아요.
그게아니라면 input을 닫지 않아요.

또, 검색어를 입력할 때마다 쿼리가 달라지게했어요.

만약 검색어를 전부 지우면 검색 이전 페이지로 돌아가도록 했어요.

<!-- 구현 한 기능에 대해 작성해 주세요. -->

## 📝 Primary Commits

<!-- 세부 구현 사항을 리스트로 작성해주세요. -->

- [X] 검색어가 있다면 검색 input이 닫히지 않도록 구현
- [X]검색어를 치면 검색 페이지로 이동
- [X] 검색어를 전부 지우면 원래 페이지로 이동

## 📷 Screenshots


https://github.com/boostcampwm2023/web03-LockFestival/assets/100738049/9beab422-38ca-4b7e-a001-616659fb7174




<!-- ex) -->
<!-- closes #1 --> 

closes #128 