### PR TITLE
Feature/FE/#281 채팅방 디자인 변경

### DIFF
--- a/frontend/src/pages/ChatRoom/components/ChatPanel/ChatPanel.tsx
+++ b/frontend/src/pages/ChatRoom/components/ChatPanel/ChatPanel.tsx
@@ -46,6 +46,10 @@ const ChatPanel = ({ roomId, sendChat, getPastChat }: ChatPanelProps) => {
   };
 
   const handleSubmit = () => {
+    if (inputValue === '') {
+      return;
+    }
+
     sendChat(inputValue);
     resetValue();
   };
@@ -139,9 +143,22 @@ const ButtonWrapper = styled.div([
 ]);
 
 const ChatDisplayContainer = styled.div([
-  tw`w-[100%] h-[100%] bg-white rounded-[2rem] font-pretendard text-l p-4`,
+  tw`w-[100%] h-[100%] bg-white rounded-[1rem] font-pretendard text-l pt-4 pb-4 pl-4 pr-2`,
   css`
     overflow-y: scroll;
+
+    ::-webkit-scrollbar {
+      width: 1rem;
+    }
+    ::-webkit-scrollbar-thumb {
+      background-color: #d2dad0;
+      border-radius: 10px;
+    }
+    ::-webkit-scrollbar-track {
+      background-color: #222222;
+      border-radius: 10px;
+      box-shadow: inset 0px 0px 5px white;
+    }
   `,
 ]);
 

--- a/frontend/src/pages/ChatRoom/components/ChatPanel/MessageBox/BoxType/MyChatBox.tsx
+++ b/frontend/src/pages/ChatRoom/components/ChatPanel/MessageBox/BoxType/MyChatBox.tsx
@@ -1,0 +1,54 @@
+import { getTimeByDate } from '@utils/dateUtil';
+import tw, { css, styled } from 'twin.macro';
+
+interface BoxProps {
+  message: string;
+  time: Date;
+}
+
+const MyChatBox = ({ message, time }: BoxProps) => {
+  return (
+    <Container>
+      <TextContainer>
+        <DateContent>{getTimeByDate(new Date(time))}</DateContent>
+        <MessageContent>{message}</MessageContent>
+      </TextContainer>
+    </Container>
+  );
+};
+
+const Container = styled.div([
+  tw`w-full my-2`,
+  css`
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+    justify-content: center;
+  `,
+]);
+
+const TextContainer = styled.div([
+  css`
+    display: flex;
+    align-items: flex-end;
+    gap: 0.6rem;
+  `,
+]);
+
+const DateContent = styled.div([
+  tw`text-xs pb-[0.2rem]`,
+  css`
+    height: inherit;
+  `,
+]);
+
+const MessageContent = styled.div([
+  tw`border border-gray border-solid rounded-[1.2rem] px-2 py-1`,
+  css`
+    max-width: 25rem;
+    width: fit-content;
+    word-break: break-all;
+  `,
+]);
+
+export default MyChatBox;

--- a/frontend/src/pages/ChatRoom/components/ChatPanel/MessageBox/BoxType/OtherChatBox.tsx
+++ b/frontend/src/pages/ChatRoom/components/ChatPanel/MessageBox/BoxType/OtherChatBox.tsx
@@ -1,0 +1,83 @@
+import { getTimeByDate } from '@utils/dateUtil';
+import { FaCircleUser } from 'react-icons/fa6';
+import tw, { css, styled } from 'twin.macro';
+
+interface BoxProps {
+  nickname: string;
+  profileImg: string;
+  message: string;
+  time: Date;
+}
+
+const OtherChatBox = ({ message, time, profileImg, nickname }: BoxProps) => {
+  return (
+    <Container>
+      <ProfileContainer>
+        {profileImg ? (
+          <ProfileImg src={profileImg} alt="profileImg" />
+        ) : (
+          <FaCircleUser size="30" color="gray" />
+        )}
+        <ProfileText>{nickname}</ProfileText>
+      </ProfileContainer>
+      <TextContainer>
+        <MessageContent>{message}</MessageContent>
+        <DateContent>{getTimeByDate(new Date(time))}</DateContent>
+      </TextContainer>
+    </Container>
+  );
+};
+
+const Container = styled.div([
+  tw`w-full my-2`,
+  css`
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+  `,
+]);
+
+const ProfileContainer = styled.div([
+  tw`mb-1`,
+  css`
+    display: flex;
+    align-items: center;
+  `,
+]);
+
+const ProfileImg = styled.img([
+  tw`border border-gray border-solid`,
+  css`
+    width: 3rem;
+    height: 3rem;
+    border-radius: 50%;
+  `,
+]);
+
+const ProfileText = styled.div([tw`text-m px-1`]);
+
+const TextContainer = styled.div([
+  css`
+    display: flex;
+    align-items: flex-end;
+    gap: 0.6rem;
+  `,
+]);
+
+const DateContent = styled.div([
+  tw`text-xs pb-[0.2rem]`,
+  css`
+    height: inherit;
+  `,
+]);
+
+const MessageContent = styled.div([
+  tw`border border-gray border-solid rounded-[1.2rem] px-2 py-1`,
+  css`
+    max-width: 25rem;
+    width: fit-content;
+    word-break: break-all;
+  `,
+]);
+
+export default OtherChatBox;

