### PR TITLE
Refactor/BE/#221:  OAuth로부터 받아오는 개인정보 정리& 프로필이미지를 받아오게 수정

### DIFF
--- a/backend/src/modules/authModules/auth/auth.service.ts
+++ b/backend/src/modules/authModules/auth/auth.service.ts
@@ -58,13 +58,15 @@ export class AuthService {
 
   async getNaverUser(accessNaverToken: string): Promise<UserNaverDto> {
     try {
-      return (
-        await this.httpService.axiosRef.post(
-          'https://openapi.naver.com/v1/nid/me',
-          {},
-          { headers: { Authorization: `Bearer ${accessNaverToken}` } }
-        )
-      ).data.response;
+      return new UserNaverDto(
+        (
+          await this.httpService.axiosRef.post(
+            'https://openapi.naver.com/v1/nid/me',
+            {},
+            { headers: { Authorization: `Bearer ${accessNaverToken}` } }
+          )
+        ).data.response
+      );
     } catch (error) {
       throw new HttpException('Failed to get Naver user data.', HttpStatus.INTERNAL_SERVER_ERROR);
     }

--- a/backend/src/modules/userModules/user/dtos/user.naver.dto.ts
+++ b/backend/src/modules/userModules/user/dtos/user.naver.dto.ts
@@ -1,9 +1,8 @@
 export class UserNaverDto {
   id: string;
-  gender: string;
-  email: string;
-  mobile: string;
-  mobile_e164: string;
-  name: string;
-  birthyear: string;
+  profileImageUrl: string;
+  constructor({ id, profile_image }) {
+    this.id = id;
+    this.profileImageUrl = profile_image;
+  }
 }

--- a/backend/src/modules/userModules/user/user.repository.ts
+++ b/backend/src/modules/userModules/user/user.repository.ts
@@ -26,6 +26,7 @@ export class UserRepository extends Repository<User> {
       gender: Gender.F,
       email: data.id,
       nickname: nickname,
+      profileImageUrl: data.profileImageUrl,
       phoneNumber: '010-0000-0000',
       name: '이름',
       birthYear: 1998,

--- a/backend/src/modules/userModules/user/user.repository.ts
+++ b/backend/src/modules/userModules/user/user.repository.ts
@@ -23,12 +23,12 @@ export class UserRepository extends Repository<User> {
 
   async createUserByNaver(data: UserNaverDto, nickname: string): Promise<User> {
     return await this.save({
-      gender: Gender[data.gender],
-      email: data.email,
+      gender: Gender.F,
+      email: data.id,
       nickname: nickname,
-      phoneNumber: data.mobile,
-      name: data.name,
-      birthYear: Number(data.birthyear),
+      phoneNumber: '010-0000-0000',
+      name: '이름',
+      birthYear: 1998,
     });
   }
 

--- a/backend/src/modules/userModules/user/user.service.ts
+++ b/backend/src/modules/userModules/user/user.service.ts
@@ -35,7 +35,7 @@ export class UserService {
 
   async login(data: UserNaverDto): Promise<User> {
     try {
-      const userData = await this.userRepository.findUserByEmail(data.email);
+      const userData = await this.userRepository.findUserByEmail(data.id);
       if (!userData) {
         let nickname: string = this.generateRandomString();
         while (!(await this.checkUsableNickname(nickname))) {


### PR DESCRIPTION
## 🤷‍♂️ Description
-  OAuth로부터 받아오는 개인정보 정리를 위해 유저정보에 임시데이터를 넣었어요
-  네이버 프로필 이미지를 받아왔어요

<!-- 구현 한 기능에 대해 작성해 주세요. -->

## 📝 Primary Commits

<!-- 세부 구현 사항을 리스트로 작성해주세요. -->

- [X] 회원가입시 임시데이터를 넣었어요
  - 고유한 회원 값을 가지고 있기 위해 네이버에서 주는 고유 아이디를 사용했어요.
  - 사용하지 않는 필드에 임시로 가짜 데이터를 넣었어요.
```
{
      gender: Gender.F,
      email: data.id,
      nickname: nickname,
      profileImageUrl: data. profileImageUrl,
      phoneNumber: '010-0000-0000',
      name: '이름',
      birthYear: 1998,
}
```
- [x] 프로필 이미지를 받아올 수 있게 수정했어요
  -  UserNaverDto을 수정했어요

## 📷 Screenshots
![image](https://github.com/boostcampwm2023/web03-LockFestival/assets/101504594/92aa0761-41ab-40de-97f0-f91abd238d2a)

close #221

