### PR TITLE
Fix/BE/#132: 위치 기반 매장 테마 반환 API pagination 추가

### DIFF
--- a/backend/src/dtos/pagination.dto.ts
+++ b/backend/src/dtos/pagination.dto.ts
@@ -1,5 +1,6 @@
 import { Transform } from 'class-transformer';
 import { IsNumber } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
 
 const DEFAULT_COUNT = 10 as const;
 const DEFAULT_PAGE = 1 as const;
@@ -9,11 +10,13 @@ export class PaginationDto {
     return parseInt(value);
   })
   @IsNumber()
+  @ApiProperty({ description: '페이지', default: DEFAULT_PAGE, required: false })
   page: number = DEFAULT_PAGE;
 
   @Transform(({ value }) => {
     return parseInt(value);
   })
   @IsNumber()
+  @ApiProperty({ description: '가져올 테마 개수', default: DEFAULT_COUNT, required: false })
   count: number = DEFAULT_COUNT;
 }

--- a/backend/src/dtos/pagination.page.meta.dto.ts
+++ b/backend/src/dtos/pagination.page.meta.dto.ts
@@ -1,0 +1,19 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class PaginationPageMetaDto {
+  @ApiProperty({
+    description: '더 받을 수 있는 남은 데이터의 개수 (0이면 더이상 받을 수 없음)',
+    example: 30,
+  })
+  restCount: number;
+  @ApiProperty({
+    description: '다음 요청 페이지 (다음 요청이 없으면 undefined)',
+    example: 9,
+    examples: [1, undefined],
+  })
+  nextPage: number | undefined;
+  constructor(restCount: number, nextPage: number | undefined) {
+    this.restCount = restCount;
+    this.nextPage = nextPage;
+  }
+}

--- a/backend/src/modules/themeModules/theme/dtos/theme.location.dto.ts
+++ b/backend/src/modules/themeModules/theme/dtos/theme.location.dto.ts
@@ -1,6 +1,5 @@
 import { IsNumber, IsLatitude, IsLongitude } from 'class-validator';
 import { Transform } from 'class-transformer';
-
 import { ApiProperty } from '@nestjs/swagger';
 import { PaginationDto } from '@src/dtos/pagination.dto';
 

--- a/backend/src/modules/themeModules/theme/dtos/theme.location.dto.ts
+++ b/backend/src/modules/themeModules/theme/dtos/theme.location.dto.ts
@@ -1,11 +1,12 @@
 import { IsNumber, IsLatitude, IsLongitude } from 'class-validator';
 import { Transform } from 'class-transformer';
+
 import { ApiProperty } from '@nestjs/swagger';
+import { PaginationDto } from '@src/dtos/pagination.dto';
 
 const DEFAULT_BOUNDARY = 5 as const;
-const DEFAULT_COUNT = 10 as const;
 
