### PR TITLE
Fix/BE/#258: message를 불러올 때 populate를 하지 않도록 수정

### DIFF
--- a/backend/src/modules/userModules/chat/chat.repository.ts
+++ b/backend/src/modules/userModules/chat/chat.repository.ts
@@ -79,10 +79,6 @@ export class ChatRepository {
         model: 'ChatMessage',
         match: { _id: { $gt: chatUnreadDto.startLogId } },
         options,
-        populate: {
-          path: 'sender',
-          model: 'ChatUser',
-        },
       })
     ).chat_list.map((message) => {
       return new ChatMessageDto(message);


### PR DESCRIPTION
## 🤷‍♂️ Description
기존에는 아래와 같이 유저 정보가 이상하게 들어가고 있었어요.
![image](https://github.com/boostcampwm2023/web03-LockFestival/assets/44056518/842648a0-6f62-4bf9-8f3e-103c2de57e74)
message를 불러올 때 populate를 하지 않도록 수정해요.

<!-- 구현 한 기능에 대해 작성해 주세요. -->

## 📝 Primary Commits

<!-- 세부 구현 사항을 리스트로 작성해주세요. -->

- [X] sender를 populate 하지 않고 _id 값만 넘기도록 수정

## 📷 Screenshots
![image](https://github.com/boostcampwm2023/web03-LockFestival/assets/44056518/7fae38b8-0944-4aed-b96e-c0b005787d12)

<!--스크린샷으로 보여줄 수 있는 이미지가 있다면 첨부해주세요!-->

<!--BE의 경우 API 테스트 결과를 첨부해주세요-->

<!--마지막으로 이슈 생성 시 우측의 옵션들을 체크했는지 확인해주세요!-->

<!-- 이슈번호를 작성해주세요. -->
<!-- 여러 이슈를 입력시 comma(,) 단위로 구분해주세요 -->
<!-- ex) close #10, resolves #123 -->


<!-- ex) -->
<!-- closes #1 --> 
closes #258
