### PR TITLE
Feature/FE/#101: 메인페이지 테마 상세정보 모달 개발

### DIFF
--- a/frontend/src/__mocks__/browser.ts
+++ b/frontend/src/__mocks__/browser.ts
@@ -1,5 +1,10 @@
 import { setupWorker } from 'msw/browser';
 import profileHandlers from './handlers/profileHandlers';
 import themesByGenreHandler from './handlers/themesByRandomHandler';
+import themeDetailsHandler from './handlers/themeDetailsHandlers';
 
-export const worker = setupWorker(...profileHandlers, ...themesByGenreHandler);
+export const worker = setupWorker(
+  ...profileHandlers,
+  ...themesByGenreHandler,
+  ...themeDetailsHandler
+);

--- a/frontend/src/__mocks__/handlers/themeDetailsHandlers.ts
+++ b/frontend/src/__mocks__/handlers/themeDetailsHandlers.ts
@@ -1,0 +1,19 @@
+import { http, HttpResponse } from 'msw';
+import { themeDetailsByThemeId } from '@__mocks__/themeDetails/themeDetailsByThemeId';
+import { SERVER_URL } from '@config/server';
+import { ThemeDetailsData } from 'types/theme';
+
+const themeDetailsHandler = [
+  http.get(SERVER_URL + '/themes/:themeId/details', (req) => {
+    const { themeId }: any = req.params;
+    const themeDetails = themeDetailsByThemeId[themeId];
+
+    if (themeDetails) {
+      return HttpResponse.json<ThemeDetailsData>(themeDetails);
+    } else {
+      return new HttpResponse('Theme not found', { status: 404 });
+    }
+  }),
+];
+
+export default themeDetailsHandler;

--- a/frontend/src/__mocks__/server.ts
+++ b/frontend/src/__mocks__/server.ts
@@ -2,5 +2,11 @@ import { setupServer } from 'msw/node';
 import profileHandlers from './handlers/profileHandlers';
 import themesByGenreHandler from './handlers/themesByRandomHandler';
 import loginHandlers from './handlers/loginHandlers';
+import themeDetailsHandler from './handlers/themeDetailsHandlers';
 
-export const server = setupServer(...profileHandlers, ...themesByGenreHandler, ...loginHandlers);
+export const server = setupServer(
+  ...profileHandlers,
+  ...themesByGenreHandler,
+  ...loginHandlers,
+  ...themeDetailsHandler
+);

