### PR TITLE
Fix/BE/#263:  last_chat_log_id -> cursorLogId로 변경

### DIFF
--- a/backend/src/modules/userModules/chat/chat.repository.ts
+++ b/backend/src/modules/userModules/chat/chat.repository.ts
@@ -73,11 +73,16 @@ export class ChatRepository {
       options['limit'] = chatUnreadDto.count;
     }
 
+    const directionOptions =
+      chatUnreadDto.direction === 1
+        ? { $gte: chatUnreadDto.cursorLogId }
+        : { $lt: chatUnreadDto.cursorLogId };
+
     return (
       await this.roomModel.findOne({ group_id: chatUnreadDto.roomId }).populate({
         path: 'chat_list',
         model: 'ChatMessage',
-        match: { _id: { $gt: chatUnreadDto.startLogId } },
+        match: { _id: directionOptions },
         options,
       })
     ).chat_list.map((message) => {

--- a/backend/src/modules/userModules/chat/chat.service.ts
+++ b/backend/src/modules/userModules/chat/chat.service.ts
@@ -24,7 +24,7 @@ export class ChatService {
 
     const countMap: object = chatUsers
       .filter((user: ChatUserInfoDto) => {
-        return !user.isMe;
+        return !user.isMe && !!user.lastChatLogId;
       })
       .map(({ lastChatLogId }) => {
         return lastChatLogId;
@@ -48,7 +48,7 @@ export class ChatService {
     await this.chatRepository.updateRead(meUser.userId);
 
     const prevMessages: ChatMessageResponseDto = await this.findMessagesByLogId({
-      startLogId: meUser.lastChatLogId,
+      cursorLogId: meUser.lastChatLogId,
       count: 0,
       direction: 1,
       roomId,
@@ -74,6 +74,6 @@ export class ChatService {
     this.logger.log(chatUnreadDto);
     const messages: ChatMessageDto[] =
       await this.chatRepository.findMessagesByStartLogId(chatUnreadDto);
-    return new ChatMessageResponseDto(chatUnreadDto.startLogId, messages);
+    return new ChatMessageResponseDto(chatUnreadDto.cursorLogId, messages, chatUnreadDto.direction);
   }
 }

--- a/backend/src/modules/userModules/chat/dtos/chat.mesage.response.dto.ts
+++ b/backend/src/modules/userModules/chat/dtos/chat.mesage.response.dto.ts
@@ -1,11 +1,13 @@
-import { ChatMessageDto } from './chat.message.dto';
+import { ChatMessageDto } from '@chat/dtos/chat.message.dto';
 
 export class ChatMessageResponseDto {
   messages: ChatMessageDto[];
-  startLogId: string;
+  cursorLogId: string;
+  direction: number;
 
-  constructor(startLogId: string, messages: ChatMessageDto[]) {
+  constructor(cursorLogId: string, messages: ChatMessageDto[], direction: number) {
     this.messages = messages;
-    this.startLogId = startLogId;
+    this.cursorLogId = cursorLogId;
+    this.direction = direction;
   }
 }

--- a/backend/src/modules/userModules/chat/dtos/chat.unread.dto.ts
+++ b/backend/src/modules/userModules/chat/dtos/chat.unread.dto.ts
@@ -1,6 +1,6 @@
 export class ChatUnreadDto {
   roomId: string;
-  startLogId: string;
+  cursorLogId: string;
   direction: -1 | 1;
   count: number;
 }


### PR DESCRIPTION
## 🤷‍♂️ Description
명칭을 변경해요.


<!-- 구현 한 기능에 대해 작성해 주세요. -->

## 📝 Primary Commits

<!-- 세부 구현 사항을 리스트로 작성해주세요. -->

- [X] `chatLog` 이벤트 응답에 방향(direction) 추가
- [X] `chatLog` 이벤트에서 last_chat_log_id -> cursorLogId로 명칭 변경
- [X] 최신 데이터를 불러오는 경우(directon: 1) 커서 값을 포함해서 반환하도록 변경

## 📷 Screenshots

<!--스크린샷으로 보여줄 수 있는 이미지가 있다면 첨부해주세요!-->

<!--BE의 경우 API 테스트 결과를 첨부해주세요-->

<!--마지막으로 이슈 생성 시 우측의 옵션들을 체크했는지 확인해주세요!-->

<!-- 이슈번호를 작성해주세요. -->
<!-- 여러 이슈를 입력시 comma(,) 단위로 구분해주세요 -->
<!-- ex) close #10, resolves #123 -->


<!-- ex) -->
<!-- closes #1 --> 
closes #263
