### PR TITLE
Feature/FE/#107 카드 컴포넌트 구성

### DIFF
--- a/frontend/src/__mocks__/recruitment/recruitmentCard.ts
+++ b/frontend/src/__mocks__/recruitment/recruitmentCard.ts
@@ -1,0 +1,116 @@
+import { GroupInfoCardProps } from 'types/recruitment';
+
+export const recruitmentCard: Array<GroupInfoCardProps> = [
+  {
+    writer: {
+      profileUrl: 'https://www.keyescape.co.kr/file/theme_info/27_a.jpg',
+      nickName: '박정석',
+    },
+    theme: {
+      themeUrl: 'https://www.keyescape.co.kr/file/theme_info/22_a.jpg',
+      themeTitle: '홀리데이',
+      zizum: '키이스케이프 - 홍대점',
+      date: new Date(),
+      maxCount: 5,
+      curCount: 3,
+      isRevervation: true,
+      isRecruitment: false,
+      title: '11월 5일 오후 5시에 갈사람 구해요',
+      phone: '010-1234-5687',
+      address: '서울 강남구 강남대로98길 16, 5층',
+      personnel: '2-6',
+      playTime: 120,
+      genre: 'Fantasy',
+    },
+    etc: {
+      groupId: 'group123',
+      isEnter: true,
+      isLock: false,
+    },
+  },
+
+  {
+    writer: {
+      profileUrl: '',
+      nickName: '박정석',
+    },
+    theme: {
+      themeUrl: 'http://www.secretgardenescape.com/pimages/Product/Pr_1625824874.jpg',
+      themeTitle: '홀리데이',
+      zizum: '키이스케이프 - 홍대점',
+      date: new Date(),
+      maxCount: 5,
+      curCount: 3,
+      isRevervation: true,
+      isRecruitment: true,
+      title:
+        '11월 5일 오후 5시에 갈사람 구해요. (테마 변경 가능) 11월 5일 오후 5시에 갈사람 구해요. (테마 변경 가능 11월 5일 오후 5시에 갈사람 구해요. (테마 변경 가능',
+      phone: '010-1234-5687',
+      address: '서울 강남구 강남대로98길 16, 5층',
+      personnel: '2-6',
+      playTime: 120,
+      genre: 'Fantasy',
+    },
+    etc: {
+      groupId: 'group123',
+      isEnter: false,
+      isLock: true,
+    },
+  },
+
+  {
+    writer: {
+      profileUrl: '',
+      nickName: '박정석',
+    },
+    theme: {
+      themeUrl: 'http://www.secretgardenescape.com/pimages/Product/Pr_1677730631.png',
+      themeTitle: '홀리데이',
+      zizum: '키이스케이프 - 홍대점',
+      date: new Date(),
+      maxCount: 5,
+      curCount: 3,
+      isRevervation: false,
+      isRecruitment: false,
+      title: '11월 5일 오후 5시에 갈사람 구해요. (테마 변경 가능)',
+      phone: '010-1234-5687',
+      address: '서울 강남구 강남대로98길 16, 5층',
+      personnel: '2-6',
+      playTime: 120,
+      genre: 'Fantasy',
+    },
+    etc: {
+      groupId: 'group123',
+      isEnter: true,
+      isLock: true,
+    },
+  },
+
+  {
+    writer: {
+      profileUrl: '',
+      nickName: '박정석',
+    },
+    theme: {
+      themeUrl: 'http://www.secretgardenescape.com/pimages/Product/Pr_1602671819.jpg',
+      themeTitle: '홀리데이',
+      zizum: '키이스케이프 - 홍대점',
+      date: new Date(),
+      maxCount: 5,
+      curCount: 3,
+      isRevervation: false,
+      isRecruitment: true,
+      title: '11월 5일 오후 5시에 갈사람 구해요. (테마 변경 가능)',
+      phone: '010-1234-5687',
+      address: '서울 강남구 강남대로98길 16, 5층',
+      personnel: '2-6',
+      playTime: 120,
+      genre: 'Fantasy',
+    },
+    etc: {
+      groupId: 'group123',
+      isEnter: true,
+      isLock: true,
+    },
+  },
+];