--- a/frontend/src/pages/ChatRoom/components/ChatPanel/MessageBox/BoxType/SystemChatBox.tsx
+++ b/frontend/src/pages/ChatRoom/components/ChatPanel/MessageBox/BoxType/SystemChatBox.tsx
@@ -1,0 +1,42 @@
+import tw, { css, styled } from 'twin.macro';
+
+interface BoxProps {
+  message: string;
+}
+
+const SystemChatBox = ({ message }: BoxProps) => {
+  return (
+    <Container>
+      <TextContainer>
+        <MessageContent>{message}</MessageContent>
+      </TextContainer>
+    </Container>
+  );
+};
+
+const Container = styled.div([
+  tw`w-full my-2`,
+  css`
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+  `,
+]);
+
+const TextContainer = styled.div([
+  css`
+    display: flex;
+    align-items: center;
+    gap: 0.6rem;
+  `,
+]);
+
+const MessageContent = styled.div([
+  tw`w-full border border-gray border-solid rounded-[1.2rem] px-2 py-2 bg-gray-light text-white-60`,
+  css`
+    text-align: center;
+    word-break: break-all;
+  `,
+]);
+
+export default SystemChatBox;

--- a/frontend/src/pages/ChatRoom/components/ChatPanel/MessageBox/MessageBox.tsx
+++ b/frontend/src/pages/ChatRoom/components/ChatPanel/MessageBox/MessageBox.tsx
@@ -1,4 +1,4 @@
-import tw, { styled, css } from 'twin.macro';
+import { styled, css } from 'twin.macro';
 import { ChatLog } from 'types/chat';
 import { userListInfoAtom } from '@store/chatRoom';
 import { useRecoilValue } from 'recoil';

--- a/frontend/src/pages/ChatRoom/components/ChatPanel/MessageBox/MessageBox.tsx
+++ b/frontend/src/pages/ChatRoom/components/ChatPanel/MessageBox/MessageBox.tsx
@@ -2,7 +2,9 @@ import tw, { styled, css } from 'twin.macro';
 import { ChatLog } from 'types/chat';
 import { userListInfoAtom } from '@store/chatRoom';
 import { useRecoilValue } from 'recoil';
