### PR TITLE
Feature/BE/#139: 검색 시 심플 테마 반환 API

### DIFF
--- a/backend/src/modules/themeModules/theme/dtos/genre.dto.ts
+++ b/backend/src/modules/themeModules/theme/dtos/genre.dto.ts
@@ -2,17 +2,17 @@ import { ApiProperty } from '@nestjs/swagger';
 
 export class GenreDto {
   @ApiProperty({
-    name: 'name',
+    name: 'genreName',
     description: '장르 이름',
     example: '공포',
     examples: ['공포', '코믹', 'SF', '판타지', '드라마', '로맨스', '스릴러', '추리'],
   })
-  name: string;
+  genreName: string;
   @ApiProperty({
-    name: 'id',
+    name: 'genreId',
     description: '분류용 장르 id',
     example: 1,
     examples: [1, 2, 3, 4, 5, 6, 7, 8],
   })
-  id: number;
+  genreId: number;
 }

--- a/backend/src/modules/themeModules/theme/dtos/genre.themes.response.dto.ts
+++ b/backend/src/modules/themeModules/theme/dtos/genre.themes.response.dto.ts
@@ -3,7 +3,7 @@ import { ThemeResponseDto } from '@theme/dtos/theme.response.dto';
 
 export class GenreThemesResponseDto {
   @ApiProperty({ example: '공포' })
-  genre: string;
+  genreName: string;
   @ApiProperty({ type: [ThemeResponseDto] })
   themes: ThemeResponseDto[];
 }

--- a/backend/src/modules/themeModules/theme/dtos/theme.simple.search.response.dto.ts
+++ b/backend/src/modules/themeModules/theme/dtos/theme.simple.search.response.dto.ts
@@ -1,0 +1,7 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { ThemeResponseDto } from '@theme/dtos/theme.response.dto';
+
+export class ThemeSimpleSearchResponseDto extends ThemeResponseDto {
+  @ApiProperty({ name: 'branchName', description: '지점명', example: '강남점' })
+  branchName: string;
+}

--- a/backend/src/modules/themeModules/theme/genre.repository.ts
+++ b/backend/src/modules/themeModules/theme/genre.repository.ts
@@ -15,15 +15,15 @@ export class GenreRepository extends Repository<Genre> {
       .limit(count)
       .getMany();
     return genres.map(({ id, name }) => {
-      return { id, name };
+      return { genreId: id, genreName: name };
     });
   }
 
   async getAllGenres(): Promise<GenreDto[]> {
     const genreDtos: GenreDto[] = await this.dataSource
       .createQueryBuilder()
-      .select('genre.id', 'id')
-      .addSelect('genre.name', 'name')
+      .select('genre.id', 'genreId')
+      .addSelect('genre.name', 'genreName')
       .from(Genre, 'genre')
       .orderBy('genre.id')
       .getRawMany();

--- a/backend/src/modules/themeModules/theme/theme.controller.ts
+++ b/backend/src/modules/themeModules/theme/theme.controller.ts
@@ -1,4 +1,5 @@
 import { Controller, DefaultValuePipe, Get, Param, ParseIntPipe, Query } from '@nestjs/common';
+import { ApiOkResponse, ApiOperation, ApiParam, ApiQuery, ApiTags } from '@nestjs/swagger';
 import { ThemeService } from '@theme/theme.service';
 import { GenreThemesResponseDto } from '@theme/dtos/genre.themes.response.dto';
 import { ThemeResponseDto } from '@theme/dtos/theme.response.dto';
@@ -6,7 +7,7 @@ import { ThemeLocationDto } from '@theme/dtos/theme.location.dto';
 import { ThemeDeatailsResponseDto } from '@theme/dtos/theme.detail.response.dto';
 import { GenreService } from '@theme/genre.service';
 import { GenreDto } from '@theme/dtos/genre.dto';
-import { ApiOkResponse, ApiOperation, ApiParam, ApiQuery, ApiTags } from '@nestjs/swagger';
+import { ThemeSimpleSearchResponseDto } from '@theme/dtos/theme.simple.search.response.dto';
 
 const DEFAULT_THEME_COUNT = 10;
 
@@ -117,5 +118,24 @@ export class ThemeController {
   })
   async getGenres(): Promise<GenreDto[]> {
     return await this.genreService.getAllGenres();
+  }
+
+  @Get('/simple-themes')
+  @ApiOperation({
+    summary: '검색 리스트 반환',
+    description: '모집글 생성 시 검색한 테마 리스트를 10개 반환합니다',
+  })
+  @ApiQuery({
+    description: `검색어`,
+    name: 'query',
+    required: true,
+  })
+  @ApiOkResponse({
+    status: 200,
+    description: '',
+    type: [ThemeSimpleSearchResponseDto],
+  })
+  async getSimpleThemes(@Query('query') query: string): Promise<ThemeSimpleSearchResponseDto[]> {
+    return await this.themeService.getSimpleThemesBySearch(query);
   }
 }