--- a/frontend/src/apis/enterGroupByGroupId.ts
+++ b/frontend/src/apis/enterGroupByGroupId.ts
@@ -1,0 +1,9 @@
+import { SERVER_URL } from '@config/server';
+import axios from 'axios';
+
+const enterGroupByGroupId = async (groupId: number) => {
+  //TODO: 방 입장 api 및 axios 인스턴스 생성 후 리팩토링
+  return (await axios({ method: 'post', url: SERVER_URL + '/' })).data;
+};
+
+export default enterGroupByGroupId;

--- a/frontend/src/components/Card/GroupInfoCard/GroupInfoCard.tsx
+++ b/frontend/src/components/Card/GroupInfoCard/GroupInfoCard.tsx
@@ -1,0 +1,40 @@
+import { useState } from 'react';
+import tw, { css, styled } from 'twin.macro';
+
+import HeadCard from './HeadCard/HeadCard';
+import TailCard from './TailCard/TailCard';
+
+import { GroupInfoCardProps } from 'types/recruitment';
+
+const GroupInfoCard = (props: GroupInfoCardProps) => {
+  const [isHead, setIsHead] = useState<boolean>(true);
+
+  const handleClickFlipButton = () => {
+    setIsHead((prev) => !prev);
+  };
+
+  return (
+    <Container isHead={isHead}>
+      {isHead ? (
+        <HeadCard {...props} handleClickFlipButton={handleClickFlipButton} />
+      ) : (
+        <TailCard {...props} handleClickFlipButton={handleClickFlipButton} />
+      )}
+    </Container>
+  );
+};
+
+const Container = styled.div<{ isHead: boolean }>(({ isHead }) => [
+  tw`w-4/5 mx-auto px-4 py-2 text-white bg-gray-light font-pretendard`,
+  tw`desktop:(w-[48rem]) h-[34.4rem]`,
+  tw`mobile:(h-[55rem])`,
+  css`
+    position: relative;
+    transition: transform 0.3s;
+    transform: ${isHead
+      ? 'perspective(800px) rotateY(0deg)'
+      : 'perspective(800px) rotateY(180deg)'};
+  `,
+]);
+
+export default GroupInfoCard;

--- a/frontend/src/components/Card/GroupInfoCard/HeadCard/HeadCard.tsx
+++ b/frontend/src/components/Card/GroupInfoCard/HeadCard/HeadCard.tsx
@@ -1,0 +1,30 @@
+import { GroupInfoCardProps } from 'types/recruitment';
+import HeadCardContent from './HeadCardContent';
+import HeadCardHeader from './HeadCardHeader';
+import tw, { css, styled } from 'twin.macro';
+
+export interface HeadCardProps extends GroupInfoCardProps {
+  handleClickFlipButton: () => void;
+}
+
+const HeadCard = ({ writer, etc, theme, handleClickFlipButton }: HeadCardProps) => {
+  return (
+    <Container>
+      <HeadCardHeader
+        nickName={writer.nickName}
+        profileUrl={writer.profileUrl}
+        isLock={etc.isLock}
+      />
+      <HeadCardContent etc={etc} theme={theme} handleClickFlipButton={handleClickFlipButton} />
+    </Container>
+  );
+};
+
+const Container = styled.div([
+  tw`h-full`,
+  css`
+    position: relative;
+  `,
+]);
+
+export default HeadCard;

