### PR TITLE
Fix/FE/#210: 방 목록을 불러오지 않던 문제를 해결

### DIFF
--- a/frontend/src/apis/fetchRoomList.tsx
+++ b/frontend/src/apis/fetchRoomList.tsx
@@ -2,7 +2,7 @@ import userInstance from '@config/userInstance';
 import { GroupProps } from 'types/group';
 
 const fetchRoomList = async () => {
-  return (await userInstance<Array<GroupProps>>({ method: 'get', url: '/rooms' })).data;
+  return (await userInstance<Array<GroupProps>>({ method: 'get', url: '/users/rooms' })).data;
 };
 
 export default fetchRoomList;

--- a/frontend/src/hooks/query/useRoomListQuery.tsx
+++ b/frontend/src/hooks/query/useRoomListQuery.tsx
@@ -5,6 +5,7 @@ const useRoomListQuery = () => {
   const { data } = useSuspenseQuery({
     queryKey: [QUERY_MANAGEMENT['roomList'].key],
     queryFn: QUERY_MANAGEMENT['roomList'].fn,
+    retry: false,
   });
 
   return { data };

--- a/frontend/src/pages/RoomList/components/RoomListLayout.tsx
+++ b/frontend/src/pages/RoomList/components/RoomListLayout.tsx
@@ -8,7 +8,7 @@ const RoomListLayout = () => {
   return (
     <Container>
       {data.map((room) => {
-        return <Room {...room} />;
+        return <Room {...room} key={room.groupId} />;
       })}
     </Container>
   );


### PR DESCRIPTION
## 🤷‍♂️ Description
채팅방 리스트에서 채팅방 목록을 불러오지 못하던 문제를 해결했어요!

<!-- 구현 한 기능에 대해 작성해 주세요. -->

## 📝 Primary Commits

<!-- 세부 구현 사항을 리스트로 작성해주세요. -->

- [X] 채팅방 리스트에서 채팅방 목록을 불러오지 못하던 문제를 해결
- [X] map의 key값 추가
- 방 목록 query 기본 retry 0으로 설정

## 📷 Screenshots

<img width="833" alt="6666" src="https://github.com/boostcampwm2023/web03-LockFestival/assets/100738049/6c49614f-9949-41f5-9a3a-d0f57df1b0a7">

<!--스크린샷으로 보여줄 수 있는 이미지가 있다면 첨부해주세요!-->

<!--BE의 경우 API 테스트 결과를 첨부해주세요-->

<!--마지막으로 이슈 생성 시 우측의 옵션들을 체크했는지 확인해주세요!-->

<!-- 이슈번호를 작성해주세요. -->
<!-- 여러 이슈를 입력시 comma(,) 단위로 구분해주세요 -->
<!-- ex) close #10, resolves #123 -->


<!-- ex) -->
<!-- closes #1 --> 
closes #210 