-export class ThemeLocationDto {
+export class ThemeLocationDto extends PaginationDto {
   @Transform(({ value }) => {
     return parseFloat(value);
   })
@@ -19,13 +20,6 @@ export class ThemeLocationDto {
   @IsLongitude()
   @ApiProperty({ description: '경로', example: '126.97255197' })
   y: number;
-
-  @Transform(({ value }) => {
-    return parseInt(value);
-  })
-  @IsNumber()
-  @ApiProperty({ description: '가져올 테마 개수', default: DEFAULT_COUNT, required: false })
-  count: number = DEFAULT_COUNT;
 
   @Transform(({ value }) => {
     return parseInt(value);

--- a/backend/src/modules/themeModules/theme/dtos/theme.location.response.dto.ts
+++ b/backend/src/modules/themeModules/theme/dtos/theme.location.response.dto.ts
@@ -1,0 +1,14 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { PaginationPageMetaDto } from '@src/dtos/pagination.page.meta.dto';
+import { ThemeResponseDto } from '@theme/dtos/theme.response.dto';
+
+export class ThemeLocationResponseDto {
+  @ApiProperty({ description: '페이지네이션 메타 정보', type: PaginationPageMetaDto })
+  _meta: PaginationPageMetaDto;
+  @ApiProperty({ type: [ThemeResponseDto] })
+  data: ThemeResponseDto[];
+  constructor(restCount: number, nextPage: number, data: ThemeResponseDto[]) {
+    this._meta = new PaginationPageMetaDto(restCount, nextPage);
+    this.data = data;
+  }
+}

--- a/backend/src/modules/themeModules/theme/theme.controller.ts
+++ b/backend/src/modules/themeModules/theme/theme.controller.ts
@@ -74,8 +74,10 @@ export class ThemeController {
     description: '',
     type: [ThemeResponseDto],
   })
-  async getLocationThemes(@Query() themeLocation: ThemeLocationDto): Promise<ThemeResponseDto[]> {
-    return await this.themeService.getLocationThemes(themeLocation);
+  async getLocationThemes(
+    @Query() themeLocationDto: ThemeLocationDto
+  ): Promise<ThemeResponseDto[]> {
+    return await this.themeService.getLocationThemes(themeLocationDto);
   }
 
   @Get('/genres/:genreId')

--- a/backend/src/modules/themeModules/theme/theme.controller.ts
+++ b/backend/src/modules/themeModules/theme/theme.controller.ts
@@ -1,4 +1,5 @@
 import { Controller, DefaultValuePipe, Get, Param, ParseIntPipe, Query } from '@nestjs/common';
+import { ApiOkResponse, ApiOperation, ApiParam, ApiQuery, ApiTags } from '@nestjs/swagger';
 import { ThemeService } from '@theme/theme.service';
 import { GenreThemesResponseDto } from '@theme/dtos/genre.themes.response.dto';
 import { ThemeResponseDto } from '@theme/dtos/theme.response.dto';
@@ -6,7 +7,7 @@ import { ThemeLocationDto } from '@theme/dtos/theme.location.dto';
 import { ThemeDeatailsResponseDto } from '@theme/dtos/theme.detail.response.dto';
 import { GenreService } from '@theme/genre.service';
 import { GenreDto } from '@theme/dtos/genre.dto';
-import { ApiOkResponse, ApiOperation, ApiParam, ApiQuery, ApiTags } from '@nestjs/swagger';
+import { ThemeLocationResponseDto } from '@theme/dtos/theme.location.response.dto';
 
 const DEFAULT_THEME_COUNT = 10;
 
@@ -72,11 +73,11 @@ export class ThemeController {
   @ApiOkResponse({
     status: 200,
     description: '',
-    type: [ThemeResponseDto],
+    type: ThemeLocationResponseDto,
   })
   async getLocationThemes(
     @Query() themeLocationDto: ThemeLocationDto
-  ): Promise<ThemeResponseDto[]> {
+  ): Promise<ThemeLocationResponseDto> {
     return await this.themeService.getLocationThemes(themeLocationDto);
   }
 

--- a/backend/src/modules/themeModules/theme/theme.repository.ts
+++ b/backend/src/modules/themeModules/theme/theme.repository.ts
@@ -5,6 +5,7 @@ import { Brand } from '@brand/entities/brand.entity';
 import { Theme } from '@theme/entities/theme.entity';
 import { ThemeResponseDto } from '@theme/dtos/theme.response.dto';
 import { ThemeDeatailsResponseDto } from '@theme/dtos/theme.detail.response.dto';
+import { ThemeLocationDto } from '@theme/dtos/theme.location.dto';
 
 const KM = 1000;
 
@@ -56,7 +57,7 @@ export class ThemeRepository extends Repository<Theme> {
     return themes;
   }
 
-  async getThemesByBoundary({ x, y, boundary, count }): Promise<ThemeResponseDto[]> {
+  async getThemesByBoundary(themeLocationDto: ThemeLocationDto): Promise<ThemeResponseDto[]> {
     const themes: ThemeResponseDto[] = await this.dataSource
       .createQueryBuilder()
       .select([
@@ -67,11 +68,12 @@ export class ThemeRepository extends Repository<Theme> {
       .from(Theme, 'theme')
       .innerJoin('theme.branch', 'branch')
       .where('ST_Distance_Sphere(point(branch.y, branch.x), point(:y, :x)) <= :boundary', {
-        x,
-        y,
-        boundary: boundary * KM,
+        x: themeLocationDto.x,
+        y: themeLocationDto.y,
+        boundary: themeLocationDto.boundary * KM,
       })
-      .limit(count)
+      .offset(themeLocationDto.page * themeLocationDto.count - themeLocationDto.count)
+      .limit(themeLocationDto.count)
       .getRawMany();
 
     return themes;

--- a/backend/src/modules/themeModules/theme/theme.service.ts
+++ b/backend/src/modules/themeModules/theme/theme.service.ts
@@ -7,6 +7,7 @@ import { ThemeResponseDto } from '@theme/dtos/theme.response.dto';
 import { GenreThemesResponseDto } from '@theme/dtos/genre.themes.response.dto';
 import { ThemeLocationDto } from '@theme/dtos/theme.location.dto';
 import { ThemeDeatailsResponseDto } from '@theme/dtos/theme.detail.response.dto';
+import { ThemeLocationResponseDto } from '@theme/dtos/theme.location.response.dto';
 
 @Injectable()
 export class ThemeService {
@@ -45,8 +46,25 @@ export class ThemeService {
       })
     );
   }
-  public async getLocationThemes(themeLocationDto: ThemeLocationDto): Promise<ThemeResponseDto[]> {
-    return await this.themeRepository.getThemesByBoundary(themeLocationDto);
+  public async getLocationThemes(
+    themeLocationDto: ThemeLocationDto
+  ): Promise<ThemeLocationResponseDto> {
+    const { count, themes } = await this.themeRepository.getThemesByBoundary(themeLocationDto);
+
+    const restCount = Math.max(
+      count - (themeLocationDto.page * themeLocationDto.count + themes.length),
+      0
+    );
+
+    if (restCount === 0) {
+      return new ThemeLocationResponseDto(0, undefined, themes);
+    }
+
+    return new ThemeLocationResponseDto(
+      restCount,
+      restCount > 0 ? themeLocationDto.page + 1 : undefined,
+      themes
+    );
   }
 
   public async getGenreThemes(genreId: number, count: number): Promise<Array<ThemeResponseDto>> {


### PR DESCRIPTION
## 🤷‍♂️ Description
위치 기반 테마 반환 API에 page 기반 pagination 옵션을 추가해요.
(cursor 기반의 경우 정렬 기준이 제공되어야 하는데, 마땅한 정렬 기준이 없어요. 거리 값을 넘겨주고 있지 않기에 넘겨주기 애매하여 페이지 기반으로 변경하였습니다)

<!-- 구현 한 기능에 대해 작성해 주세요. -->

## 📝 Primary Commits

<!-- 세부 구현 사항을 리스트로 작성해주세요. -->

- [X] 페이지 기반 페이지네이션 구현
- [X] 페이지 기반 페이지네이션의 메타 정보 추가
  - PaginationPageMetaDto 

## 📷 Screenshots
![image](https://github.com/boostcampwm2023/web03-LockFestival/assets/44056518/c781c638-27ac-4d18-8294-2043d380826e)
- 더이상 남은 데이터가 없는 경우 
  ![image](https://github.com/boostcampwm2023/web03-LockFestival/assets/44056518/adf33a81-f512-413f-9b31-520debe863f1)
- 남은 데이터가 있는 경우
  ![image](https://github.com/boostcampwm2023/web03-LockFestival/assets/44056518/85fc5e71-da3d-4331-9255-678a4766c5ef)


<!--스크린샷으로 보여줄 수 있는 이미지가 있다면 첨부해주세요!-->

<!--BE의 경우 API 테스트 결과를 첨부해주세요-->

<!--마지막으로 이슈 생성 시 우측의 옵션들을 체크했는지 확인해주세요!-->

<!-- 이슈번호를 작성해주세요. -->
<!-- 여러 이슈를 입력시 comma(,) 단위로 구분해주세요 -->
<!-- ex) close #10, resolves #123 -->


<!-- ex) -->
<!-- closes #1 --> 
closes #132 