--- a/frontend/src/components/Card/GroupInfoCard/HeadCard/HeadCardContent.tsx
+++ b/frontend/src/components/Card/GroupInfoCard/HeadCard/HeadCardContent.tsx
@@ -1,0 +1,207 @@
+import tw, { styled, css } from 'twin.macro';
+
+import Label from '@components/Label/Label';
+import getStringByDate from '@utils/getStringByDate';
+
+import { HeadCardProps } from './HeadCard';
+import { FaRegUser } from 'react-icons/fa6';
+import { useNavigate } from 'react-router-dom';
+
+const HeadCardContent = ({ theme, etc, handleClickFlipButton }: Omit<HeadCardProps, 'writer'>) => {
+  const navigate = useNavigate();
+
+  const handleNavigate = (isEnter: boolean, groudId: string) => {
+    if (!isEnter) {
+      navigate(`chat/${groudId}`);
+    }
+  };
+
+  return (
+    <Content>
+      <ThemeCard>
+        <ThemeImg src={theme.themeUrl} />
+      </ThemeCard>
+      <ThemeContent>
+        <ThemeInfo>
+          <List>
+            <Label isBorder={true} size="l" font="pretendard">
+              <LabelText>지점</LabelText>
+            </Label>
+            <Text>{theme.zizum}</Text>
+          </List>
+          <List>
+            <Label isBorder={true} size="l" font="pretendard">
+              <LabelText>날짜</LabelText>
+            </Label>
+            <Text>{getStringByDate(theme.date)}</Text>
+          </List>
+          <List>
+            <Label isBorder={true} size="l" font="pretendard">
+              <LabelText>인원</LabelText>
+            </Label>
+            <Text>
+              {Array.from({ length: theme.curCount }, (_) => (
+                <Circle isCur={true}>
+                  <FaRegUser size={10} color="#40B753" />
+                </Circle>
+              ))}
+              {Array.from({ length: theme.maxCount - theme.curCount }, (_) => (
+                <Circle isCur={false}>
+                  <FaRegUser size={10} color="#525252" />
+                </Circle>
+              ))}
+            </Text>
+          </List>
+          <List>
+            <Label isBorder={true} size="l" font="pretendard">
+              <LabelText>상태</LabelText>
+            </Label>
+            <Text>
+              <LabelContainer>
+                <Label
+                  isBorder={false}
+                  size="s"
+                  backgroundColor={theme.isRevervation ? 'green-dark' : 'green-light'}
+                >
+                  <>{theme.isRevervation ? '예약완료' : '예약중'}</>
+                </Label>
+                <Label
+                  isBorder={false}
+                  size="s"
+                  backgroundColor={theme.isRecruitment ? 'green-dark' : 'green-light'}
+                >
+                  <>{theme.isRecruitment ? '모집완료' : '모집중'}</>
+                </Label>
+              </LabelContainer>
+            </Text>
+          </List>
+          <TitleText>{theme.title}</TitleText>
+        </ThemeInfo>
+        <ButtonContainer>
+          <Button onClick={handleClickFlipButton}>상세보기</Button>
+          <Button isEnter={etc.isEnter} onClick={() => handleNavigate(etc.isEnter, etc.groupId)}>
+            입장하기
+          </Button>
+        </ButtonContainer>
+      </ThemeContent>
+    </Content>
+  );
+};
+
+const Content = styled.div([
+  tw`text-m mt-2 gap-x-2`,
+  tw`tablet:(gap-x-4 justify-evenly)`,
+  tw`mobile:(flex-col)`,
+  css`
+    display: flex;
+  `,
+]);
+
+const ThemeCard = styled.div([
+  tw`w-[17.6rem] h-[28rem] bg-gray rounded-[2rem]`,
+  tw`mobile:(w-[14rem] h-[22.4rem] mx-auto)`,
+  css`
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  `,
+]);
+
+const ThemeImg = styled.img([
+  tw`rounded-[0.5rem] w-[15.2rem] h-[24.32rem]`,
+  tw`mobile:(w-[12rem] h-[19.2rem])`,
+]);
+
+const ThemeContent = styled.div([
+  css`
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+  `,
+]);
+
+const ThemeInfo = styled.div([]);
+
+const List = styled.div([
+  tw`mb-2 gap-x-8`,
+  tw`tablet:(gap-x-10)`,
+  tw`mobile:(gap-x-3)`,
+  css`
+    display: flex;
+    align-items: center;
+    column-gap: 2.4rem;
+  `,
+]);
+
+const ButtonContainer = styled.div([
+  css`
+    position: absolute;
+    bottom: 0.4rem;
+    right: 0;
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    column-gap: 1.6rem;
+  `,
+]);
+
+const Button = styled.button<{ isEnter?: boolean }>(({ isEnter }) => [
+  tw`text-white bg-transparent font-pretendard`,
+  css`
+    cursor: ${isEnter ? 'not-allowed' : 'pointer'};
+    color: ${isEnter && '#525252'};
+    &:hover {
+      text-decoration: underline;
+      text-underline-position: under;
+    }
+  `,
+]);
+
+const LabelText = styled.div([
+  tw`w-[4.8rem] text-l`,
+  tw`mobile:(w-[3.2rem] text-m)`,
+  css`
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  `,
+]);
+
+const Circle = styled.span<{ isCur: boolean }>(({ isCur }) => [
+  tw`(w-[2rem] h-[2rem] mr-1) rounded-full border-[0.1rem] border-white border-solid`,
+  css`
+    border: 1px solid ${isCur ? '#40B753' : '#525252'};
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  `,
+]);
+
+const Text = styled.div([
+  tw`font-pretendard`,
+  tw`mobile:(text-m)`,
+  css`
+    display: flex;
+    align-items: center;
+  `,
+]);
+
+const TitleText = styled.div([
+  tw`border-[0.1rem] border-white border-solid rounded-[1.5rem] px-2 py-1 h-[8rem] w-[25.6rem]`,
+  tw`tablet:(max-w-[35.2rem] w-full)`,
+  css`
+    display: flex;
+    align-items: center;
+    justify-self: center;
+  `,
+]);
+
+const LabelContainer = styled.div([
+  css`
+    display: flex;
+    align-items: center;
+    column-gap: 1rem;
+  `,
+]);
+
+export default HeadCardContent;

