### PR TITLE
Refactor/BE/#157: 쿼리 상수 파일 생성 

### DIFF
--- a/backend/src/config/constants/query.ts
+++ b/backend/src/config/constants/query.ts
@@ -1,0 +1,35 @@
+export const SELECT = {
+  THEME_DETAIL: [
+    'theme.name as themeName',
+    'theme.id as themeId',
+    'theme.real_genre as realGenre',
+    'theme.poster_image_url as posterImageUrl',
+    'theme.difficulty as difficulty',
+    'theme.min_member as minMember',
+    'theme.max_member as maxMember',
+    'theme.time_limit as playTime',
+    'branch.website as website',
+    'branch.phone_number as phone',
+    'branch.address as address',
+    "CONCAT(branch.branch_name, ' ', brand.brand_name) AS brandBranchName",
+  ],
+  SIMPLE_THEME_BY_THEME_ID: [
+    'theme.id as themeId',
+    'theme.name as themeName',
+    'theme.poster_image_url as posterImageUrl',
+  ],
+  THEME_BY_THEME_ID: [
+    'theme.id as themeId',
+    'theme.name as themeName',
+    'theme.poster_image_url as posterImageUrl',
+    'branch.branch_name as BranchName',
+  ],
+};
+
+export const ORDER_BY = {
+  QUERY: `CASE WHEN theme.name = :exactQuery THEN 0 
+      WHEN theme.name LIKE :startWithQuery THEN 1 
+      WHEN theme.name LIKE :containsQuery THEN 2 
+      WHEN theme.name LIKE :endsWithQuery THEN 3 
+    END`,
+};


### PR DESCRIPTION

## 🤷‍♂️ Description
- 중복 되는 쿼리가 많아 상수로 관리할게요 

<!-- 구현 한 기능에 대해 작성해 주세요. -->

## 📝 Primary Commits

<!-- 세부 구현 사항을 리스트로 작성해주세요. -->
- src/config/constants/query.ts 을 만들었어요
- `@config/constants/query` 로 alias를 사용할 수 있어요 
```typescript
export const SELECT = {
  THEME_DETAIL: []
}
```
```typescript
export const THEME = {
  SELECT_DETAIL: []
}
```
- 상수 객체 명을 쿼리명령어로 할지 모듈 단위로 할지 고민했어요 
- 현재는 `theme.repository` 만 수정했어요. 개발 진행하면서 수정할 예정이에요
<!-- ex) -->
 closes #157