--- a/frontend/src/__mocks__/themeDetails/themeDetailsByThemeId.ts
+++ b/frontend/src/__mocks__/themeDetails/themeDetailsByThemeId.ts
@@ -1,0 +1,256 @@
+import { ThemeDetailsData } from 'types/theme';
+
+export const themeDetailsByThemeId: Record<string, ThemeDetailsData> = {
+  '34': {
+    name: '머니머니패키지',
+    posterImageUrl: 'https://www.keyescape.co.kr/file/theme_info/38_a.jpg',
+    brandBranchName: '키이스케이프 강남점',
+    themeId: 34,
+    realGenre: '오락',
+    difficulty: '4.0',
+    minMember: 2,
+    maxMember: 6,
+    playTime: 50,
+    phone: '010-1234-3465',
+    address: '서울 강남구 봉은사로2길 7 지하 1층',
+    website: 'https://www.keyescape.co.kr/web/home.php',
+    otherThemes: [
+      {
+        name: 'SOUL CHASER - 실종',
+        posterImageUrl: 'https://i.postimg.cc/nLwL9k0H/theme-SOUL-CHASER.jpg',
+        themeId: 5,
+      },
+      {
+        name: 'B아파트 13동 1313호',
+        posterImageUrl:
+          'https://i.postimg.cc/B6ktkgKh/theme-Kakao-Talk-Photo-2019-03-05-17-11-51-4-B-13-1313.jpg',
+        themeId: 6,
+      },
+      {
+        name: '어제, 그리고 오늘',
+        posterImageUrl: 'https://i.postimg.cc/CxRkKmG4/theme.png',
+        themeId: 7,
+      },
+      {
+        name: '동화나라 수비대',
+        posterImageUrl: 'https://i.postimg.cc/ZYLrs9Y6/theme-80min.png',
+        themeId: 8,
+      },
+      {
+        name: '안녕하세요? 무엇을 도와드릴까요?',
+        posterImageUrl: 'https://i.postimg.cc/qRJZSPKL/theme.jpg',
+        themeId: 9,
+      },
+    ],
+  },
+  '5': {
+    name: 'SOUL CHASER - 실종',
+    posterImageUrl: 'https://i.postimg.cc/nLwL9k0H/theme-SOUL-CHASER.jpg',
+    brandBranchName: '키이스케이프 강남점',
+    themeId: 34,
+    realGenre: '오락',
+    difficulty: '4.0',
+    minMember: 2,
+    maxMember: 6,
+    playTime: 50,
+    phone: '010-1234-3465',
+    address: '서울 강남구 봉은사로2길 7 지하 1층',
+    website: 'https://www.keyescape.co.kr/web/home.php',
+    otherThemes: [
+      {
+        name: '머니머니패키지',
+        posterImageUrl: 'https://www.keyescape.co.kr/file/theme_info/38_a.jpg',
+        themeId: 34,
+      },
+      {
+        name: 'B아파트 13동 1313호',
+        posterImageUrl:
+          'https://i.postimg.cc/B6ktkgKh/theme-Kakao-Talk-Photo-2019-03-05-17-11-51-4-B-13-1313.jpg',
+        themeId: 6,
+      },
+      {
+        name: '어제, 그리고 오늘',
+        posterImageUrl: 'https://i.postimg.cc/CxRkKmG4/theme.png',
+        themeId: 7,
+      },
+      {
+        name: '동화나라 수비대',
+        posterImageUrl: 'https://i.postimg.cc/ZYLrs9Y6/theme-80min.png',
+        themeId: 8,
+      },
+      {
+        name: '안녕하세요? 무엇을 도와드릴까요?',
+        posterImageUrl: 'https://i.postimg.cc/qRJZSPKL/theme.jpg',
+        themeId: 9,
+      },
+    ],
+  },
+  '6': {
+    name: 'B아파트 13동 1313호',
+    posterImageUrl:
+      'https://i.postimg.cc/B6ktkgKh/theme-Kakao-Talk-Photo-2019-03-05-17-11-51-4-B-13-1313.jpg',
+    brandBranchName: '키이스케이프 강남점',
+    themeId: 34,
+    realGenre: '오락',
+    difficulty: '4.0',
+    minMember: 2,
+    maxMember: 6,
+    playTime: 50,
+    phone: '010-1234-3465',
+    address: '서울 강남구 봉은사로2길 7 지하 1층',
+    website: 'https://www.keyescape.co.kr/web/home.php',
+    otherThemes: [
+      {
+        name: 'SOUL CHASER - 실종',
+        posterImageUrl: 'https://i.postimg.cc/nLwL9k0H/theme-SOUL-CHASER.jpg',
+        themeId: 5,
+      },
+      {
+        name: '머니머니패키지',
+        posterImageUrl: 'https://www.keyescape.co.kr/file/theme_info/38_a.jpg',
+        themeId: 34,
+      },
+      {
+        name: '어제, 그리고 오늘',
+        posterImageUrl: 'https://i.postimg.cc/CxRkKmG4/theme.png',
+        themeId: 7,
+      },
+      {
+        name: '동화나라 수비대',
+        posterImageUrl: 'https://i.postimg.cc/ZYLrs9Y6/theme-80min.png',
+        themeId: 8,
+      },
+      {
+        name: '안녕하세요? 무엇을 도와드릴까요?',
+        posterImageUrl: 'https://i.postimg.cc/qRJZSPKL/theme.jpg',
+        themeId: 9,
+      },
+    ],
+  },
+  '7': {
+    name: '어제, 그리고 오늘',
+    posterImageUrl: 'https://i.postimg.cc/CxRkKmG4/theme.png',
+    brandBranchName: '키이스케이프 강남점',
+    themeId: 34,
+    realGenre: '오락',
+    difficulty: '4.0',
+    minMember: 2,
+    maxMember: 6,
+    playTime: 50,
+    phone: '010-1234-3465',
+    address: '서울 강남구 봉은사로2길 7 지하 1층',
+    website: 'https://www.keyescape.co.kr/web/home.php',
+    otherThemes: [
+      {
+        name: 'SOUL CHASER - 실종',
+        posterImageUrl: 'https://i.postimg.cc/nLwL9k0H/theme-SOUL-CHASER.jpg',
+        themeId: 5,
+      },
+      {
+        name: 'B아파트 13동 1313호',
+        posterImageUrl:
+          'https://i.postimg.cc/B6ktkgKh/theme-Kakao-Talk-Photo-2019-03-05-17-11-51-4-B-13-1313.jpg',
+        themeId: 6,
+      },
+      {
+        name: '머니머니패키지',
+        posterImageUrl: 'https://www.keyescape.co.kr/file/theme_info/38_a.jpg',
+        themeId: 34,
+      },
+      {
+        name: '동화나라 수비대',
+        posterImageUrl: 'https://i.postimg.cc/ZYLrs9Y6/theme-80min.png',
+        themeId: 8,
+      },
+      {
+        name: '안녕하세요? 무엇을 도와드릴까요?',
+        posterImageUrl: 'https://i.postimg.cc/qRJZSPKL/theme.jpg',
+        themeId: 9,
+      },
+    ],
+  },
+  '8': {
+    name: '동화나라 수비대',
+    posterImageUrl: 'https://i.postimg.cc/ZYLrs9Y6/theme-80min.png',
+    brandBranchName: '키이스케이프 강남점',
+    themeId: 34,
+    realGenre: '오락',
+    difficulty: '4.0',
+    minMember: 2,
+    maxMember: 6,
+    playTime: 50,
+    phone: '010-1234-3465',
+    address: '서울 강남구 봉은사로2길 7 지하 1층',
+    website: 'https://www.keyescape.co.kr/web/home.php',
+    otherThemes: [
+      {
+        name: 'SOUL CHASER - 실종',
+        posterImageUrl: 'https://i.postimg.cc/nLwL9k0H/theme-SOUL-CHASER.jpg',
+        themeId: 5,
+      },
+      {
+        name: 'B아파트 13동 1313호',
+        posterImageUrl:
+          'https://i.postimg.cc/B6ktkgKh/theme-Kakao-Talk-Photo-2019-03-05-17-11-51-4-B-13-1313.jpg',
+        themeId: 6,
+      },
+      {
+        name: '어제, 그리고 오늘',
+        posterImageUrl: 'https://i.postimg.cc/CxRkKmG4/theme.png',
+        themeId: 7,
+      },
+      {
+        name: '머니머니패키지',
+        posterImageUrl: 'https://www.keyescape.co.kr/file/theme_info/38_a.jpg',
+        themeId: 34,
+      },
+      {
+        name: '안녕하세요? 무엇을 도와드릴까요?',
+        posterImageUrl: 'https://i.postimg.cc/qRJZSPKL/theme.jpg',
+        themeId: 9,
+      },
+    ],
+  },
+  '9': {
+    name: '안녕하세요? 무엇을 도와드릴까요?',
+    posterImageUrl: 'https://i.postimg.cc/qRJZSPKL/theme.jpg',
+    brandBranchName: '키이스케이프 강남점',
+    themeId: 34,
+    realGenre: '오락',
+    difficulty: '4.0',
+    minMember: 2,
+    maxMember: 6,
+    playTime: 50,
+    phone: '010-1234-3465',
+    address: '서울 강남구 봉은사로2길 7 지하 1층',
+    website: 'https://www.keyescape.co.kr/web/home.php',
+    otherThemes: [
+      {
+        name: 'SOUL CHASER - 실종',
+        posterImageUrl: 'https://i.postimg.cc/nLwL9k0H/theme-SOUL-CHASER.jpg',
+        themeId: 5,
+      },
+      {
+        name: 'B아파트 13동 1313호',
+        posterImageUrl:
+          'https://i.postimg.cc/B6ktkgKh/theme-Kakao-Talk-Photo-2019-03-05-17-11-51-4-B-13-1313.jpg',
+        themeId: 6,
+      },
+      {
+        name: '어제, 그리고 오늘',
+        posterImageUrl: 'https://i.postimg.cc/CxRkKmG4/theme.png',
+        themeId: 7,
+      },
+      {
+        name: '동화나라 수비대',
+        posterImageUrl: 'https://i.postimg.cc/ZYLrs9Y6/theme-80min.png',
+        themeId: 8,
+      },
+      {
+        name: '머니머니패키지',
+        posterImageUrl: 'https://www.keyescape.co.kr/file/theme_info/38_a.jpg',
+        themeId: 34,
+      },
+    ],
+  },
+};

