### PR TITLE
Fix/BE/#223: `branch brand` -> `brand branch`로 쿼리 변경

### DIFF
--- a/backend/src/modules/themeModules/theme/theme.repository.ts
+++ b/backend/src/modules/themeModules/theme/theme.repository.ts
@@ -31,7 +31,7 @@ export class ThemeRepository extends Repository<Theme> {
         'branch.website as website',
         'branch.phone_number as phone',
         'branch.address as address',
-        "CONCAT(branch.branch_name, ' ', brand.brand_name) AS brandBranchName",
+        "CONCAT(brand.brand_name, ' ', branch.branch_name) AS brandBranchName",
       ])
       .from(Theme, 'theme')
       .innerJoin(Branch, 'branch', 'theme.branch_id = branch.id')

--- a/backend/src/modules/userModules/group/group.repository.ts
+++ b/backend/src/modules/userModules/group/group.repository.ts
@@ -53,7 +53,7 @@ export class GroupRepository extends Repository<Group> {
         'branch.website as website',
         'branch.phone_number as phone',
         'branch.address as address',
-        "CONCAT(branch.branch_name, ' ', brand.brand_name) AS brandBranchName",
+        "CONCAT(brand.brand_name, ' ', branch.branch_name) AS brandBranchName",
 
         'group.id as groupId',
         'group.appointment_date as appointmentDate',


### PR DESCRIPTION
## 🤷‍♂️ Description
`brand branch`로 반환되어야 할 쿼리가 `branch brand`로 반환된 내용을 수정해요.

<!-- 구현 한 기능에 대해 작성해 주세요. -->

## 📝 Primary Commits

<!-- 세부 구현 사항을 리스트로 작성해주세요. -->

- [X] ThemeRepository.getThemeDetailsById()
- [X] GroupRepository.findByFindOptions()
### before
```ts
"CONCAT(branch.branch_name, ' ', brand.brand_name) AS brandBranchName",
```
### after
```ts
"CONCAT(brand.brand_name, ' ', branch.branch_name) AS brandBranchName",
```

## 📷 Screenshots

<!--스크린샷으로 보여줄 수 있는 이미지가 있다면 첨부해주세요!-->

<!--BE의 경우 API 테스트 결과를 첨부해주세요-->

<!--마지막으로 이슈 생성 시 우측의 옵션들을 체크했는지 확인해주세요!-->

<!-- 이슈번호를 작성해주세요. -->
<!-- 여러 이슈를 입력시 comma(,) 단위로 구분해주세요 -->
<!-- ex) close #10, resolves #123 -->


<!-- ex) -->
<!-- closes #1 --> 
closes #223