-import { getStringByDate, getTimeByDate } from '@utils/dateUtil';
+import MyChatBox from './BoxType/MyChatBox';
+import OtherChatBox from './BoxType/OtherChatBox';
+import SystemChatBox from './BoxType/SystemChatBox';
 
 const MessageBox = ({ message, userId, type, time }: ChatLog) => {
   const userData = useRecoilValue(userListInfoAtom);
@@ -11,46 +13,21 @@ const MessageBox = ({ message, userId, type, time }: ChatLog) => {
     isMe: false,
     profileImg: '',
   };
-
   const { nickname, isMe, profileImg } = myData;
 
   // 같은 년 월 일, 시각 분, 사용자가 같으면 하나의 nickname만
 
   return (
     <Layout type={type} isMe={isMe}>
-      {type === 'message' &&
-        (isMe ? (
-          <ProfileContainer>
-            <div>{nickname}</div>
-            <ProfileImg src={profileImg} alt="사용자 프로필" />
-          </ProfileContainer>
-        ) : (
-          <ProfileContainer>
-            <ProfileImg src={profileImg} alt="사용자 프로필" />
-            <div>{nickname}</div>
-          </ProfileContainer>
-        ))}
-
-      {isMe ? (
-        <MessageLayout type={type}>
-          <DateContent>
-            {getStringByDate(new Date(time))} {getTimeByDate(new Date(time))}
-          </DateContent>
-          <MessageContent type={type}>{message}</MessageContent>
-        </MessageLayout>
+      {type !== 'message' && <SystemChatBox message={message} />}
+      {type === 'message' && isMe ? (
+        <MyChatBox message={message} time={time} />
       ) : (
-        <MessageLayout type={type}>
-          <MessageContent type={type}>{message}</MessageContent>
-          <DateContent>
-            {getStringByDate(new Date(time))} {getTimeByDate(new Date(time))}
-          </DateContent>
-        </MessageLayout>
+        <OtherChatBox message={message} time={time} nickname={nickname} profileImg={profileImg} />
       )}
     </Layout>
   );
 };
-
-export default MessageBox;
 
 const Layout = styled.div<{ isMe: boolean; type: string }>(({ isMe, type }) => [
   css`
@@ -60,38 +37,4 @@ const Layout = styled.div<{ isMe: boolean; type: string }>(({ isMe, type }) => [
   `,
 ]);
 
-const MessageLayout = styled.div<{ type: string }>(({ type }) => [
-  css`
-    display: flex;
-
-    margin-bottom: 1rem;
-  `,
-  tw`font-pretendard text-m mt-1`,
-]);
-
-const MessageContent = styled.div<{ type: string }>(({ type }) => [
-  tw`border border-gray border-solid rounded-[2rem] px-2 py-1`,
-  css`
-    background-color: ${type === 'message' ? 'transparent' : 'yellow'};
-    max-width: ${type === 'message' && '25rem'};
-    width: ${type === 'message' ? 'fit-content' : '100%'};
-    word-break: break-all;
-  `,
-]);
-
-const ProfileContainer = styled.div([
-  css`
-    display: flex;
-    align-items: center;
-    gap: 0.6rem;
-  `,
-]);
-
-const DateContent = styled.div([
-  css`
-    display: flex;
-    align-items: flex-end;
-  `,
-]);
-
-const ProfileImg = styled.img([tw`w-[2rem] h-[2rem] rounded-[50%]`]);
+export default MessageBox;


### PR DESCRIPTION
## 🤷‍♂️ Description
채팅에 빈 값을 입력했을 때 전송 이벤트를 막았어요.

채팅방 디자인을 변경했어요.

참고사항
- 기존 채팅방 내부에 좌우상하 전부 padding이 16px이였는데 우측의 경우 스크롤도 있기 때문에 우측 padding을 8px 정도로 줄였습니다!






<!-- 구현 한 기능에 대해 작성해 주세요. -->

## 📝 Primary Commits

<!-- 세부 구현 사항을 리스트로 작성해주세요. -->

- [X] 빈 값 전송 이벤트 막기
- [X] 채팅방 디자인 변경

## 📷 Screenshots

- 이전
<img width="794" alt="전" src="https://github.com/boostcampwm2023/web03-LockFestival/assets/100738049/e3eb95bd-d6ec-42d8-bc8a-3900351d08bf">


- 이후

![녹화_2023_12_05_18_08_38_292](https://github.com/boostcampwm2023/web03-LockFestival/assets/100738049/24c16b3e-46b6-47c0-98db-19505d1036e6)


<!--스크린샷으로 보여줄 수 있는 이미지가 있다면 첨부해주세요!-->

<!--BE의 경우 API 테스트 결과를 첨부해주세요-->

<!--마지막으로 이슈 생성 시 우측의 옵션들을 체크했는지 확인해주세요!-->

<!-- 이슈번호를 작성해주세요. -->
<!-- 여러 이슈를 입력시 comma(,) 단위로 구분해주세요 -->
<!-- ex) close #10, resolves #123 -->


<!-- ex) -->
<!-- closes #1 --> 
closes #281