--- a/frontend/src/components/Card/GroupInfoCard/HeadCard/HeadCardHeader.tsx
+++ b/frontend/src/components/Card/GroupInfoCard/HeadCard/HeadCardHeader.tsx
@@ -1,0 +1,58 @@
+import tw, { styled, css } from 'twin.macro';
+import { FaRegUser } from 'react-icons/fa6';
+import { FaLock } from 'react-icons/fa6';
+
+interface Props {
+  profileUrl: string;
+  nickName: string;
+  isLock: boolean;
+}
+
+const HeadCardHeader = ({ profileUrl, nickName, isLock }: Props) => {
+  return (
+    <Header>
+      <UserContainer>
+        {profileUrl ? (
+          <ProfileImg src={profileUrl} />
+        ) : (
+          <Circle>
+            <FaRegUser size={16} />
+          </Circle>
+        )}
+        <Text>{nickName}</Text>
+      </UserContainer>
+      {isLock && <FaLock size={16} />}
+    </Header>
+  );
+};
+
+const Header = styled.div([
+  css`
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+  `,
+]);
+
+const UserContainer = styled.div([
+  tw`text-m`,
+  css`
+    display: flex;
+    align-items: center;
+  `,
+]);
+
+const ProfileImg = styled.img([tw`rounded-full w-[3.2rem] h-[3.2rem]`]);
+
+const Text = styled.span([tw`px-2`]);
+
+const Circle = styled.div([
+  tw`(w-[3.2rem] h-[3.2rem]) rounded-full border-[0.1rem] border-white border-solid`,
+  css`
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  `,
+]);
+
+export default HeadCardHeader;

