### PR TITLE
Feature/BE/#273: 채팅방 입장시 안읽은 메세지를 반환하는 API 개발

### DIFF
--- a/backend/src/gateway/events.gateway.ts
+++ b/backend/src/gateway/events.gateway.ts
@@ -125,13 +125,16 @@ export class EventsGateway implements OnGatewayInit, OnGatewayConnection, OnGate
   }
 
   async handleDisconnect(client: Socket) {
+    this.logger.log('by' + client.id);
     const roomId = this.socketToRoomId[client.id];
+    if (!roomId) {
+      return;
+    }
     const userId = this.socketsInrooms[roomId][client.id];
 
     delete this.socketsInrooms[roomId][client.id];
     delete this.socketToRoomId[client.id];
     await this.chatService.updateLastChatLogId(roomId, userId);
-    this.logger.log('by' + client.id);
   }
   afterInit(server: Server) {
     this.logger.log('Initialized!');

--- a/backend/src/modules/userModules/chat/chat.controller.ts
+++ b/backend/src/modules/userModules/chat/chat.controller.ts
@@ -1,7 +1,29 @@
-import { Controller } from '@nestjs/common';
+import { Controller, Get, Param, Req, UseGuards } from '@nestjs/common';
 import { ChatService } from '@chat/chat.service';
+import { TokenAuthGuard } from '@auth/auth.guard';
+import { ApiBadRequestResponse, ApiBearerAuth, ApiOperation } from '@nestjs/swagger';
+import { EnteredChatMessageRequestDto } from '@chat/dtos/chat.entered.response.dto';
 
-@Controller('chat/')
+@Controller('chat')
 export class ChatController {
   constructor(private readonly chatService: ChatService) {}
+
+  @Get(':groupId/unread')
+  @UseGuards(TokenAuthGuard)
+  @ApiOperation({
+    description: '채팅방 입장시 안읽은 메세지 리스트를 반환합니다.',
+  })
+  @ApiBadRequestResponse({
+    description: '유저가 방에 없습니다.',
+  })
+  @ApiBearerAuth('Authorization')
+  async getUnreadChatListByGroupId(
+    @Req() { user },
+    @Param('groupId') groupId: number
+  ): Promise<EnteredChatMessageRequestDto> {
+    return await this.chatService.findUnreadMessagesByRoomIdAndNickname(
+      String(groupId),
+      user.nickname
+    );
+  }
 }

--- a/backend/src/modules/userModules/chat/chat.controller.ts
+++ b/backend/src/modules/userModules/chat/chat.controller.ts
@@ -2,7 +2,7 @@ import { Controller, Get, Param, Req, UseGuards } from '@nestjs/common';
 import { ChatService } from '@chat/chat.service';
 import { TokenAuthGuard } from '@auth/auth.guard';
 import { ApiBadRequestResponse, ApiBearerAuth, ApiOperation } from '@nestjs/swagger';
-import { EnteredChatMessageRequestDto } from '@chat/dtos/chat.entered.response.dto';
+import { EnteredChatMessageResponseDto } from '@chat/dtos/chat.entered.response.dto';
 
 @Controller('chat')
 export class ChatController {
@@ -20,7 +20,7 @@ export class ChatController {
   async getUnreadChatListByGroupId(
     @Req() { user },
     @Param('groupId') groupId: number
-  ): Promise<EnteredChatMessageRequestDto> {
+  ): Promise<EnteredChatMessageResponseDto> {
     return await this.chatService.findUnreadMessagesByRoomIdAndNickname(
       String(groupId),
       user.nickname

--- a/backend/src/modules/userModules/chat/chat.repository.ts
+++ b/backend/src/modules/userModules/chat/chat.repository.ts
@@ -151,11 +151,9 @@ export class ChatRepository {
   }
 
   async updateRead(userId: string) {
-    this.chatUserModel.updateOne(
+    await this.chatUserModel.updateOne(
       {
-        _id: {
-          $eq: { userId },
-        },
+        _id: userId,
       },
       {
         $unset: {
@@ -164,6 +162,7 @@ export class ChatRepository {
       }
     );
   }
+
   async findLastChatLogIdByRoomId(roomId: string) {
     const roomInfo = await this.roomModel.findOne({ group_id: roomId });
     if (!roomInfo) {

--- a/backend/src/modules/userModules/chat/chat.repository.ts
+++ b/backend/src/modules/userModules/chat/chat.repository.ts
@@ -180,7 +180,7 @@ export class ChatRepository {
       },
       {
         $set: {
-          last_chat_log_id: lastChatLogId,
+          last_chat_log_id: new mongoose.Types.ObjectId(lastChatLogId),
         },
       }
     );

--- a/backend/src/modules/userModules/chat/chat.service.ts
+++ b/backend/src/modules/userModules/chat/chat.service.ts
@@ -6,7 +6,7 @@ import { ChatMessageDto } from '@chat/dtos/chat.message.dto';
 import { ChatUserInfoDto } from '@chat/dtos/chat.user.info.dto';
 import { ChatMessageResponseDto } from '@chat/dtos/chat.mesage.response.dto';
 import { ChatUser } from '@chat/entities/chat.user.schema';
-import { EnteredChatMessageRequestDto } from '@chat/dtos/chat.entered.response.dto';
+import { EnteredChatMessageResponseDto } from '@chat/dtos/chat.entered.response.dto';
 
 @Injectable()
 export class ChatService {
@@ -82,7 +82,7 @@ export class ChatService {
   async findUnreadMessagesByRoomIdAndNickname(
     roomId: string,
     nickname: string
-  ): Promise<EnteredChatMessageRequestDto> {
+  ): Promise<EnteredChatMessageResponseDto> {
     const chatUser: ChatUser = await this.chatRepository.validateRoomAndGetChatUser(
       roomId,
       nickname
@@ -92,6 +92,6 @@ export class ChatService {
       new ChatUnreadDto(roomId, chatUser.last_chat_log_id, 1, 0)
     );
 
-    return new EnteredChatMessageRequestDto(chatUser.last_chat_log_id, messages);
+    return new EnteredChatMessageResponseDto(chatUser.last_chat_log_id, messages);
   }
 }

--- a/backend/src/modules/userModules/chat/chat.service.ts
+++ b/backend/src/modules/userModules/chat/chat.service.ts
@@ -5,6 +5,8 @@ import { ChatUnreadDto } from '@chat/dtos/chat.unread.dto';
 import { ChatMessageDto } from '@chat/dtos/chat.message.dto';
 import { ChatUserInfoDto } from '@chat/dtos/chat.user.info.dto';
 import { ChatMessageResponseDto } from '@chat/dtos/chat.mesage.response.dto';
+import { ChatUser } from '@chat/entities/chat.user.schema';
+import { EnteredChatMessageRequestDto } from '@chat/dtos/chat.entered.response.dto';
 
 @Injectable()
 export class ChatService {
@@ -75,5 +77,21 @@ export class ChatService {
     const messages: ChatMessageDto[] =
       await this.chatRepository.findMessagesByStartLogId(chatUnreadDto);
     return new ChatMessageResponseDto(chatUnreadDto.cursorLogId, messages, chatUnreadDto.direction);
+  }
+
+  async findUnreadMessagesByRoomIdAndNickname(
+    roomId: string,
+    nickname: string
+  ): Promise<EnteredChatMessageRequestDto> {
+    const chatUser: ChatUser = await this.chatRepository.validateRoomAndGetChatUser(
+      roomId,
+      nickname
+    );
+
+    const messages: ChatMessageDto[] = await this.chatRepository.findMessagesByStartLogId(
+      new ChatUnreadDto(roomId, chatUser.last_chat_log_id, 1, 0)
+    );
+
+    return new EnteredChatMessageRequestDto(chatUser.last_chat_log_id, messages);
   }
 }

--- a/backend/src/modules/userModules/chat/dtos/chat.entered.response.dto.ts
+++ b/backend/src/modules/userModules/chat/dtos/chat.entered.response.dto.ts
@@ -1,0 +1,11 @@
+import { ChatMessageDto } from '@chat/dtos/chat.message.dto';
+
+export class EnteredChatMessageRequestDto {
+  messages: ChatMessageDto[];
+  cursorLogId: string;
+
+  constructor(cursorLogId: string, messages: ChatMessageDto[]) {
+    this.messages = messages;
+    this.cursorLogId = cursorLogId;
+  }
+}

--- a/backend/src/modules/userModules/chat/dtos/chat.entered.response.dto.ts
+++ b/backend/src/modules/userModules/chat/dtos/chat.entered.response.dto.ts
@@ -1,7 +1,7 @@
 import { ChatMessageDto } from '@chat/dtos/chat.message.dto';
 import { ApiProperty } from '@nestjs/swagger';
 
-export class EnteredChatMessageRequestDto {
+export class EnteredChatMessageResponseDto {
   @ApiProperty({
     type: [ChatMessageDto],
   })

--- a/backend/src/modules/userModules/chat/dtos/chat.entered.response.dto.ts
+++ b/backend/src/modules/userModules/chat/dtos/chat.entered.response.dto.ts
@@ -1,7 +1,14 @@
 import { ChatMessageDto } from '@chat/dtos/chat.message.dto';
+import { ApiProperty } from '@nestjs/swagger';
 
 export class EnteredChatMessageRequestDto {
+  @ApiProperty({
+    type: [ChatMessageDto],
+  })
   messages: ChatMessageDto[];
+  @ApiProperty({
+    description: '커서로 사용한 안읽은 chatLogId',
+  })
   cursorLogId: string;
 
   constructor(cursorLogId: string, messages: ChatMessageDto[]) {

--- a/backend/src/modules/userModules/chat/dtos/chat.message.dto.ts
+++ b/backend/src/modules/userModules/chat/dtos/chat.message.dto.ts
@@ -1,11 +1,32 @@
 import { ChatType } from '@enum/chat.type';
+import { ApiProperty } from '@nestjs/swagger';
 
 export class ChatMessageDto {
+  @ApiProperty({
+    description: '채팅 id',
+    type: String,
+  })
   chatId: string;
+  @ApiProperty({
+    description: '채팅 내용',
+    type: String,
+  })
   message: string;
+  @ApiProperty({
+    description: '채팅 타입',
+    type: ChatType,
+  })
   type: ChatType;
+  @ApiProperty({
+    description: '채팅 날짜',
+    type: Date,
+  })
   time: Date;
-  userId: number;
+  @ApiProperty({
+    description: '채팅보낸 사람의 _id',
+    type: String,
+  })
+  userId: string;
 
   constructor(chat) {
     this.chatId = chat._id.toString();

--- a/backend/src/modules/userModules/chat/dtos/chat.unread.dto.ts
+++ b/backend/src/modules/userModules/chat/dtos/chat.unread.dto.ts
@@ -3,4 +3,10 @@ export class ChatUnreadDto {
   cursorLogId: string;
   direction: -1 | 1;
   count: number;
+  constructor(roomId: string, cursorLogId: string, direction: -1 | 1, count: number) {
+    this.roomId = roomId;
+    this.cursorLogId = cursorLogId;
+    this.direction = direction;
+    this.count = count;
+  }
 }

--- a/backend/src/modules/userModules/chat/entities/chat.message.schema.ts
+++ b/backend/src/modules/userModules/chat/entities/chat.message.schema.ts
@@ -1,10 +1,10 @@
 import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
-import mongoose from 'mongoose';
+import mongoose, {Document} from 'mongoose';
 import { ChatType } from '@src/enum/chat.type';
 import { ChatUser } from '@chat/entities/chat.user.schema';
 
 @Schema({ versionKey: false })
-export class ChatMessage {
+export class ChatMessage extends Document {
   @Prop({ type: mongoose.Schema.Types.ObjectId, ref: ChatUser.name })
   sender: ChatUser;
 

--- a/backend/src/modules/userModules/chat/entities/chat.message.schema.ts
+++ b/backend/src/modules/userModules/chat/entities/chat.message.schema.ts
@@ -1,5 +1,5 @@
 import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
-import mongoose, {Document} from 'mongoose';
+import mongoose, { Document } from 'mongoose';
 import { ChatType } from '@src/enum/chat.type';
 import { ChatUser } from '@chat/entities/chat.user.schema';
 


### PR DESCRIPTION
## 🤷‍♂️ Description
프론트의 요청으로 채팅방 입장시 안읽은 메세지를 반환하는 API를 개발해요.
```http
GET /chat/:groupId/unread
```

<!-- 구현 한 기능에 대해 작성해 주세요. -->

## 📝 Primary Commits

<!-- 세부 구현 사항을 리스트로 작성해주세요. -->

- [X] 기존과 다르게 방향값이 반환되지 않는 DTO 개발
  - EnteredChatMessageRequestDto
    ```ts
    export class EnteredChatMessageRequestDto {
      messages: ChatMessageDto[];
      cursorLogId: string;
    
      constructor(cursorLogId: string, messages: ChatMessageDto[]) {
        this.messages = messages;
        this.cursorLogId = cursorLogId;
      }
    }
    ```
- [X] 채팅방의 접속(`join`)시 마지막 읽은 메세지 커서를 지우는 함수의 오류 수정 [9980f88](https://github.com/boostcampwm2023/web03-LockFestival/commit/9980f881858734cdaa646737e2b7f2482c637f44)
  - await가 빠져있어요.
  - 전에 정민님이 말씀하신 $eq 구문에 문제가 있었어요..! -> 아마 저번 PR이 제꺼보고 참고하셔서 틀렸었나보네요 ㅋㅋㅋㅋㅋ
    ```ts
    //AS-IS
    async updateRead(userId: string) {
      this.chatUserModel.updateOne(
        {
          _id: {
            $eq: { userId },
          },
        },
        {
          $unset: {
            last_chat_log_id: true,
          },
        }
      );
    }
    //TO-BE
    async updateRead(userId: string) {
      await this.chatUserModel.updateOne(
        {
          _id: userId,
        },
        {
          $unset: {
            last_chat_log_id: true,
          },
        }
      );
    }
    ```
- [X] ChatMessage에 mongoose.Document를 상속해요
  - _id 를 사용할 일이 많은 것 같아 상속을 추가했어요
- [X] 안읽은 메세지를 찾아서 반환하는 로직을 구현해요
  - 기존 로직을 사용하려 했으나 여러 의존 문제가 있어서 일단은 따로 구축했어요.
  - 추후 로직 개선되면 리팩토링이 필요해요.
  - 현재는 마지막으로 읽은 채팅 값을 건들지 않아요.
    - 채팅방 소켓에 정상적으로 접속하지 못할 문제를 대비하여서 소켓에 연결할 때 처리해요.
 
## 📷 Screenshots

<!--스크린샷으로 보여줄 수 있는 이미지가 있다면 첨부해주세요!-->

<!--BE의 경우 API 테스트 결과를 첨부해주세요-->

<!--마지막으로 이슈 생성 시 우측의 옵션들을 체크했는지 확인해주세요!-->

<!-- 이슈번호를 작성해주세요. -->
<!-- 여러 이슈를 입력시 comma(,) 단위로 구분해주세요 -->
<!-- ex) close #10, resolves #123 -->
![image](https://github.com/boostcampwm2023/web03-LockFestival/assets/44056518/0049463d-5e3c-4fb8-8397-d3f7aa596e75)


<!-- ex) -->
<!-- closes #1 --> 

closes #273 