### PR TITLE
Feature/BE/#175: 그룹/채팅방 입장 API 개발

### DIFF
--- a/backend/src/modules/userModules/group/entities/group.entity.ts
+++ b/backend/src/modules/userModules/group/entities/group.entity.ts
@@ -78,14 +78,4 @@ export class Group extends BaseTime {
       leader_id: user.id,
     };
   }
-
-  static createUserGroupObject(newGroup, user: User) {
-    return {
-      group: newGroup,
-      user_id: user.id,
-      group_id: newGroup.id,
-      user: user,
-      hasWrittenComment: false,
-    };
-  }
 }

--- a/backend/src/modules/userModules/group/group.controller.ts
+++ b/backend/src/modules/userModules/group/group.controller.ts
@@ -2,12 +2,14 @@ import {
   Body,
   Controller,
   Get,
+  HttpStatus,
+  Param,
+  ParseIntPipe,
   Post,
+  Query,
   Req,
   Res,
   UseGuards,
-  HttpStatus,
-  Query,
 } from '@nestjs/common';
 import {
   ApiBearerAuth,
@@ -15,6 +17,7 @@ import {
   ApiInternalServerErrorResponse,
   ApiOkResponse,
   ApiOperation,
+  ApiParam,
   ApiTags,
 } from '@nestjs/swagger';
 import { OptionalGuard } from '@src/utils/decorator';
@@ -75,5 +78,29 @@ export class GroupController {
     @Query() findOptions: GroupFindOptionsDto
   ): Promise<GroupsResponseDto> {
     return await this.groupService.getAllGroups(user?.nickname, findOptions);
+  }
+
+  @Post(`:groupId/enter`)
+  @UseGuards(TokenAuthGuard)
+  @ApiOperation({
+    summary: '그룹에 해당 유저 추가',
+    description: '그룹에 로그인한 현재 유저를 추가하고 채팅방에 추가해줍니다.',
+  })
+  @ApiParam({
+    name: 'groupId',
+    description: '입장하고자하는 그룹의 groupId',
+  })
+  @ApiOkResponse({
+    type: Boolean,
+  })
+  @ApiBearerAuth('Authorization')
+  async enterGroup(
+    @Req() { user },
+    @Param('groupId', ParseIntPipe)
+    groupId: number,
+    @Res() res
+  ): Promise<boolean> {
+    await this.groupService.enterGroup(user.nickname, groupId);
+    return res.status(HttpStatus.OK).json({ success: true, message: 'Group created successfully' });
   }
 }

--- a/backend/src/modules/userModules/group/group.repository.ts
+++ b/backend/src/modules/userModules/group/group.repository.ts
@@ -23,7 +23,7 @@ export class GroupRepository extends Repository<Group> {
         Group,
         Group.createGroupObject(groupRequest, user, theme)
       );
