### PR TITLE
Feature/BE/#272: 채팅방 리스트 반환 API에 채팅 정보 추가

### DIFF
--- a/backend/src/modules/userModules/chat/chat.controller.ts
+++ b/backend/src/modules/userModules/chat/chat.controller.ts
@@ -1,9 +1,10 @@
 import { Controller, Get, Param, Req, UseGuards } from '@nestjs/common';
 import { ChatService } from '@chat/chat.service';
 import { TokenAuthGuard } from '@auth/auth.guard';
-import { ApiBadRequestResponse, ApiBearerAuth, ApiOperation } from '@nestjs/swagger';
+import { ApiBadRequestResponse, ApiBearerAuth, ApiOperation, ApiTags } from '@nestjs/swagger';
 import { EnteredChatMessageResponseDto } from '@chat/dtos/chat.entered.response.dto';
 
+@ApiTags('chat')
 @Controller('chat')
 export class ChatController {
   constructor(private readonly chatService: ChatService) {}

--- a/backend/src/modules/userModules/chat/chat.repository.ts
+++ b/backend/src/modules/userModules/chat/chat.repository.ts
@@ -171,6 +171,42 @@ export class ChatRepository {
     return roomInfo.last_chat.toString();
   }
 
+  async findLastChatByRoomId(roomId: string): Promise<ChatMessage> {
+    return (
+      await this.roomModel.findOne({ group_id: roomId }, { last_chat: 1, _id: 0 }).populate({
+        path: 'last_chat',
+        model: 'ChatMessage',
+        select: { _id: 1, chat_message: 1, chat_date: 1 },
+      })
+    ).last_chat;
+  }
+
+  async countChatInRoomBetweenLogIds(
+    roomId: string,
+    startId: string,
+    endId: string
+  ): Promise<number> {
+    const [minId, maxId] = startId < endId ? [startId, endId] : [endId, startId];
+
+    const res = await this.roomModel.findOne(
+      {
+        group_id: roomId,
+        chat_list: {
+          $elemMatch: {
+            $gt: minId,
+            $lte: maxId,
+          },
+        },
+      },
+      { chat_list: 1, _id: 0 }
+    );
+    if (!res) {
+      return 0;
+    }
+
+    return res.chat_list.length;
+  }
+
   async updateLastChatLogId(userId: string, lastChatLogId: string) {
     await this.chatUserModel.updateOne(
       {

--- a/backend/src/modules/userModules/user/dtos/uesrs.rooms.details.dto.ts
+++ b/backend/src/modules/userModules/user/dtos/uesrs.rooms.details.dto.ts
@@ -1,6 +1,6 @@
 import { UsersRoomsGroupDto } from '@user/dtos/users.rooms.group.dto';
 
-export class UsersRoomsResponseDto extends UsersRoomsGroupDto {
+export class UsersRoomsDetailsDto extends UsersRoomsGroupDto {
   lastChatMessage: string;
   lastChatTime: Date;
   hasNewChat: boolean;

--- a/backend/src/modules/userModules/user/dtos/uesrs.rooms.response.dto.ts
+++ b/backend/src/modules/userModules/user/dtos/uesrs.rooms.response.dto.ts
@@ -1,0 +1,27 @@
+import { UsersRoomsGroupDto } from '@user/dtos/users.rooms.group.dto';
+
+export class UsersRoomsResponseDto extends UsersRoomsGroupDto {
+  lastChatMessage: string;
+  lastChatTime: Date;
+  hasNewChat: boolean;
+  newChatCount: number;
+
+  constructor({
+    themeId,
+    themeName,
+    posterImageUrl,
+    branchName,
+    groupId,
+    recruitmentContent,
+    lastChatMessage,
+    lastChatTime,
+    hasNewChat,
+    newChatCount,
+  }) {
+    super({ themeId, themeName, posterImageUrl, branchName, groupId, recruitmentContent });
+    this.lastChatMessage = lastChatMessage;
+    this.lastChatTime = lastChatTime;
+    this.hasNewChat = hasNewChat;
+    this.newChatCount = newChatCount;
+  }
+}

--- a/backend/src/modules/userModules/user/dtos/users.rooms.group.dto.ts
+++ b/backend/src/modules/userModules/user/dtos/users.rooms.group.dto.ts
@@ -1,4 +1,4 @@
-export class UsersRoomsResponseDto {
+export class UsersRoomsGroupDto {
   themeId: number;
   themeName: string;
   posterImageUrl: string;

--- a/backend/src/modules/userModules/user/dtos/users.rooms.response.dto.ts
+++ b/backend/src/modules/userModules/user/dtos/users.rooms.response.dto.ts
@@ -1,0 +1,15 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { PaginationMetaDto } from '@src/dtos/pagination.meta.dto';
+import { UsersRoomsDetailsDto } from '@user/dtos/uesrs.rooms.details.dto';
+
+export class UsersRoomsResponseDto {
+  @ApiProperty({ type: PaginationMetaDto })
+  _meta: PaginationMetaDto;
+  @ApiProperty({ type: [UsersRoomsDetailsDto] })
+  data: UsersRoomsDetailsDto[];
+
+  constructor(restCount: number, nextCursorGroupId: number, data: UsersRoomsDetailsDto[]) {
+    this._meta = new PaginationMetaDto(restCount, nextCursorGroupId);
+    this.data = data;
+  }
+}

--- a/backend/src/modules/userModules/user/user.controller.ts
+++ b/backend/src/modules/userModules/user/user.controller.ts
@@ -1,12 +1,13 @@
 import {
   Body,
   Controller,
-  Param,
   Get,
-  Req,
-  UseGuards,
+  Param,
   Patch,
+  Query,
+  Req,
   UnauthorizedException,
+  UseGuards,
 } from '@nestjs/common';
 import { TokenAuthGuard } from '@auth/auth.guard';
 import { UserService } from '@user/user.service';
@@ -22,8 +23,9 @@ import {
   ApiTags,
   ApiUnauthorizedResponse,
 } from '@nestjs/swagger';
-import { UsersRoomsGroupDto } from '@user/dtos/users.rooms.group.dto';
 import { UserInfoResponseDto } from '@user/dtos/userInfo.response.dto';
+import { GroupsPaginationCursorDto } from '@group/dtos/group.pagination.cursor.dto';
+import { UsersRoomsResponseDto } from '@user/dtos/users.rooms.response.dto';
 
 @ApiTags('users')
 @Controller('users')
@@ -108,10 +110,13 @@ export class UserController {
   @ApiOkResponse({
     status: 200,
     description: '',
-    type: [UsersRoomsGroupDto],
+    type: UsersRoomsResponseDto,
   })
   @ApiBearerAuth('Authorization')
-  async findGroupsByNickname(@Req() { user }): Promise<UsersRoomsGroupDto[]> {
-    return await this.userService.getGroupsByNickname(user.nickname);
+  async findGroupsByNickname(
+    @Req() { user },
+    @Query() paginationCursorDto: GroupsPaginationCursorDto
+  ): Promise<UsersRoomsResponseDto> {
+    return await this.userService.getGroupsByNickname(user.nickname, paginationCursorDto);
   }
 }

--- a/backend/src/modules/userModules/user/user.controller.ts
+++ b/backend/src/modules/userModules/user/user.controller.ts
@@ -22,7 +22,7 @@ import {
   ApiTags,
   ApiUnauthorizedResponse,
 } from '@nestjs/swagger';
-import { UsersRoomsResponseDto } from '@user/dtos/users.rooms.response.dto';
+import { UsersRoomsGroupDto } from '@user/dtos/users.rooms.group.dto';
 import { UserInfoResponseDto } from '@user/dtos/userInfo.response.dto';
 
 @ApiTags('users')
@@ -108,10 +108,10 @@ export class UserController {
   @ApiOkResponse({
     status: 200,
     description: '',
-    type: [UsersRoomsResponseDto],
+    type: [UsersRoomsGroupDto],
   })
   @ApiBearerAuth('Authorization')
-  async findGroupsByNickname(@Req() { user }): Promise<UsersRoomsResponseDto[]> {
+  async findGroupsByNickname(@Req() { user }): Promise<UsersRoomsGroupDto[]> {
     return await this.userService.getGroupsByNickname(user.nickname);
   }
 }

--- a/backend/src/modules/userModules/user/user.service.ts
+++ b/backend/src/modules/userModules/user/user.service.ts
@@ -13,9 +13,11 @@ import { ThemeRepository } from '@theme/theme.repository';
 import { GenreRepository } from '@theme/genre.repository';
 import { UsersRoomsGroupDto } from '@user/dtos/users.rooms.group.dto';
 import { ChatRepository } from '@chat/chat.repository';
-import { UsersRoomsResponseDto } from '@user/dtos/uesrs.rooms.response.dto';
+import { UsersRoomsDetailsDto } from '@user/dtos/uesrs.rooms.details.dto';
 import { ChatMessage } from '@chat/entities/chat.message.schema';
 import { ChatUser } from '@chat/entities/chat.user.schema';
+import { GroupsPaginationCursorDto } from '@group/dtos/group.pagination.cursor.dto';
+import { UsersRoomsResponseDto } from '@user/dtos/users.rooms.response.dto';
 
 @Injectable()
 export class UserService {
@@ -102,46 +104,55 @@ export class UserService {
     return result;
   }
 
-  async getGroupsByNickname(nickname: string): Promise<any> {
-    const usersRoomsResponseDto: UsersRoomsGroupDto[] =
-      await this.userGroupRepository.findGroupsByNickname(nickname);
+  async getGroupsByNickname(
+    nickname: string,
+    paginationDto: GroupsPaginationCursorDto
+  ): Promise<any> {
+    const { count, dtos: usersRoomsDtos } = await this.userGroupRepository.findGroupsByNickname(
+      nickname,
+      paginationDto
+    );
 
-    return await Promise.all(
-      usersRoomsResponseDto.map(
-        async (userRoom: UsersRoomsGroupDto): Promise<UsersRoomsResponseDto> => {
-          const roomId: string = String(userRoom.groupId);
+    const usersRoomsDetailsDtos: UsersRoomsDetailsDto[] = await Promise.all(
+      usersRoomsDtos.map(async (userRoom: UsersRoomsGroupDto): Promise<UsersRoomsDetailsDto> => {
+        const roomId: string = String(userRoom.groupId);
 
-          const lastChat: ChatMessage = await this.chatRepository.findLastChatByRoomId(roomId);
-          const userInRoom: ChatUser = await this.chatRepository.validateRoomAndGetChatUser(
-            String(userRoom.groupId),
-            String(nickname)
-          );
+        const lastChat: ChatMessage = await this.chatRepository.findLastChatByRoomId(roomId);
+        const userInRoom: ChatUser = await this.chatRepository.validateRoomAndGetChatUser(
+          String(userRoom.groupId),
+          String(nickname)
+        );
 
-          if (!userInRoom.last_chat_log_id) {
-            return new UsersRoomsResponseDto({
-              ...userRoom,
-              lastChatMessage: lastChat.chat_message,
-              lastChatTime: lastChat.chat_date,
-              hasNewChat: false,
-              newChatCount: 0,
-            });
-          }
-
-          const unreadCount: number = await this.chatRepository.countChatInRoomBetweenLogIds(
-            roomId,
-            userInRoom.last_chat_log_id,
-            lastChat._id
-          );
-
-          return new UsersRoomsResponseDto({
+        if (!userInRoom.last_chat_log_id) {
+          return new UsersRoomsDetailsDto({
             ...userRoom,
             lastChatMessage: lastChat.chat_message,
             lastChatTime: lastChat.chat_date,
-            hasNewChat: userInRoom.last_chat_log_id.toString() !== lastChat._id.toString(),
-            newChatCount: unreadCount,
+            hasNewChat: false,
+            newChatCount: 0,
           });
         }
-      )
+
+        const unreadCount: number = await this.chatRepository.countChatInRoomBetweenLogIds(
+          roomId,
+          userInRoom.last_chat_log_id,
+          lastChat._id
+        );
+
+        return new UsersRoomsDetailsDto({
+          ...userRoom,
+          lastChatMessage: lastChat.chat_message,
+          lastChatTime: lastChat.chat_date,
+          hasNewChat: userInRoom.last_chat_log_id.toString() !== lastChat._id.toString(),
+          newChatCount: unreadCount,
+        });
+      })
     );
+
+    const restCount: number = Math.max(count - paginationDto.count, 0);
+    const nextCursor: number | undefined =
+      restCount > 0 ? usersRoomsDetailsDtos[usersRoomsDetailsDtos.length - 1].groupId : undefined;
+
+    return new UsersRoomsResponseDto(restCount, nextCursor, usersRoomsDetailsDtos);
   }
 }

--- a/backend/src/modules/userModules/user/user.service.ts
+++ b/backend/src/modules/userModules/user/user.service.ts
@@ -119,8 +119,8 @@ export class UserService {
 
         const lastChat: ChatMessage = await this.chatRepository.findLastChatByRoomId(roomId);
         const userInRoom: ChatUser = await this.chatRepository.validateRoomAndGetChatUser(
-          String(userRoom.groupId),
-          String(nickname)
+          roomId,
+          nickname
         );
 
         if (!userInRoom.last_chat_log_id) {

--- a/backend/src/modules/userModules/user/userGroup.repository.ts
+++ b/backend/src/modules/userModules/user/userGroup.repository.ts
@@ -2,7 +2,7 @@ import { Injectable } from '@nestjs/common';
 import { DataSource, Repository } from 'typeorm';
 import { UserGroup } from '@user/entities/userGroup.entity';
 import { User } from '@user/entities/user.entity';
-import { UsersRoomsResponseDto } from '@user/dtos/users.rooms.response.dto';
+import { UsersRoomsGroupDto } from '@user/dtos/users.rooms.group.dto';
 
 @Injectable()
 export class UserGroupRepository extends Repository<UserGroup> {
@@ -13,7 +13,7 @@ export class UserGroupRepository extends Repository<UserGroup> {
   async findUserGroupsByNicknameAndGroupId(
     nickname: string,
     groupIds: number[]
-  ): Promise<UsersRoomsResponseDto[]> {
+  ): Promise<UsersRoomsGroupDto[]> {
     return await this.dataSource
       .createQueryBuilder()
       .select('user_group.group_id as groupId')
@@ -52,7 +52,7 @@ export class UserGroupRepository extends Repository<UserGroup> {
       .getRawMany();
 
     return rawDatas.map((data) => {
-      return new UsersRoomsResponseDto(data);
+      return new UsersRoomsGroupDto(data);
     });
   }
 }


### PR DESCRIPTION
## 🤷‍♂️ Description
채팅방 리스트 반환 API에 채팅 정보를 추가하고 커서 기반 페이지네이션을 구현해요.
```http
GET /users/rooms
```

<!-- 구현 한 기능에 대해 작성해 주세요. -->

## 📝 Primary Commits

<!-- 세부 구현 사항을 리스트로 작성해주세요. -->

- [X] 서비스 로직에 채팅 정보를 불러오는 로직 추가
  - 각 채팅방 별로 아래의 쿼리들이 실행
    - 채팅방의 마지막 메세지 읽어오기
    - 채팅방에 속한 유저 객체 읽어오기
    - 채팅방 마지막 메세지와 채팅방에 속한 유저의 마지막 읽은 메세지 사이의 개수 읽어오기
    - 추후 한 번의 쿼리로 불러와서 매핑하는 구조로 개선되어야 할 것 같습니다..!
  - 최종
    ```ts
    const usersRoomsDetailsDtos: UsersRoomsDetailsDto[] =
      await Promise.all(
      usersRoomsDtos.map(async (userRoom: UsersRoomsGroupDto): Promise<UsersRoomsDetailsDto> => {
        const roomId: string = String(userRoom.groupId);

        const lastChat: ChatMessage = await this.chatRepository.findLastChatByRoomId(roomId);
        const userInRoom: ChatUser = await this.chatRepository.validateRoomAndGetChatUser(
          String(userRoom.groupId),
          String(nickname)
        );

        // 채팅방에 사용자가 참가중이라 마지막으로 읽은 채팅 id 값이 없는 경우 early return
        if (!userInRoom.last_chat_log_id) {
          return new UsersRoomsDetailsDto({
            ...userRoom,
            lastChatMessage: lastChat.chat_message,
            lastChatTime: lastChat.chat_date,
            hasNewChat: false,
            newChatCount: 0,
          });
        }

        const unreadCount: number = await this.chatRepository.countChatInRoomBetweenLogIds(
          roomId,
          userInRoom.last_chat_log_id,
          lastChat._id
        );

        return new UsersRoomsDetailsDto({
          ...userRoom,
          lastChatMessage: lastChat.chat_message,
          lastChatTime: lastChat.chat_date,
          hasNewChat: userInRoom.last_chat_log_id.toString() !== lastChat._id.toString(),
          newChatCount: unreadCount,
        });
      })
    );
    ```
- [X] 커서 기반 페이지네이션 구현
  - 정렬에 들어가는 요소를 커서로 사용해야하지만, 생성일과 groupId는 정렬 결과가 동일하여 groupId를 사용합니다.

## 📷 Screenshots
![image](https://github.com/boostcampwm2023/web03-LockFestival/assets/44056518/e9eaa5de-12ce-486d-9d29-2c72fb6d6a51)

<!--스크린샷으로 보여줄 수 있는 이미지가 있다면 첨부해주세요!-->

<!--BE의 경우 API 테스트 결과를 첨부해주세요-->

<!--마지막으로 이슈 생성 시 우측의 옵션들을 체크했는지 확인해주세요!-->

<!-- 이슈번호를 작성해주세요. -->
<!-- 여러 이슈를 입력시 comma(,) 단위로 구분해주세요 -->
<!-- ex) close #10, resolves #123 -->


<!-- ex) -->
<!-- closes #1 --> 
closes #272
