### PR TITLE
Feature/FE/#214: 채팅방 페이지 상태라벨 개발

### DIFF
--- a/frontend/src/pages/Chat/components/RoomInfoContainer.tsx
+++ b/frontend/src/pages/Chat/components/RoomInfoContainer.tsx
@@ -1,11 +1,13 @@
 import tw, { styled, css } from 'twin.macro';
 import Label from '@components/Label/Label';
 import { RoomInfo } from 'types/chat';
+import StateLabel from './StateLabel/StateLabel';
 
-const RoomInfoContainer = ({ roomInfo }: { roomInfo: RoomInfo }) => {
-  const appointmentText = roomInfo.recruitmentCompleted ? '예약 O' : '예약 X';
-  const recruitmentText = roomInfo.recruitmentCompleted ? '모집 O' : '모집X';
+interface RoomInfoProps {
+  roomInfo: RoomInfo;
+}
 
+const RoomInfoContainer = ({ roomInfo }: RoomInfoProps) => {
   return (
     <Layout>
       <HeadContainer>
@@ -46,12 +48,8 @@ const RoomInfoContainer = ({ roomInfo }: { roomInfo: RoomInfo }) => {
           <LabelText>상태</LabelText>
         </Label>
         <RoomInfoContent>
-          <Label isBorder={true} backgroundColor={'green-dark'} width="10rem">
-            <LabelText>{appointmentText}</LabelText>
-          </Label>
-          <Label isBorder={true} backgroundColor={'green-light'} width="10rem">
-            <LabelText>{recruitmentText}</LabelText>
-          </Label>
+          <StateLabel text="예약" state={roomInfo.appointmentCompleted} />
+          <StateLabel text="모집" state={roomInfo.recruitmentCompleted} />
         </RoomInfoContent>
       </RoomInfoWrapper>
     </Layout>

--- a/frontend/src/pages/Chat/components/StateLabel/StateLabel.tsx
+++ b/frontend/src/pages/Chat/components/StateLabel/StateLabel.tsx
@@ -1,0 +1,32 @@
+import Label from '@components/Label/Label';
+import { styled, css } from 'twin.macro';
+import { FaRegCircleCheck } from 'react-icons/fa6';
+import { FaRegCircleXmark } from 'react-icons/fa6';
+
+interface StateLabelProps {
+  text: string;
+  state: boolean;
+}
+
+const StateLabel = ({ text, state }: StateLabelProps) => {
+  return (
+    <Label isBorder={true} backgroundColor={state ? 'green-light' : 'green-dark'} width="10rem">
+      <LabelText>
+        {text}
+        {state ? <FaRegCircleCheck /> : <FaRegCircleXmark />}
+      </LabelText>
+    </Label>
+  );
+};
+
+const LabelText = styled.div([
+  css`
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    width: 100%;
+    gap: 0.4rem;
+  `,
+]);
+
+export default StateLabel;


### PR DESCRIPTION
## 🤷‍♂️ Description
- 예약, 모집 상태를 나타내는 라벨 컴포넌트를 만들어서 적용했어요.

<!-- 구현 한 기능에 대해 작성해 주세요. -->

## 📝 Primary Commits

<!-- 세부 구현 사항을 리스트로 작성해주세요. -->

- [X] 상태 라벨 컴포넌트 생성
- [x] 채팅방 페이지에 적용

## 📷 Screenshots
![image](https://github.com/boostcampwm2023/web03-LockFestival/assets/82202370/573f669b-f3b8-4617-9f09-98c417e24460)

<!--스크린샷으로 보여줄 수 있는 이미지가 있다면 첨부해주세요!-->

<!--BE의 경우 API 테스트 결과를 첨부해주세요-->

<!--마지막으로 이슈 생성 시 우측의 옵션들을 체크했는지 확인해주세요!-->

<!-- 이슈번호를 작성해주세요. -->
<!-- 여러 이슈를 입력시 comma(,) 단위로 구분해주세요 -->
<!-- ex) close #10, resolves #123 -->


<!-- ex) -->
<!-- closes #1 --> 