--- a/frontend/src/__tests__/Card/SimpleThemeCard/SimpleThemeCard.test.tsx
+++ b/frontend/src/__tests__/Card/SimpleThemeCard/SimpleThemeCard.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen } from '@testing-library/react';
 import SimpleThemeCard from '@components/Card/SimpleThemeCard/SimpleThemeCard';
 import { SimpleThemeCardData } from 'types/theme';
+import { RecoilRoot } from 'recoil';
 
 describe('SimpleThemeCard 컴포넌트 테스트', () => {
   const tmpProps: SimpleThemeCardData = {
@@ -10,7 +11,11 @@ describe('SimpleThemeCard 컴포넌트 테스트', () => {
   };
 
   it('컴포넌트에 넘긴 테마명이 렌더링된다.', () => {
-    render(<SimpleThemeCard {...tmpProps} />);
+    render(
+      <RecoilRoot>
+        <SimpleThemeCard {...tmpProps} />
+      </RecoilRoot>
+    );
 
     const textEl = screen.getByText('삐릿-뽀');
 
@@ -18,7 +23,11 @@ describe('SimpleThemeCard 컴포넌트 테스트', () => {
   });
 
   it('컴포넌트에 이미지가 렌더링된다.', () => {
-    render(<SimpleThemeCard {...tmpProps} />);
+    render(
+      <RecoilRoot>
+        <SimpleThemeCard {...tmpProps} />
+      </RecoilRoot>
+    );
 
     const imgEl = screen.getByRole('img');
 

--- a/frontend/src/__tests__/List/SimpleThemeCardList/SimpleThemeCardList.test.tsx
+++ b/frontend/src/__tests__/List/SimpleThemeCardList/SimpleThemeCardList.test.tsx
@@ -1,10 +1,15 @@
 import { simpleThemeCardListMock } from '@__mocks__/SimpleThemeCardList/simpleThemeCardListMock';
 import SimpleThemeCardList from '@components/List/SimpleThemeCardList/SimpleThemeCardList';
 import { render, screen } from '@testing-library/react';
+import { RecoilRoot } from 'recoil';
 
 describe('SimpleThemeCardList 컴포넌트 테스트', () => {
   it('10개의 테마를 전달하면 총 10개의 테마 이미지가 렌더링된다.', () => {
-    render(<SimpleThemeCardList themes={simpleThemeCardListMock} />);
+    render(
+      <RecoilRoot>
+        <SimpleThemeCardList themes={simpleThemeCardListMock} />
+      </RecoilRoot>
+    );
     const NUMBER_OF_IMGS = simpleThemeCardListMock.length;
 
     const imgElements = screen.getAllByRole('img');

--- a/frontend/src/apis/fetchThemeDetails.ts
+++ b/frontend/src/apis/fetchThemeDetails.ts
@@ -1,0 +1,14 @@
+import axios from 'axios';
+import { SERVER_URL } from '@config/server';
+import { ThemeDetailsData } from 'types/theme';
+
+const fetchThemeDetails = async (themeId: number): Promise<ThemeDetailsData> => {
+  return (
+    await axios({
+      method: 'get',
+      url: SERVER_URL + `/themes/${themeId}/details`,
+    })
+  ).data;
+};
+
+export default fetchThemeDetails;

--- a/frontend/src/components/Button/Button.tsx
+++ b/frontend/src/components/Button/Button.tsx
@@ -29,6 +29,9 @@ rounded-default bg-gray-light text-white
         cursor: default;
         opacity: 60%;
       }
+      svg {
+        pointer-events: none;
+      }
     `,
   ];
 

--- a/frontend/src/components/Card/SimpleThemeCard/SimpleThemeCard.tsx
+++ b/frontend/src/components/Card/SimpleThemeCard/SimpleThemeCard.tsx
@@ -1,10 +1,24 @@
 import tw, { css, styled } from 'twin.macro';
 import { SimpleThemeCardData } from 'types/theme';
+import Modal from '@components/Modal/Modal';
+import useModal from '@hooks/useModal';
+import ThemeDetailsModal from '@components/ThemeDetailsModal/ThemeDetailsModal';
 
 const SimpleThemeCard = ({ themeId, name, posterImageUrl }: SimpleThemeCardData) => {
+  const { openModal, closeModal } = useModal();
+
   return (
-    <CardContainer key={themeId}>
-      <CardImg alt="테마사진" src={posterImageUrl} />
+    <CardContainer
+      key={themeId}
+      onClick={() => {
+        openModal(Modal, {
+          children: <ThemeDetailsModal themeId={themeId} onClose={() => closeModal(Modal)} />,
+          onClose: () => closeModal(Modal),
+          closeOnExternalClick: true,
+        });
+      }}
+    >
+      <CardImg id={themeId.toString()} alt="테마사진" src={posterImageUrl} />
       <CardText>{name}</CardText>
     </CardContainer>
   );
@@ -19,6 +33,7 @@ const CardContainer = styled.div([
     align-items: center;
     justify-content: center;
     flex-direction: column;
+    cursor: pointer;
   `,
 ]);
 

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -1,11 +1,14 @@
 import tw, { styled } from 'twin.macro';
 import Header from './Header/Header';
 import { Outlet } from 'react-router-dom';
+import Modals from './Modals/Modals';
+
 const Layout = () => {
   return (
     <Container>
       <Header />
       <Main>
+        <Modals />
         <Outlet />
       </Main>
     </Container>

--- a/frontend/src/components/ThemeDetailsModal/ThemeDetailsModal.tsx
+++ b/frontend/src/components/ThemeDetailsModal/ThemeDetailsModal.tsx
@@ -1,0 +1,172 @@
+import { ModalProps } from 'types/modal';
+import tw, { css, styled } from 'twin.macro';
+import Button from '@components/Button/Button';
+import { FaXmark } from 'react-icons/fa6';
+import { ThemeInfoItem } from './components/ThemeInfoItem';
+import { useNavigate } from 'react-router-dom';
+import useThemeDetailsQuery from './useThemeDetailsQuery';
+import ThemeCard from './components/ThemeCard';
+
+interface ThemeDetailsModalProps {
+  themeId: number;
+  onClose: ModalProps['onClose'];
+}
+
+function ThemeDetailsModal({ themeId, onClose }: ThemeDetailsModalProps) {
+  const { data, isError, isLoading } = useThemeDetailsQuery(themeId);
+  const navigate = useNavigate();
+
+  if (isError) {
+    return <DetailModalContainer>해당 테마의 상세정보가 없습니다.</DetailModalContainer>;
+  }
+
+  return (
+    <>
+      {isLoading ? (
+        <div>로딩중</div>
+      ) : (
+        data && (
+          <DetailModalContainer>
+            <HeadWrapper>
+              <div>{data.name}</div>
+              <Button isIcon={true} onClick={onClose}>
+                <>
+                  <FaXmark />
+                </>
+              </Button>
+            </HeadWrapper>
+            <MainWrapper>
+              <MainThemePosterBox>
+                <ThemePoster src={data.posterImageUrl} alt="포스터_이미지"></ThemePoster>
+              </MainThemePosterBox>
+              <InfoWrapper>
+                {ThemeInfoItem('지점', data.brandBranchName)}
+                {ThemeInfoItem('장르', data.realGenre)}
+                {ThemeInfoItem('난이도', data.difficulty)}
+                {ThemeInfoItem('인원', `${data.minMember}-${data.maxMember}`)}
+                {ThemeInfoItem('플레이타임', `${data.playTime}분`)}
+                {ThemeInfoItem('전화번호', data.phone)}
+                {ThemeInfoItem('주소', data.address)}
+              </InfoWrapper>
+              <ButtonWrapper>
+                <Button
+                  isIcon={false}
+                  size="m"
+                  onClick={() => {
+                    window.open(data.website);
+                  }}
+                >
+                  <>예약바로가기</>
+                </Button>
+                <Button
+                  isIcon={false}
+                  size="m"
+                  onClick={() => {
+                    onClose();
+                    navigate('/recruitment');
+                  }}
+                >
+                  <>모집바로가기</>
+                </Button>
+              </ButtonWrapper>
+            </MainWrapper>
+            <BottomWrapper>
+              <HeadWrapper>{data.brandBranchName}의 다른 테마</HeadWrapper>
+              <OtherThemeList>
+                {data.otherThemes.map((theme) => {
+                  const { themeId, posterImageUrl, name } = theme;
+                  return (
+                    <ThemeCard
+                      themeId={themeId}
+                      posterImageUrl={posterImageUrl}
+                      name={name}
+                      onClose={onClose}
+                    />
+                  );
+                })}
+              </OtherThemeList>
+            </BottomWrapper>
+          </DetailModalContainer>
+        )
+      )}
+    </>
+  );
+}
+
+export default ThemeDetailsModal;
+
+const DetailModalContainer = styled.div([
+  css`
+    display: flex;
+    flex-direction: column;
+  `,
+  tw`p-4 bg-gray-light rounded-default`,
+]);
+
+const HeadWrapper = styled.div([
+  css`
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    height: 1.8rem;
+  `,
+  tw`font-maplestory text-xl-bold mb-2 ml-2`,
+]);
+
+const MainWrapper = styled.div([
+  css`
+    display: flex;
+    justify-content: flex-start;
+    margin-bottom: 1.6rem;
+  `,
+]);
+
+const MainThemePosterBox = styled.div([
+  tw`bg-gray-dark rounded-[2rem]`,
+  css`
+    width: 18.5rem;
+    height: 27.2rem;
+    padding: 1.6rem;
+  `,
+]);
+
+const ThemePoster = styled.img([
+  css`
+    width: 100%;
+    height: 100%;
+  `,
+  tw`rounded-[2rem]`,
+]);
+
+const InfoWrapper = styled.div([
+  css`
+    display: flex;
+    flex-direction: column;
+    gap: 0.8rem;
+  `,
+  tw`ml-4`,
+]);
+
+const ButtonWrapper = styled.div([
+  css`
+    display: flex;
+    flex-direction: column;
+    justify-content: flex-end;
+    gap: 0.8rem;
+  `,
+  tw`ml-4`,
+]);
+
+const BottomWrapper = styled.div([
+  css`
+    display: flex;
+    flex-direction: column;
+  `,
+]);
+
+const OtherThemeList = styled.div([
+  css`
+    display: flex;
+    justify-content: space-between;
+  `,
+]);

--- a/frontend/src/components/ThemeDetailsModal/ThemeDetailsModal.tsx
+++ b/frontend/src/components/ThemeDetailsModal/ThemeDetailsModal.tsx
@@ -17,7 +17,16 @@ function ThemeDetailsModal({ themeId, onClose }: ThemeDetailsModalProps) {
   const navigate = useNavigate();
 
   if (isError) {
-    return <DetailModalContainer>해당 테마의 상세정보가 없습니다.</DetailModalContainer>;
+    return (
+      <ErrorContainer>
+        해당 테마의 상세정보가 없습니다.
+        <Button isIcon={true} onClick={onClose}>
+          <>
+            <FaXmark />
+          </>
+        </Button>
+      </ErrorContainer>
+    );
   }
 
   return (
@@ -94,6 +103,18 @@ function ThemeDetailsModal({ themeId, onClose }: ThemeDetailsModalProps) {
 }
 
 export default ThemeDetailsModal;
+
+const ErrorContainer = styled.div([
+  css`
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    height: 38rem;
+    align-items: center;
+    gap: 3.6rem;
+  `,
+  tw`font-pretendard text-l`,
+]);
 
 const DetailModalContainer = styled.div([
   css`

--- a/frontend/src/components/ThemeDetailsModal/components/ThemeCard.tsx
+++ b/frontend/src/components/ThemeDetailsModal/components/ThemeCard.tsx
@@ -1,0 +1,60 @@
+import tw, { styled, css } from 'twin.macro';
+import { ModalProps } from 'types/modal';
+import Modal from '@components/Modal/Modal';
+import useModal from '@hooks/useModal';
+import ThemeDetailsModal from '../ThemeDetailsModal';
+
+interface ThemeCardProps {
+  themeId: number;
+  posterImageUrl: string;
+  name: string;
+  onClose: ModalProps['onClose'];
+}
+
+const ThemeCard = ({ themeId, posterImageUrl, name, onClose }: ThemeCardProps) => {
+  const { openModal, closeModal } = useModal();
+  return (
+    <ThemeCardBox
+      key={themeId}
+      onClick={() => {
+        onClose();
+        setTimeout(() => {
+          openModal(Modal, {
+            children: <ThemeDetailsModal themeId={themeId} onClose={() => closeModal(Modal)} />,
+            onClose: () => closeModal(Modal),
+            closeOnExternalClick: true,
+          });
+        }, 100);
+      }}
+    >
+      <img src={posterImageUrl} alt="추천_테마_포스터_이미지" />
+      <div>{name}</div>
+    </ThemeCardBox>
+  );
+};
+
+export default ThemeCard;
+
+const ThemeCardBox = styled.div([
+  css`
+    display: flex;
+    flex-direction: column;
+    gap: 1.2rem;
+    justify-content: space-between;
+    align-items: center;
+    width: 11rem;
+    height: 16rem;
+    padding: 1.2rem;
+    text-align: center;
+    cursor: pointer;
+
+    img {
+      width: 7.8rem;
+      height: 13.6rem;
+      border-radius: 2rem;
+    }
+  `,
+  tw`
+    bg-gray-dark rounded-[2rem] font-pretendard text-s
+  `,
+]);

--- a/frontend/src/components/ThemeDetailsModal/components/ThemeInfoItem.tsx
+++ b/frontend/src/components/ThemeDetailsModal/components/ThemeInfoItem.tsx
@@ -1,0 +1,31 @@
+import Label from '@components/Label/Label';
+import tw, { styled, css } from 'twin.macro';
+
+export const ThemeInfoItem = (labelName: string, infoContent: string) => {
+  return (
+    <InfoItem>
+      <Label isBorder={true} size="m-bold" width="10rem">
+        <FlexCenter>{labelName}</FlexCenter>
+      </Label>
+      <InfoContent>{infoContent}</InfoContent>
+    </InfoItem>
+  );
+};
+
+const FlexCenter = styled.div([
+  css`
+    display: flex;
+    width: 100%;
+    justify-content: center;
+  `,
+]);
+
+const InfoItem = styled.div([
+  css`
+    display: flex;
+    align-items: center;
+    gap: 1.6rem;
+  `,
+]);
+
+const InfoContent = styled.div([tw`font-pretendard text-l`]);

--- a/frontend/src/components/ThemeDetailsModal/useThemeDetailsQuery.tsx
+++ b/frontend/src/components/ThemeDetailsModal/useThemeDetailsQuery.tsx
@@ -1,0 +1,15 @@
+import { useQuery } from '@tanstack/react-query';
+import fetchThemeDetails from '@apis/fetchThemeDetails';
+import { ThemeDetailsData } from 'types/theme';
+
+const useThemeDetailsQuery = (themeId: number) => {
+  const { data, isSuccess, isError, isLoading } = useQuery<ThemeDetailsData>({
+    queryKey: ['themeDetails'],
+    queryFn: () => fetchThemeDetails(themeId),
+    retry: false,
+  });
+
+  return { data, isSuccess, isError, isLoading };
+};
+
+export default useThemeDetailsQuery;

--- a/frontend/src/components/ThemeDetailsModal/useThemeDetailsQuery.tsx
+++ b/frontend/src/components/ThemeDetailsModal/useThemeDetailsQuery.tsx
@@ -1,11 +1,11 @@
 import { useQuery } from '@tanstack/react-query';
-import fetchThemeDetails from '@apis/fetchThemeDetails';
 import { ThemeDetailsData } from 'types/theme';
+import QUERY_MANAGEMENT from '@constants/queryManagement';
 
 const useThemeDetailsQuery = (themeId: number) => {
   const { data, isSuccess, isError, isLoading } = useQuery<ThemeDetailsData>({
-    queryKey: ['themeDetails'],
-    queryFn: () => fetchThemeDetails(themeId),
+    queryKey: QUERY_MANAGEMENT['themeDetails'].key,
+    queryFn: () => QUERY_MANAGEMENT['themeDetails'].fn(themeId),
     retry: false,
   });
 

--- a/frontend/src/constants/queryManagement.ts
+++ b/frontend/src/constants/queryManagement.ts
@@ -1,5 +1,6 @@
 import fetchThemesByLocation from '@apis/fetchThemesByLocation';
 import fetchThemesByRandomGenres from '@apis/fetchThemesByRandomGenres';
+import fetchThemeDetails from '@apis/fetchThemeDetails';
 
 const QUERY_MANAGEMENT = {
   geolocation: {
@@ -9,6 +10,10 @@ const QUERY_MANAGEMENT = {
   randomThemes: {
     key: 'randomThemes',
     fn: fetchThemesByRandomGenres,
+  },
+  themeDetails: {
+    key: ['themeDetails'],
+    fn: (themeId: number) => fetchThemeDetails(themeId),
   },
 };
 

--- a/frontend/src/constants/themeGenres.ts
+++ b/frontend/src/constants/themeGenres.ts
@@ -4,8 +4,7 @@ export const themeGenres = ['공포', '코믹', '감성'];
 export const genreList = [
   {
     genre: '공포',
-    thumbnail:
-      'https://www.master-key.co.kr/upload/room/197_img1.gif',
+    thumbnail: 'https://www.master-key.co.kr/upload/room/197_img1.gif',
   },
   {
     genre: '코믹',
@@ -17,8 +16,7 @@ export const genreList = [
   },
   {
     genre: '판타지',
-    thumbnail:
-      'https://www.master-key.co.kr/upload/room/198_img1.gif',
+    thumbnail: 'https://www.master-key.co.kr/upload/room/198_img1.gif',
   },
   {
     genre: '드라마',

--- a/frontend/src/hooks/useModal.tsx
+++ b/frontend/src/hooks/useModal.tsx
@@ -1,29 +1,22 @@
 import { useRecoilState, atom } from 'recoil';
 import { ModalProps } from 'types/modal';
 import { FunctionComponent } from 'react';
-
 interface Modal {
   Component: FunctionComponent<ModalProps>;
   props: ModalProps;
 }
-
 const modalAtom = atom<Array<Modal>>({ key: 'modalList', default: [] });
-
 const useModal = () => {
   const [modals, setModals] = useRecoilState(modalAtom);
-
   const openModal = (
     Component: FunctionComponent<ModalProps>,
     props: Omit<ModalProps, 'isOpen'>
   ) => {
-    setModals([...modals, { Component, props: { ...props, isOpen: true } }]);
+    setModals((prev) => [...prev, { Component, props: { ...props, isOpen: true } }]);
   };
-
   const closeModal = (Component: FunctionComponent<ModalProps>) => {
-    setModals(modals.filter((modal) => modal.Component !== Component));
+    setModals((prev) => prev.filter((modal) => modal.Component !== Component));
   };
-
   return { modals, openModal, closeModal };
 };
-
 export default useModal;

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -6,7 +6,6 @@ import GlobalStyle from './styles/GlobalStyles.tsx';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import { RecoilRoot } from 'recoil';
-import Modals from '@components/Modals/Modals.tsx';
 
 async function deferRender() {
   if (!import.meta.env.DEV) {
@@ -25,7 +24,6 @@ deferRender().then(() => {
         <QueryClientProvider client={queryClient}>
           <ReactQueryDevtools initialIsOpen={false} />
           <GlobalStyle />
-          <Modals />
           <App />
         </QueryClientProvider>
       </RecoilRoot>

--- a/frontend/src/types/theme.ts
+++ b/frontend/src/types/theme.ts
@@ -3,3 +3,16 @@ export interface SimpleThemeCardData {
   name: string;
   posterImageUrl: string;
 }
+
+export interface ThemeDetailsData extends SimpleThemeCardData {
+  brandBranchName: string;
+  realGenre: string;
+  difficulty: string;
+  minMember: number;
+  maxMember: number;
+  playTime: number;
+  phone: string;
+  address: string;
+  website: string;
+  otherThemes: SimpleThemeCardData[];
+}

--- a/frontend/tailwind.config.ts
+++ b/frontend/tailwind.config.ts
@@ -81,6 +81,19 @@ export default {
           fontWeight: 900,
         },
       ],
+      'xl': [
+        '1.8rem',
+        {
+          lineHeight: '1.8rem',
+        },
+      ],
+      'xl-bold': [
+        '1.8rem',
+        {
+          lineHeight: '1.8rem',
+          fontWeight: 900,
+        },
+      ],
     },
     spacing: spacingObject,
     extend: {


### PR DESCRIPTION
## 🤷‍♂️ Description
테마 상세정보 모달을 개발했어요.

<!-- 구현 한 기능에 대해 작성해 주세요. -->
1. 메인 페이지에서 테마 카드를 클릭하면, 해당 테마의 상세 정보 모달이 나타나요.
2. 상세 정보 모달에서 같은 지점의 추천 테마 카드를 클릭하면 현재 모달이 닫히고, 클릭한 테마의 상세정보 모달이 나타나요.

- 아직 반응형은 고려안되어있습니다.
## 📝 Primary Commits

<!-- 세부 구현 사항을 리스트로 작성해주세요. -->

- [X] 상세정보 Mock API 개발
- [X] 상세정보 모달 개발

## 📷 Screenshots
1. 테마 상세정보가 없는경우

https://github.com/boostcampwm2023/web03-LockFestival/assets/82202370/fd1dc667-0641-4f53-b2bb-1fb81e7b0c37

2. 정상적으로 동작하는 경우
- 현재 목데이터에서 엔제리오 테마만 적용

https://github.com/boostcampwm2023/web03-LockFestival/assets/82202370/93f989d1-c96e-4ab4-955e-b4cfabae8498


<!--스크린샷으로 보여줄 수 있는 이미지가 있다면 첨부해주세요!-->

<!--BE의 경우 API 테스트 결과를 첨부해주세요-->

<!--마지막으로 이슈 생성 시 우측의 옵션들을 체크했는지 확인해주세요!-->

<!-- 이슈번호를 작성해주세요. -->
<!-- 여러 이슈를 입력시 comma(,) 단위로 구분해주세요 -->
<!-- ex) close #10, resolves #123 -->


<!-- ex) -->
<!-- closes #1 --> 
closes #101