--- a/backend/src/modules/themeModules/theme/theme.repository.ts
+++ b/backend/src/modules/themeModules/theme/theme.repository.ts
@@ -19,7 +19,7 @@ export class ThemeRepository extends Repository<Theme> {
     const themeDetailsResponseDto: ThemeDeatailsResponseDto = await this.dataSource
       .createQueryBuilder()
       .select([
-        'theme.name as name',
+        'theme.name as themeName',
         'theme.id as themeId',
         'theme.real_genre as realGenre',
         'theme.poster_image_url as posterImageUrl',
@@ -45,7 +45,7 @@ export class ThemeRepository extends Repository<Theme> {
       .createQueryBuilder()
       .select([
         'theme.id as themeId',
-        'theme.name as name',
+        'theme.name as themeName',
         'theme.poster_image_url as posterImageUrl',
       ])
       .from(Theme, 'theme')
@@ -62,7 +62,7 @@ export class ThemeRepository extends Repository<Theme> {
       .createQueryBuilder()
       .select([
         'theme.id as themeId',
-        'theme.name as name',
+        'theme.name as themeName',
         'theme.poster_image_url as posterImageUrl',
       ])
       .from(Theme, 'theme')
@@ -83,7 +83,7 @@ export class ThemeRepository extends Repository<Theme> {
       .createQueryBuilder()
       .select([
         'theme.id as themeId',
-        'theme.name as name',
+        'theme.name as themeName',
         'theme.poster_image_url as posterImageUrl',
       ])
       .from(Theme, 'theme')
@@ -99,7 +99,7 @@ export class ThemeRepository extends Repository<Theme> {
       .createQueryBuilder()
       .select([
         'theme.id as themeId',
-        'theme.name as name',
+        'theme.name as themeName',
         'theme.poster_image_url as posterImageUrl',
       ])
       .from(Theme, 'theme')
@@ -114,7 +114,7 @@ export class ThemeRepository extends Repository<Theme> {
       .createQueryBuilder()
       .select([
         'theme.id as themeId',
-        'theme.name as name',
+        'theme.name as themeName',
         'theme.poster_image_url as posterImageUrl',
       ])
       .from(Theme, 'theme')
@@ -133,7 +133,7 @@ export class ThemeRepository extends Repository<Theme> {
       .createQueryBuilder()
       .select([
         'theme.id as themeId',
-        'theme.name as name',
+        'theme.name as themeName',
         'theme.poster_image_url as posterImageUrl',
         'branch.branch_name as BranchName',
       ])

--- a/backend/src/modules/themeModules/theme/theme.service.ts
+++ b/backend/src/modules/themeModules/theme/theme.service.ts
@@ -39,10 +39,10 @@ export class ThemeService {
     return await Promise.all(
       genreDtos.map(async (genreDto: GenreDto): Promise<GenreThemesResponseDto> => {
         const themeDtos = await this.themeRepository.getRandomThemesByGenre(
-          genreDto.id,
+          genreDto.genreId,
           themeCount
         );
-        return { genre: genreDto.name, themes: themeDtos };
+        return { genreName: genreDto.genreName, themes: themeDtos };
       })
     );
   }

--- a/backend/src/modules/themeModules/theme/theme.service.ts
+++ b/backend/src/modules/themeModules/theme/theme.service.ts
@@ -7,6 +7,7 @@ import { ThemeResponseDto } from '@theme/dtos/theme.response.dto';
 import { GenreThemesResponseDto } from '@theme/dtos/genre.themes.response.dto';
 import { ThemeLocationDto } from '@theme/dtos/theme.location.dto';
 import { ThemeDeatailsResponseDto } from '@theme/dtos/theme.detail.response.dto';
+import { ThemeSimpleSearchResponseDto } from '@theme/dtos/theme.simple.search.response.dto';
 
 @Injectable()
 export class ThemeService {
@@ -51,5 +52,8 @@ export class ThemeService {
 
   public async getGenreThemes(genreId: number, count: number): Promise<Array<ThemeResponseDto>> {
     return await this.themeRepository.getThemesByGenre(genreId, count);
+  }
+  public async getSimpleThemesBySearch(query: string): Promise<ThemeSimpleSearchResponseDto[]> {
+    return await this.themeRepository.getSimpleThemesBySearch(query);
   }
 }


### PR DESCRIPTION
## 🤷‍♂️ Description
- 모집글을 생성할 때 테마 선택시 검색하는 기능을 만들었어요

### request
```http
GET /api/v1/themes/simple-themes?query={검색어}
```
### response

```
[
    {
        "themeId": 62,
        "themeName": "그카지말라캤자나",
        "posterImageUrl": "https://www.keyescape.co.kr/file/theme_info/7_a.jpg",
        "BranchName": "강남점"
    },
    ....
]
```
#### 해당하는 테마가 없을 때는 빈 배열을 리턴해요
```
[]
```
## 📝 Primary Commits
- ThemeResponseDto를 상속받아 branchName을 추가한 dto를 만들었어요
```typescript
export class ThemeSimpleSearchResponseDto extends ThemeResponseDto {
  @ApiProperty({ name: 'branchName', description: '지점명', example: '강남점' })
  branchName: string;
}

```
- query에 전달되는 단어를 검색해 테마 10개를 가져왔어요 
  - 정렬에 우선순위를 둬 최대한 연관있는 단어 순으로 보이게 했어요 
  - 검색어랑 같은 이름, 검색어로 시작하는 이름,검색어를 포함한 이름,검색어로 끝나는 이름 순으로 우선순위를 두었어요.
```typescript
      .where('theme.name LIKE :themeName', { themeName: `%${query}%` })
      .orderBy(
        `CASE WHEN theme.name = :exactQuery THEN 0 
      WHEN theme.name LIKE :startWithQuery THEN 1 
      WHEN theme.name LIKE :containsQuery THEN 2 
      WHEN theme.name LIKE :endsWithQuery THEN 3 
    END`,
        'ASC'
      )
      .setParameters({
        exactQuery: query,
        startWithQuery: `${query}%`,
        containsQuery: `%${query}%`,
        endsWithQuery: `%${query}`,
      })
  
```

## 📷 Screenshots
```http
GET /api/v1/themes/simple-themes?query=도시
```
### response
![image](https://github.com/boostcampwm2023/web03-LockFestival/assets/101504594/31d8a485-7d74-47e7-a87e-db64cf5256b6)

closes #139 