--- a/frontend/src/components/Card/GroupInfoCard/TailCard/TailCard.tsx
+++ b/frontend/src/components/Card/GroupInfoCard/TailCard/TailCard.tsx
@@ -1,0 +1,118 @@
+import tw, { css, styled } from 'twin.macro';
+import { HeadCardProps } from '../HeadCard/HeadCard';
+import Label from '@components/Label/Label';
+import { useNavigate } from 'react-router-dom';
+
+const TailCard = ({ writer, etc, theme, handleClickFlipButton }: HeadCardProps) => {
+  const navigate = useNavigate();
+
+  const handleNavigate = (isEnter: boolean, groudId: string) => {
+    if (!isEnter) {
+      navigate(`chat/${groudId}`);
+    }
+  };
+
+  return (
+    <Container>
+      <ThemeInfo>
+        <List>
+          <Label isBorder={true} size="l" font="pretendard">
+            <LabelText>전화번호</LabelText>
+          </Label>
+          <Text>{theme.phone}</Text>
+        </List>
+        <List>
+          <Label isBorder={true} size="l" font="pretendard">
+            <LabelText>주소</LabelText>
+          </Label>
+          <Text>{theme.address}</Text>
+        </List>
+        <List>
+          <Label isBorder={true} size="l" font="pretendard">
+            <LabelText>인원</LabelText>
+          </Label>
+          <Text>{theme.personnel}</Text>
+        </List>
+        <List>
+          <Label isBorder={true} size="l" font="pretendard">
+            <LabelText>플레이타임</LabelText>
+          </Label>
+          <Text>{theme.playTime}</Text>
+        </List>
+        <List>
+          <Label isBorder={true} size="l" font="pretendard">
+            <LabelText>장르</LabelText>
+          </Label>
+          <Text>{theme.genre}</Text>
+        </List>
+      </ThemeInfo>
+      <ButtonContainer>
+        <Button onClick={handleClickFlipButton}>돌아가기</Button>
+        <Button isEnter={etc.isEnter} onClick={() => handleNavigate(etc.isEnter, etc.groupId)}>
+          입장하기
+        </Button>
+      </ButtonContainer>
+    </Container>
+  );
+};
+
+const Container = styled.div([
+  tw`h-full text-l`,
+  css`
+    position: relative;
+    transform: rotateY(180deg);
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+  `,
+]);
+
+const ThemeInfo = styled.div([]);
+
+const List = styled.div([
+  tw`my-2`,
+  tw`mobile:(my-6)`,
+  css`
+    display: flex;
+    align-items: center;
+    column-gap: 2.4rem;
+  `,
+]);
+
+const ButtonContainer = styled.div([
+  css`
+    position: absolute;
+    bottom: 0.4rem;
+    right: 0;
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    column-gap: 1.6rem;
+  `,
+]);
+
+const LabelText = styled.div([
+  tw`w-[8rem] text-l`,
+  tw`mobile:(w-[5.6rem] text-s)`,
+  css`
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  `,
+]);
+
+const Button = styled.button<{ isEnter?: boolean }>(({ isEnter }) => [
+  tw`text-white bg-transparent font-pretendard`,
+  css`
+    cursor: ${isEnter ? 'not-allowed' : 'pointer'};
+    color: ${isEnter && '#525252'};
+    &:hover {
+      text-decoration: underline;
+      text-underline-position: under;
+    }
+  `,
+]);
+
+const Text = styled.span([tw`font-pretendard`, tw`mobile:(text-m)`]);
+
+export default TailCard;