-      await queryRunner.manager.save(UserGroup, Group.createUserGroupObject(newGroup, user));
+      await queryRunner.manager.save(UserGroup, UserGroup.createUserGroupObject(newGroup, user));
       await queryRunner.commitTransaction();
     } catch (err) {
       await queryRunner.rollbackTransaction();

--- a/backend/src/modules/userModules/group/group.repository.ts
+++ b/backend/src/modules/userModules/group/group.repository.ts
@@ -118,7 +118,7 @@ export class GroupRepository extends Repository<Group> {
     const queryRunner = this.dataSource.createQueryRunner();
     try {
       await queryRunner.startTransaction();
-      // group의 count 검증 증가
+
       const group: Group = await queryRunner.manager.findOneBy(Group, { id: groupId });
 
       if (!group) {

--- a/backend/src/modules/userModules/group/group.repository.ts
+++ b/backend/src/modules/userModules/group/group.repository.ts
@@ -125,6 +125,16 @@ export class GroupRepository extends Repository<Group> {
         throw new HttpException('해당 그룹은 존재하지 않습니다', HttpStatus.BAD_REQUEST);
       }
 
+      if (
+        await queryRunner.manager
+          .createQueryBuilder(UserGroup, 'userGroup')
+          .where('user_id = :userId', { userId: user.id })
+          .andWhere('group_id = :groupId', { groupId: group.id })
+          .getExists()
+      ) {
+        throw new HttpException('이미 해당 그룹의 소속되어 있습니다.', HttpStatus.BAD_REQUEST);
+      }
+
       if (group.recruitmentMembers <= group.currentMembers) {
         throw new HttpException('이미 그룹이 꽉차있습니다.', HttpStatus.BAD_REQUEST);
       }

--- a/backend/src/modules/userModules/group/group.service.ts
+++ b/backend/src/modules/userModules/group/group.service.ts
@@ -8,6 +8,9 @@ import { GroupFindResponseDto } from '@group/dtos/group.find.response.dto';
 import { GroupsResponseDto } from '@group/dtos/groups.response.dto';
 import { Theme } from '@theme/entities/theme.entity';
 import { UserGroupRepository } from '@user/userGroup.repository';
+import { UserRepository } from '@user/user.repository';
+import { User } from '@user/entities/user.entity';
+import { ChatRepository } from '@chat/chat.repository';
 
 @Injectable()
 export class GroupService {
@@ -17,7 +20,10 @@ export class GroupService {
     @InjectRepository(ThemeRepository)
     private readonly themeRepository: ThemeRepository,
     @InjectRepository(UserGroupRepository)
-    private readonly userGroupRepository: UserGroupRepository
+    private readonly userGroupRepository: UserGroupRepository,
+    @InjectRepository(UserRepository)
+    private readonly userRepository: UserRepository,
+    private readonly chatRepository: ChatRepository
   ) {}
 
   async createGroup(groupRequest: GroupRequestDto, nickname: string) {
@@ -66,5 +72,11 @@ export class GroupService {
         return new GroupFindResponseDto(dto);
       })
     );
+  }
+
+  async enterGroup(nickname: string, groupId: number) {
+    const user: User = await this.userRepository.findOneBy({ nickname });
+    await this.groupRepository.insertGroup(user, groupId);
+    await this.chatRepository.addUserInRoom(groupId, user.id, user.nickname, user.profileImageUrl);
   }
 }

--- a/backend/src/modules/userModules/user/entities/userGroup.entity.ts
+++ b/backend/src/modules/userModules/user/entities/userGroup.entity.ts
@@ -34,4 +34,14 @@ export class UserGroup extends BaseTime {
   )
   @JoinColumn({ name: 'group_id', referencedColumnName: 'id' })
   group: Group;
+
+  static createUserGroupObject(group: Group, user: User) {
+    return {
+      group: group,
+      user_id: user.id,
+      group_id: group.id,
+      user: user,
+      hasWrittenComment: false,
+    };
+  }
 }

--- a/backend/src/modules/userModules/user/entities/userGroup.entity.ts
+++ b/backend/src/modules/userModules/user/entities/userGroup.entity.ts
@@ -8,7 +8,7 @@ export class UserGroup extends BaseTime {
   @PrimaryGeneratedColumn()
   id: number;
 
-  @Column({ name: 'has_written_comment' })
+  @Column({ name: 'has_written_comment', default: false })
   hasWrittenComment: boolean;
 
   @ManyToOne(
@@ -41,7 +41,6 @@ export class UserGroup extends BaseTime {
       user_id: user.id,
       group_id: group.id,
       user: user,
-      hasWrittenComment: false,
     };
   }
 }


### PR DESCRIPTION
## 🤷‍♂️ Description
그룹/채팅방에 신규 추가되는 API를 개발해요.
```http
GET /groups/:groupId/enter
```

<!-- 구현 한 기능에 대해 작성해 주세요. -->

## 📝 Primary Commits

<!-- 세부 구현 사항을 리스트로 작성해주세요. -->

### UserGroup Object 생성 함수 이동 [53a453d4](https://github.com/boostcampwm2023/web03-LockFestival/commit/53a453d44f2998ccbbec6c754a5f7cba190e5e9f)
UserGroup의 Obejct 생성 함수를  Group -> UserGroup 으로 이동했어요.  

### UserGroup Entity의 hasWrittenComment 컬럼 기본값 추가 [f392e54b](https://github.com/boostcampwm2023/web03-LockFestival/commit/f392e54be9016e1fa3fdb3a0520b8e39c9ae28de)
UserGroup의 hasWrittenComment가 항상 false 로 시작해서 기본값을 false로 변경했어요. 


### MongoDB의 Room에 새로운 유저 추가하는 로직 구현 [e0f28f03](https://github.com/boostcampwm2023/web03-LockFestival/commit/e0f28f03931861edf610bc9b54ebe28c58412e6d)
- 채팅방 입장 메세지 생성
  - type을 실어서 보내요.
  ```ts
  const inChat = await this.chatMessageModel.create({
    chat_message: `${nickname}님이 입장하셨습니다.`,
    chat_date: new Date(),
    type: ChatType.in,
  });
  ```
- 채팅방 유저 생성
  - 해당 유저는 유저의 입장 메세지까지의 채팅들을 읽음 처리해요.
  ```ts
  const chatUser = await this.chatUserModel.create({
    user_id: userId,
    user_nickname: nickname,
    user_profile_url: profileImageUrl,
    is_leader: isLeader,
    is_leave: false,
    last_chat_log_id: inChat._id,
  });
  ```
- 채팅방(Room)에 사용자와 메세지를 추가하고 가장 최근 메세지를 업데이트
  ```ts
  await this.roomModel
    .updateOne(
      { group_id: groupId },
      {
        $push: {
          user_list: chatUser._id,
          chat_list: inChat._id,
        },
        $set: {
          last_chat: inChat._id,
        },
      }
    )
    .exec();
  ```
### MySQL의 Group에 새로운 유저 추가 로직
- 트랜잭션 시작
- 해당 그룹 가져오기
  - groupId에 해당하는 그룹을 가져오고 존재하는지 검사해요.
  ```ts
  const group: Group = await queryRunner.manager.findOneBy(Group, { id: groupId });

  if (!group) {
    throw new HttpException('해당 그룹은 존재하지 않습니다', HttpStatus.BAD_REQUEST);
  }
  ```
- 이미 해당 그룹의 소속 인원인지 검사해요.
  ```ts
  if (
    await queryRunner.manager
      .createQueryBuilder(UserGroup, 'userGroup')
      .where('user_id = :userId', { userId: user.id })
      .andWhere('group_id = :groupId', { groupId: group.id })
      .getExists()
  ) {
    throw new HttpException('이미 해당 그룹의 소속되어 있습니다.', HttpStatus.BAD_REQUEST);
  }
  ```
- 그룹이 꽉차있는지 검증해요.
  ```ts
  if (group.recruitmentMembers <= group.currentMembers) {
    throw new HttpException('이미 그룹이 꽉차있습니다.', HttpStatus.BAD_REQUEST);
  }
  ```
- UserGroup에 해당 유저를 추가해요.
  ```ts
  await queryRunner.manager.save(UserGroup, UserGroup.createUserGroupObject(group, user));
  ```
- 그룹의 현재 인원을 증가시켜요.
  ```ts
  group.currentMembers += 1;
  await queryRunner.manager.save(group);
  ```

## 📷 Screenshots
- 성공
![image](https://github.com/boostcampwm2023/web03-LockFestival/assets/44056518/3754a46c-ed19-491c-b1ed-c25c53413da2)

- 존재하지 않는 그룹일 때
![image](https://github.com/boostcampwm2023/web03-LockFestival/assets/44056518/bfc40765-e58a-4200-af82-9ee35ddaa9a9)
- 이미 해당 그룹 소속일 때
![image](https://github.com/boostcampwm2023/web03-LockFestival/assets/44056518/579b4ef9-01c2-4111-a761-cefb4fd298ed)
<!--스크린샷으로 보여줄 수 있는 이미지가 있다면 첨부해주세요!-->

<!--BE의 경우 API 테스트 결과를 첨부해주세요-->

<!--마지막으로 이슈 생성 시 우측의 옵션들을 체크했는지 확인해주세요!-->

<!-- 이슈번호를 작성해주세요. -->
<!-- 여러 이슈를 입력시 comma(,) 단위로 구분해주세요 -->
<!-- ex) close #10, resolves #123 -->


<!-- ex) -->
<!-- closes #1 --> 
closes #175
