### PR TITLE
Fix/BE/#270: 이전 채팅 불러오는 로직 수정

### DIFF
--- a/backend/src/modules/userModules/chat/chat.repository.ts
+++ b/backend/src/modules/userModules/chat/chat.repository.ts
@@ -66,7 +66,7 @@ export class ChatRepository {
   }
   async findMessagesByStartLogId(chatUnreadDto: ChatUnreadDto): Promise<ChatMessageDto[]> {
     const options = {
-      sort: { _id: 1 },
+      sort: { _id: chatUnreadDto.direction },
     };
 
     if (chatUnreadDto?.count > 0) {
@@ -78,7 +78,7 @@ export class ChatRepository {
         ? { $gte: chatUnreadDto.cursorLogId }
         : { $lt: chatUnreadDto.cursorLogId };
 
-    return (
+    const chatMessageDtos = (
       await this.roomModel.findOne({ group_id: chatUnreadDto.roomId }).populate({
         path: 'chat_list',
         model: 'ChatMessage',
@@ -88,6 +88,8 @@ export class ChatRepository {
     ).chat_list.map((message) => {
       return new ChatMessageDto(message);
     });
+
+    return chatUnreadDto.direction === 1 ? chatMessageDtos : chatMessageDtos.reverse();
   }
 
   async findUserListWithLeavedUserByRoomId(roomId: string): Promise<ChatUserInfoDto[]> {


### PR DESCRIPTION
## 🤷‍♂️ Description
이전 채팅을 불러오는 로직에서 제일 오래된 데이터 부터 들고오는 문제가 있었어요.

<!-- 구현 한 기능에 대해 작성해 주세요. -->

## 📝 Primary Commits

<!-- 세부 구현 사항을 리스트로 작성해주세요. -->

- [X] populate할 때 sort는 request에서 온 direction을 그대로 사용하되, 반환할 때 이전 데이터이면 데이터 순서를 reverse 해서 보내요.

## 📷 Screenshots

<!--스크린샷으로 보여줄 수 있는 이미지가 있다면 첨부해주세요!-->

<!--BE의 경우 API 테스트 결과를 첨부해주세요-->

<!--마지막으로 이슈 생성 시 우측의 옵션들을 체크했는지 확인해주세요!-->

<!-- 이슈번호를 작성해주세요. -->
<!-- 여러 이슈를 입력시 comma(,) 단위로 구분해주세요 -->
<!-- ex) close #10, resolves #123 -->


<!-- ex) -->
<!-- closes #1 --> 
closes #270
