### PR TITLE
Feature/FE/#261 입장 가능 여부 로직 변경

### DIFF
--- a/frontend/src/components/Card/GroupInfoCard/HeadCard/HeadCardContent.tsx
+++ b/frontend/src/components/Card/GroupInfoCard/HeadCard/HeadCardContent.tsx
@@ -113,8 +113,9 @@ const HeadCardContent = ({
         <ButtonContainer>
           <DetailButton onClick={handleClickFlipButton}>상세보기</DetailButton>
           <Button
-            isEnter={checkRoomState()}
+            canEnter={checkRoomState()}
             onClick={() => handleNavigate(groupDetail.isEnter, groupDetail.groupId)}
+            disabled={!checkRoomState()}
           >
             입장하기
           </Button>
@@ -181,11 +182,11 @@ const ButtonContainer = styled.div([
   `,
 ]);
 
-const Button = styled.button<{ isEnter?: boolean }>(({ isEnter }) => [
+const Button = styled.button<{ canEnter: boolean }>(({ canEnter }) => [
   tw`text-white bg-transparent font-pretendard`,
   css`
-    cursor: ${isEnter ? 'pointer' : 'not-allowed'};
-    color: ${!isEnter && '#525252'};
+    cursor: ${canEnter ? 'pointer' : 'not-allowed'};
+    color: ${!canEnter && '#525252'};
     &:hover {
       text-decoration: underline;
       text-underline-position: under;

--- a/frontend/src/components/Card/GroupInfoCard/TailCard/TailCard.tsx
+++ b/frontend/src/components/Card/GroupInfoCard/TailCard/TailCard.tsx
@@ -73,8 +73,9 @@ const TailCard = ({ leader, themeDetail, groupDetail, handleClickFlipButton }: H
       <ButtonContainer>
         <DetailButton onClick={handleClickFlipButton}>돌아가기</DetailButton>
         <Button
-          isEnter={checkRoomState()}
+          canEnter={checkRoomState()}
           onClick={() => handleNavigate(groupDetail.isEnter, groupDetail.groupId)}
+          disabled={!checkRoomState()}
         >
           입장하기
         </Button>
@@ -128,11 +129,11 @@ const LabelText = styled.div([
   `,
 ]);
 
-const Button = styled.button<{ isEnter?: boolean }>(({ isEnter }) => [
+const Button = styled.button<{ canEnter: boolean }>(({ canEnter }) => [
   tw`text-white bg-transparent font-pretendard`,
   css`
-    cursor: ${isEnter ? 'pointer' : 'not-allowed'};
-    color: ${!isEnter && '#525252'};
+    cursor: ${canEnter ? 'pointer' : 'not-allowed'};
+    color: ${!canEnter && '#525252'};
     &:hover {
       text-decoration: underline;
       text-underline-position: under;


### PR DESCRIPTION
## 🤷‍♂️ Description
이미 방에 입장했을 때도 탈출러 모집 페이지에서 입장 가능하도록 변경했어요.
또, 빈 자리가 하나도 없다면 입장 할 수 없도록 변경했어요.

현재 렌더링 될때마다 checkRoomState 함수를 호출하는데 추후에 최적화를 해야할 것 같아요

<!-- 구현 한 기능에 대해 작성해 주세요. -->

## 📝 Primary Commits

<!-- 세부 구현 사항을 리스트로 작성해주세요. -->

- [X] 이미 방에 입장했을 때도 탈출러 모집 페이지에서 입장 가능하도록 변경
- [X] 또, 빈 자리가 하나도 없다면 입장 할 수 없도록 변경

## 📷 Screenshots


https://github.com/boostcampwm2023/web03-LockFestival/assets/100738049/0d039a38-d5bf-4d74-85ec-2847ec90cd0a


<!--스크린샷으로 보여줄 수 있는 이미지가 있다면 첨부해주세요!-->

<!--BE의 경우 API 테스트 결과를 첨부해주세요-->

<!--마지막으로 이슈 생성 시 우측의 옵션들을 체크했는지 확인해주세요!-->

<!-- 이슈번호를 작성해주세요. -->
<!-- 여러 이슈를 입력시 comma(,) 단위로 구#261 요 -->
<!-- ex) close #10, resolves #123 -->


<!-- ex) -->
<!-- closes #1 --> 
closes #261