--- a/frontend/src/constants/StyleMap/ButtonsStyleMap.ts
+++ b/frontend/src/constants/StyleMap/ButtonsStyleMap.ts
@@ -23,20 +23,28 @@ const basicButtonBaseStyle = (width: string | undefined): CSSInterpolation => cs
 
 const iconStyleMap: Record<string, TwStyle[]> = {
   l: [
-    tw`mobile:(w-[3.2rem] h-[3.2rem]) desktop:(w-[3.6rem] h-[3.6rem])`,
-    { svg: tw`mobile:(w-[1.8rem] h-[1.8rem]) desktop:(w-[2.2rem] h-[2.2rem])` },
+    tw`mobile:(w-[3.2rem] h-[3.2rem]) tablet:(w-[3.6rem] h-[3.6rem]) desktop:(w-[3.6rem] h-[3.6rem])`,
+    {
+      svg: tw`mobile:(w-[1.8rem] h-[1.8rem]) tablet:(w-[2.2rem] h-[2.2rem]) desktop:(w-[2.2rem] h-[2.2rem])`,
+    },
   ],
   m: [
-    tw`mobile:(w-[2.8rem] h-[2.8rem]) desktop:(w-[3.2rem] h-[3.2rem])`,
-    { svg: tw`mobile:(w-[1.5rem] h-[1.5rem]) desktop:(w-[1.8rem] h-[1.8rem])` },
+    tw`mobile:(w-[2.8rem] h-[2.8rem]) tablet:(w-[3.2rem] h-[3.2rem]) desktop:(w-[3.2rem] h-[3.2rem])`,
+    {
+      svg: tw`mobile:(w-[1.5rem] h-[1.5rem]) tablet:(w-[1.8rem] h-[1.8rem]) desktop:(w-[1.8rem] h-[1.8rem])`,
+    },
   ],
   s: [
-    tw`mobile:(w-[2.4rem] h-[2.4rem]) desktop:(w-[2.8rem] h-[2.8rem])`,
-    { svg: tw`mobile:(w-[1.2rem] h-[1.2rem]) desktop:(w-[1.5rem] h-[1.5rem])` },
+    tw`mobile:(w-[2.4rem] h-[2.4rem]) tablet:(w-[2.8rem] h-[2.8rem]) desktop:(w-[2.8rem] h-[2.8rem])`,
+    {
+      svg: tw`mobile:(w-[1.2rem] h-[1.2rem]) tablet:(w-[1.5rem] h-[1.5rem]) desktop:(w-[1.5rem] h-[1.5rem])`,
+    },
   ],
   default: [
-    tw`mobile:(w-[2.8rem] h-[2.8rem]) desktop:(w-[3.2rem] h-[3.2rem])`,
-    { svg: tw`mobile:(w-[1.5rem] h-[1.5rem]) desktop:(w-[1.8rem] h-[1.8rem])` },
+    tw`mobile:(w-[2.8rem] h-[2.8rem]) tablet:(w-[3.2rem] h-[3.2rem]) desktop:(w-[3.2rem] h-[3.2rem])`,
+    {
+      svg: tw`mobile:(w-[1.5rem] h-[1.5rem]) tablet:(w-[1.8rem] h-[1.8rem]) desktop:(w-[1.8rem] h-[1.8rem])`,
+    },
   ],
 };
 

