### PR TITLE
Feature/FE/#277: 검색페이지 카드 컴포넌트 UI 마크업

### DIFF
--- a/frontend/src/components/Modal/MakeGroupModal/MakeGroupModal.tsx
+++ b/frontend/src/components/Modal/MakeGroupModal/MakeGroupModal.tsx
@@ -9,14 +9,19 @@ import ReservationContainer from './FormElement/ReservationContainer';
 import MemberCountContainer from './FormElement/MemberCountContainer';
 import SelectThemeForm from './FormElement/SelectThemeForm';
 
-import useCreateRecruitmentForm from '@hooks/useCreateRecruitmentForm';
+import useCreateRecruitmentForm, { Theme } from '@hooks/useCreateRecruitmentForm';
 
 import createRecruitment from '@apis/createRecruitment';
 
 import Button from '@components/Button/Button';
 import { FaXmark } from 'react-icons/fa6';
 
-const MakeGroupModal = ({ onClose }: { onClose: () => void }) => {
+interface Props {
+  selectedTheme?: Theme;
+  onClose: () => void;
+}
+
+const MakeGroupModal = ({ selectedTheme, onClose }: Props) => {
   const navigate = useNavigate();
 
   const {
@@ -33,7 +38,7 @@ const MakeGroupModal = ({ onClose }: { onClose: () => void }) => {
     isReservation,
     setIsReservation,
     checkValidate,
-  } = useCreateRecruitmentForm();
+  } = useCreateRecruitmentForm({ selectedTheme });
 
   const handleCreateRoom = async () => {
     if (!checkValidate) {

--- a/frontend/src/hooks/useCreateRecruitmentForm.tsx
+++ b/frontend/src/hooks/useCreateRecruitmentForm.tsx
@@ -9,13 +9,13 @@ export interface Theme {
   themeName: string;
 }
 
-const useCreateRecruitmentForm = () => {
+const useCreateRecruitmentForm = ({ selectedTheme }: { selectedTheme?: Theme }) => {
   const [isClickCalendar, setIsClickCalendar] = useState<boolean>(false);
   const [date, setDate] = useState<Value>(new Date());
 
   const [memberCount, setMemberCount] = useState<string>('2');
 
-  const [theme, setTheme] = useState<Theme>();
+  const [theme, setTheme] = useState<Theme | undefined>(selectedTheme || undefined);
 
   const [contents, setContents] = useInput('');
 

--- a/frontend/src/pages/Search/components/Card.tsx
+++ b/frontend/src/pages/Search/components/Card.tsx
@@ -1,0 +1,69 @@
+import { ThemeDetailsData } from 'types/theme';
+import tw, { styled, css } from 'twin.macro';
+import HeadCard from './Card/HeadCard/HeadCard';
+import TailCard from './Card/TailCard/TailCard';
+import { useState } from 'react';
+
+const Card = ({ theme }: { theme: Omit<ThemeDetailsData, 'otherThemes'> }) => {
+  const [isHead, setIsHead] = useState<boolean>(true);
+
+  const {
+    themeName,
+    themeId,
+    brandBranchName,
+    realGenre,
+    posterImageUrl,
+    difficulty,
+    minMember,
+    maxMember,
+    playTime,
+    website,
+    phone,
+    address,
+  } = theme;
+
+  const handleClickFlipButton = () => {
+    setIsHead((prev) => !prev);
+  };
+
+  return (
+    <Layout isHead={isHead}>
+      {isHead ? (
+        <HeadCard
+          themeId={themeId}
+          themeName={themeName}
+          posterImageUrl={posterImageUrl}
+          brandBranchName={brandBranchName}
+          handleClickFlipButton={handleClickFlipButton}
+        />
+      ) : (
+        <TailCard
+          brandBranchName={brandBranchName}
+          realGenre={realGenre}
+          difficulty={difficulty}
+          minMember={minMember}
+          maxMember={maxMember}
+          playTime={playTime}
+          website={website}
+          phone={phone}
+          address={address}
+          handleClickFlipButton={handleClickFlipButton}
+        />
+      )}
+    </Layout>
+  );
+};
+
+export default Card;
+
+const Layout = styled.div<{ isHead: boolean }>(({ isHead }) => [
+  tw`w-[48%] text-white bg-gray-light rounded-default p-4`,
+  css`
+    display: flex;
+    gap: 1.6rem;
+    position: relative;
+    transition: transform 0.3s;
+    transform: ${isHead ? 'perspective(50%) rotateY(0deg)' : 'perspective(50%) rotateY(180deg)'};
+    height: 28rem;
+  `,
+]);

--- a/frontend/src/pages/Search/components/Card/CardInfoLabel/CardInfoLabel.tsx
+++ b/frontend/src/pages/Search/components/Card/CardInfoLabel/CardInfoLabel.tsx
@@ -3,13 +3,13 @@ import tw, { styled, css } from 'twin.macro';
 
 interface Props {
   labelName: string;
-  labelContent: string;
+  labelContent: JSX.Element;
 }
 
-const CardInfo = ({ labelName, labelContent }: Props) => {
+const CardInfoLabel = ({ labelName, labelContent }: Props) => {
   return (
     <LabelWrapper>
-      <Label isBorder={false} size="l" width="8rem">
+      <Label isBorder={false} size="l" width="10rem">
         <Text>{labelName}</Text>
       </Label>
       <LabelContent>{labelContent}</LabelContent>
@@ -17,7 +17,7 @@ const CardInfo = ({ labelName, labelContent }: Props) => {
   );
 };
 
-export default CardInfo;
+export default CardInfoLabel;
 
 const LabelWrapper = styled.div([
   css`

--- a/frontend/src/pages/Search/components/Card/HeadCard/HeadCard.tsx
+++ b/frontend/src/pages/Search/components/Card/HeadCard/HeadCard.tsx
@@ -1,0 +1,88 @@
+import MakeGroupModal from '@components/Modal/MakeGroupModal/MakeGroupModal';
+import Modal from '@components/Modal/Modal';
+import useModal from '@hooks/useModal';
+import { useNavigate } from 'react-router-dom';
+import tw, { styled, css } from 'twin.macro';
+import CardInfoLabel from '../CardInfoLabel/CardInfoLabel';
+import UnderLineButton from '../UnderLineButton/UnderLineButton';
+
+interface Props {
+  themeId: number;
+  posterImageUrl: string;
+  brandBranchName: string;
+  themeName: string;
+  handleClickFlipButton: () => void;
+}
+
+const HeadCard = ({
+  themeId,
+  posterImageUrl,
+  brandBranchName,
+  themeName,
+  handleClickFlipButton,
+}: Props) => {
+  const navigate = useNavigate();
+  const { openModal, closeModal } = useModal();
+
+  const handleGoRecruitment = () => {
+    navigate('/recruitment');
+  };
+
+  const handleCreateRoom = () => {
+    const selectedTheme = {
+      themeId,
+      posterImageUrl,
+      branchName: brandBranchName.split(' ')[0],
+      themeName,
+    };
+
+    openModal(Modal, {
+      children: <MakeGroupModal selectedTheme={selectedTheme} onClose={() => closeModal(Modal)} />,
+      onClose: () => closeModal(Modal),
+      closeOnExternalClick: false,
+    });
+  };
+
+  return (
+    <>
+      <LeftSection>
+        <ThemeImg src={posterImageUrl} alt="테마_이미지" />
+      </LeftSection>
+      <RightSection>
+        <CardInfoLabel labelName="지점" labelContent={<>{brandBranchName}</>} />
+        <CardInfoLabel labelName="테마명" labelContent={<>{themeName}</>} />
+        <ButtonWrapper
+          onMouseDown={(e: React.MouseEvent) => {
+            e.preventDefault();
+          }}
+        >
+          <UnderLineButton children={<>모집 바로가기</>} onClick={handleGoRecruitment} />
+          <UnderLineButton children={<>방 생성하기</>} onClick={handleCreateRoom} />
+          <UnderLineButton children={<>상세보기</>} onClick={handleClickFlipButton} />
+        </ButtonWrapper>
+      </RightSection>
+    </>
+  );
+};
+
+export default HeadCard;
+
+const LeftSection = styled.div([tw`w-[40%] bg-gray-dark rounded-default p-3`]);
+const ThemeImg = styled.img([tw`w-[100%] rounded-default`]);
+const RightSection = styled.div([
+  css`
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    gap: 1.6rem;
+    padding-top: 14%;
+  `,
+]);
+
+const ButtonWrapper = styled.div([
+  css`
+    display: flex;
+    gap: 1.6rem;
+    margin-top: 15%;
+  `,
+]);

--- a/frontend/src/pages/Search/components/Card/TailCard/TailCard.tsx
+++ b/frontend/src/pages/Search/components/Card/TailCard/TailCard.tsx
@@ -1,0 +1,95 @@
+import { styled, css } from 'twin.macro';
+import { ThemeExtraData } from 'types/theme';
+import UnderLineButton from '../UnderLineButton/UnderLineButton';
+import CardInfoLabel from '../CardInfoLabel/CardInfoLabel';
+import { useNavigate } from 'react-router-dom';
+
+interface Props extends Omit<ThemeExtraData, 'otherThemes'> {
+  handleClickFlipButton: () => void;
+}
+
+const TailCard = ({
+  brandBranchName,
+  realGenre,
+  difficulty,
+  minMember,
+  maxMember,
+  playTime,
+  website,
+  phone,
+  address,
+  handleClickFlipButton,
+}: Props) => {
+  const navigate = useNavigate();
+  return (
+    <Layout>
+      <CardInfoLabel labelName="전화번호" labelContent={<>{phone}</>} />
+      <CardInfoLabel labelName="주소" labelContent={<>{address}</>} />
+      <CardInfoLabel
+        labelName="홈페이지"
+        labelContent={
+          <UnderLineButton
+            children={<>{brandBranchName} 바로가기</>}
+            onClick={() => navigate(website)}
+          />
+        }
+      />
+      <CardInfoContainer>
+        <CardInfoWrapper>
+          <CardInfoLabel
+            labelName="인원"
+            labelContent={
+              <>
+                {minMember} - {maxMember} 명
+              </>
+            }
+          />
+          <CardInfoLabel labelName="플레이타임" labelContent={<>{playTime}분</>} />
+        </CardInfoWrapper>
+        <CardInfoWrapper>
+          <CardInfoLabel labelName="장르" labelContent={<>{realGenre}</>} />
+          <CardInfoLabel labelName="난이도" labelContent={<>{difficulty}</>} />
+        </CardInfoWrapper>
+      </CardInfoContainer>
+      <ButtonWrapper>
+        <UnderLineButton children={<>상세보기</>} onClick={handleClickFlipButton} />
+      </ButtonWrapper>
+    </Layout>
+  );
+};
+
+export default TailCard;
+
+const Layout = styled.div([
+  css`
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    gap: 1.5rem;
+    width: 100%;
+  `,
+]);
+
+const CardInfoContainer = styled.div([
+  css`
+    display: flex;
+    gap: 1.6rem;
+  `,
+]);
+
+const CardInfoWrapper = styled.div([
+  css`
+    display: flex;
+    flex-direction: column;
+    gap: 1.6rem;
+  `,
+]);
+
+const ButtonWrapper = styled.div([
+  css`
+    position: absolute;
+    right: 1.2rem;
+    bottom: 1.2rem;
+  `,
+]);

--- a/frontend/src/pages/Search/components/Card/UnderLineButton/UnderLineButton.tsx
+++ b/frontend/src/pages/Search/components/Card/UnderLineButton/UnderLineButton.tsx
@@ -1,0 +1,34 @@
+import tw, { styled, css } from 'twin.macro';
+
+interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  children: JSX.Element;
+  onClick?: () => void;
+}
+
+const UnderLineButton = ({ children, onClick }: ButtonProps) => {
+  return <UnderlineButton onClick={onClick}>{children}</UnderlineButton>;
+};
+
+export default UnderLineButton;
+
+const UnderlineButton = styled.button([
+  tw`font-pretendard text-l text-white bg-transparent`,
+  css`
+    cursor: pointer;
+
+    :after {
+      display: block;
+      content: '';
+      border-bottom: solid 2px white;
+      transform: scale(0);
+      transition: transform 250ms ease-in-out;
+    }
+
+    :hover:after {
+      transform: scaleX(1);
+    }
+    :after {
+      transform-origin: top left;
+    }
+  `,
+]);

--- a/frontend/src/pages/Search/components/CardInfo.tsx
+++ b/frontend/src/pages/Search/components/CardInfo.tsx
@@ -1,0 +1,37 @@
+import Label from '@components/Label/Label';
+import tw, { styled, css } from 'twin.macro';
+
+interface Props {
+  labelName: string;
+  labelContent: string;
+}
+
+const CardInfo = ({ labelName, labelContent }: Props) => {
+  return (
+    <LabelWrapper>
+      <Label isBorder={false} size="l" width="8rem">
+        <Text>{labelName}</Text>
+      </Label>
+      <LabelContent>{labelContent}</LabelContent>
+    </LabelWrapper>
+  );
+};
+
+export default CardInfo;
+
+const LabelWrapper = styled.div([
+  css`
+    display: flex;
+    gap: 1.2rem;
+  `,
+]);
+
+const Text = styled.div([tw`m-auto`]);
+
+const LabelContent = styled.div([
+  tw`font-pretendard text-l text-white`,
+  css`
+    display: flex;
+    align-items: center;
+  `,
+]);

--- a/frontend/src/types/theme.ts
+++ b/frontend/src/types/theme.ts
@@ -4,7 +4,9 @@ export interface SimpleThemeCardData {
   posterImageUrl: string;
 }
 
-export interface ThemeDetailsData extends SimpleThemeCardData {
+export type ThemeDetailsData = SimpleThemeCardData & ThemeExtraData;
+
+export interface ThemeExtraData {
   brandBranchName: string;
   realGenre: string;
   difficulty: string;


### PR DESCRIPTION
## 🤷‍♂️ Description
- 검색 페이지에서 사용될 카드 컴포넌트를 만들었어요.
- 카드형 컴포넌트에서 자주 쓰이는 카드 정보 컴포넌트를 만들었어요, 리팩토링 할 때 전체에 적용해도 좋을 것 같아요.
- 애니메이션이 들어간 밑줄형 버튼 컴포넌트를 만들었어요. 
- 정석님의 카드 뒤집는 로직을 따라 썼는데, FlipCard 로 컴포넌트로 분리하면 좋을 것 같아요.

<!-- 구현 한 기능에 대해 작성해 주세요. -->

## 📝 Primary Commits

<!-- 세부 구현 사항을 리스트로 작성해주세요. -->

- [X] 카드 정보 컴포넌트 만들기
- [X] 밑줄형 버튼 만들기
- [X] 카드 앞면 컴포넌트 만들기
- [X] 카드 뒷면 컴포넌트 만들기
- [X] 카드 컴포넌트 만들기

## 📷 Screenshots

https://github.com/boostcampwm2023/web03-LockFestival/assets/82202370/f0b06914-8d42-472e-b4f5-49a5a86daaa7


<!--스크린샷으로 보여줄 수 있는 이미지가 있다면 첨부해주세요!-->

<!--BE의 경우 API 테스트 결과를 첨부해주세요-->

<!--마지막으로 이슈 생성 시 우측의 옵션들을 체크했는지 확인해주세요!-->

<!-- 이슈번호를 작성해주세요. -->
<!-- 여러 이슈를 입력시 comma(,) 단위로 구분해주세요 -->
<!-- ex) close #10, resolves #123 -->


<!-- ex) -->
<!-- closes #1 --> 

