### PR TITLE
Fix/FE/#227: 방정보 상태 표기 변경

### DIFF
--- a/frontend/src/pages/ChatRoom/components/RoomInfoPanel/StateLabel/StateLabel.tsx
+++ b/frontend/src/pages/ChatRoom/components/RoomInfoPanel/StateLabel/StateLabel.tsx
@@ -1,8 +1,5 @@
 import Label from '@components/Label/Label';
 import { styled, css } from 'twin.macro';
-import { FaRegCircleCheck } from 'react-icons/fa6';
-import { FaRegCircleXmark } from 'react-icons/fa6';
-
 interface StateLabelProps {
   text: string;
   state: boolean;
@@ -10,10 +7,10 @@ interface StateLabelProps {
 
 const StateLabel = ({ text, state }: StateLabelProps) => {
   return (
-    <Label isBorder={true} backgroundColor={state ? 'green-light' : 'green-dark'} width="10rem">
+    <Label isBorder={true} backgroundColor={state ? 'green-dark' : 'green-light'} width="10rem">
       <LabelText>
         {text}
-        {state ? <FaRegCircleCheck /> : <FaRegCircleXmark />}
+        {state ? '완료' : '중'}
       </LabelText>
     </Label>
   );


### PR DESCRIPTION
## 🤷‍♂️ Description
- 데이터가 completed 여부였는데, 제가 반대로 의미를 해석해서 표기 오류가 있었어요!
- 기존에 아이콘으로 표기했었는데, 의미가 모호해서 그룹채팅방에서 표기하는 방법으로 통일 시켰어요!

<!-- 구현 한 기능에 대해 작성해 주세요. -->

## 📝 Primary Commits

<!-- 세부 구현 사항을 리스트로 작성해주세요. -->

- [X] 상태라벨 컴포넌트 수정하기

## 📷 Screenshots
![image](https://github.com/boostcampwm2023/web03-LockFestival/assets/82202370/3ad73b81-80b4-46f4-a982-769a2c62c0b8)

<!--스크린샷으로 보여줄 수 있는 이미지가 있다면 첨부해주세요!-->

<!--BE의 경우 API 테스트 결과를 첨부해주세요-->

<!--마지막으로 이슈 생성 시 우측의 옵션들을 체크했는지 확인해주세요!-->

<!-- 이슈번호를 작성해주세요. -->
<!-- 여러 이슈를 입력시 comma(,) 단위로 구분해주세요 -->
<!-- ex) close #10, resolves #123 -->


<!-- ex) -->
<!-- closes #1 --> 

closes #227