--- a/frontend/src/constants/StyleMap/CommonStyleMap.ts
+++ b/frontend/src/constants/StyleMap/CommonStyleMap.ts
@@ -8,32 +8,46 @@ const fontStyleMap: Record<string, TwStyle> = {
 
 const sizeStyleMap: Record<string, TwStyle[]> = {
   'l': [
-    tw`mobile:(text-m px-2.5 h-[3.2rem]) desktop:(text-l px-3 h-[3.6rem])`,
-    { svg: tw`mobile:(w-[1.8rem] h-[1.8rem]) desktop:(w-[2rem] h-[2rem])` },
+    tw`mobile:(text-m px-2.5 h-[3.2rem]) tablet:(text-l px-3 h-[3.6rem]) desktop:(text-l px-3 h-[3.6rem])`,
+    {
+      svg: tw`mobile:(w-[1.8rem] h-[1.8rem]) tablet:(w-[2rem] h-[2rem]) desktop:(w-[2rem] h-[2rem])`,
+    },
   ],
   'l-bold': [
-    tw`mobile:(text-m-bold px-2.5 h-[3.2rem]) desktop:(text-l-bold px-3 h-[3.6rem])`,
-    { svg: tw`mobile:(w-[1.8rem] h-[1.8rem]) desktop:(w-[2rem] h-[2rem])` },
+    tw`mobile:(text-m-bold px-2.5 h-[3.2rem]) tablet:(text-l-bold px-3 h-[3.6rem]) desktop:(text-l-bold px-3 h-[3.6rem])`,
+    {
+      svg: tw`mobile:(w-[1.8rem] h-[1.8rem]) tablet:(w-[2rem] h-[2rem]) desktop:(w-[2rem] h-[2rem])`,
+    },
   ],
   'm': [
-    tw`mobile:(text-s px-2 h-[2.8rem]) desktop:(text-m px-2.5) h-[3.2rem]`,
-    { svg: tw`mobile:(w-[1.5rem] h-[1.5rem]) desktop:(w-[1.8rem] h-[1.8rem])` },
+    tw`mobile:(text-s px-2 h-[2.8rem]) tablet:(text-m px-2.5) h-[3.2rem] desktop:(text-m px-2.5) h-[3.2rem]`,
+    {
+      svg: tw`mobile:(w-[1.5rem] h-[1.5rem]) tablet:(w-[1.8rem] h-[1.8rem]) desktop:(w-[1.8rem] h-[1.8rem])`,
+    },
   ],
   'm-bold': [
-    tw`mobile:(text-s-bold px-2 h-[2.8rem]) desktop:(text-m-bold px-2.5) h-[3.2rem]`,
-    { svg: tw`mobile:(w-[1.5rem] h-[1.5rem]) desktop:(w-[1.8rem] h-[1.8rem])` },
+    tw`mobile:(text-s-bold px-2 h-[2.8rem]) tablet:(text-m-bold px-2.5) h-[3.2rem] desktop:(text-m-bold px-2.5) h-[3.2rem]`,
+    {
+      svg: tw`mobile:(w-[1.5rem] h-[1.5rem]) tablet:(w-[1.8rem] h-[1.8rem]) desktop:(w-[1.8rem] h-[1.8rem])`,
+    },
   ],
   's': [
-    tw`mobile:(text-xs px-1.5 h-[2.4rem]) desktop:(text-s px-2 h-[2.8rem])`,
-    { svg: tw`mobile:(w-[1.2rem] h-[1.2rem]) desktop:(w-[1.5rem] h-[1.5rem])` },
+    tw`mobile:(text-xs px-1.5 h-[2.4rem]) tablet:(text-s px-2 h-[2.8rem]) desktop:(text-s px-2 h-[2.8rem])`,
+    {
+      svg: tw`mobile:(w-[1.2rem] h-[1.2rem]) tablet:(w-[1.5rem] h-[1.5rem]) desktop:(w-[1.5rem] h-[1.5rem])`,
+    },
   ],
   's-bold': [
-    tw`mobile:(text-xs-bold px-1.5 h-[2.4rem]) desktop:(text-s-bold px-2 h-[2.8rem])`,
-    { svg: tw`mobile:(w-[1.2rem] h-[1.2rem]) desktop:(w-[1.5rem] h-[1.5rem])` },
+    tw`mobile:(text-xs-bold px-1.5 h-[2.4rem]) tablet:(text-s-bold px-2 h-[2.8rem]) desktop:(text-s-bold px-2 h-[2.8rem])`,
+    {
+      svg: tw`mobile:(w-[1.2rem] h-[1.2rem]) tablet:(w-[1.5rem] h-[1.5rem]) desktop:(w-[1.5rem] h-[1.5rem])`,
+    },
   ],
   'default': [
-    tw`mobile:(text-s px-2 h-[2.8rem]) desktop:(text-m px-2.5 h-[3.2rem])`,
-    { svg: tw`mobile:(w-[1.5rem] h-[1.5rem]) desktop:(w-[1.8rem] h-[1.8rem])` },
+    tw`mobile:(text-s px-2 h-[2.8rem]) tablet:(text-m px-2.5 h-[3.2rem]) desktop:(text-m px-2.5 h-[3.2rem])`,
+    {
+      svg: tw`mobile:(w-[1.5rem] h-[1.5rem]) tablet:(w-[1.8rem] h-[1.8rem]) desktop:(w-[1.8rem] h-[1.8rem])`,
+    },
   ],
 };
 

--- a/frontend/src/pages/Recruitment/Recruitment.tsx
+++ b/frontend/src/pages/Recruitment/Recruitment.tsx
@@ -1,5 +1,7 @@
+import RecruitmentLayout from './components/RecruitmentLayout';
+
 const Recruitment = () => {
-  return <div>모집 페이지</div>;
+  return <RecruitmentLayout />;
 };
 
 export default Recruitment;

--- a/frontend/src/pages/Recruitment/components/RecruitmentLayout.tsx
+++ b/frontend/src/pages/Recruitment/components/RecruitmentLayout.tsx
@@ -1,0 +1,18 @@
+import tw, { css, styled } from 'twin.macro';
+
+const RecruitmentLayout = () => {
+  return <Container></Container>;
+};
+
+const Container = styled.div([
+  tw`w-full mx-auto grid-cols-1 w-4/5`,
+  tw`desktop:(w-[102.4rem] grid-cols-2)`,
+  css`
+    display: grid;
+    justify-content: center;
+    align-items: center;
+    row-gap: 2rem;
+  `,
+]);
+
+export default RecruitmentLayout;

--- a/frontend/src/types/recruitment.ts
+++ b/frontend/src/types/recruitment.ts
@@ -1,0 +1,27 @@
+export interface GroupInfoCardProps {
+  writer: {
+    profileUrl: string;
+    nickName: string;
+  };
+  theme: {
+    themeUrl: string;
+    themeTitle: string;
+    zizum: string;
+    date: Date;
+    maxCount: number;
+    curCount: number;
+    isRevervation: boolean;
+    isRecruitment: boolean;
+    title: string;
+    phone: string;
+    address: string;
+    personnel: string;
+    playTime: number;
+    genre: string;
+  };
+  etc: {
+    groupId: string;
+    isEnter: boolean;
+    isLock: boolean;
+  };
+}

--- a/frontend/src/utils/getStringByDate.ts
+++ b/frontend/src/utils/getStringByDate.ts
@@ -1,0 +1,14 @@
+/**
+ * Date 객체를 받아서 yyyy년 mm월 dd일로 변환하는 함수
+ * @param date
+ * @returns yyyy년 mm월 dd일
+ */
+const getStringByDate = (inputDate: Date) => {
+  const year = inputDate.getFullYear();
+  const month = inputDate.getMonth() + 1;
+  const date = inputDate.getDate();
+
+  return `${year}년 ${month}월 ${date}일`;
+};
+
+export default getStringByDate;

--- a/frontend/tailwind.config.ts
+++ b/frontend/tailwind.config.ts
@@ -20,9 +20,9 @@ export default {
   content: ['index.html', './src/components/**/*.tsx', './src/pages/**/*.tsx'],
   theme: {
     screens: {
-      mobile: { max: '430px' },
-      // tablet: { min: '431px', max: '1023px' },
-      desktop: '431px',
+      mobile: { max: '640px' },
+      tablet: { min: '641px', max: '1023px' },
+      desktop: { min: '1024px' },
     },
     fontFamily: {
       pretendard: ['Pretendard-Regular'],


### PR DESCRIPTION
## 🤷‍♂️ Description
- 카드 컴포넌트 구성
모집 페이지에서 사용하는 컴포넌트를 구성했어요.
또, 반응형 기준에 태블릿을 추가하고 버튼 컴포넌트에 태블릿인 경우도 추가했어요.

내가 참여중인 방을 캔버스로 그리니 생각보다 안예쁘고 또, 주소와 겹칠때도 있어서 그냥 입장하기 버튼을 어둡게 하고 not-allowed 커서를 나타나게 했어요.

또, 기존에 인원을 초록색과 흰색으로 했는데 의미가 모호해서 초록색과 회색으로 했어요!
<!-- 구현 한 기능에 대해 작성해 주세요. -->

## 📝 Primary Commits

<!-- 세부 구현 사항을 리스트로 작성해주세요. -->

- [X] 모집 페이지 카드 컴포넌트
- [X] 반응형 기준 변경
- [X] 버튼에 적용

## 📷 Screenshots

- 반응형

![캡처_2023_11_27_01_38_50_711](https://github.com/boostcampwm2023/web03-LockFestival/assets/100738049/3ad797bc-e120-4532-bad2-8c8ce8c4866f)

- 카드 뒤집기 애니메이션

![녹화_2023_11_27_01_39_13_212](https://github.com/boostcampwm2023/web03-LockFestival/assets/100738049/d45725a4-a213-4b44-8796-9218bdc3d4ea)

<!--스크린샷으로 보여줄 수 있는 이미지가 있다면 첨부해주세요!-->

<!--BE의 경우 API 테스트 결과를 첨부해주세요-->

<!--마지막으로 이슈 생성 시 우측의 옵션들을 체크했는지 확인해주세요!-->

<!-- 이슈번호를 작성해주세요. -->
<!-- 여러 이슈를 입력시 comma(,) 단위로 구분해주세요 -->
<!-- ex) close #10, resolves #123 -->


<!-- ex) -->
<!-- closes #1 --> 
closes #107 
