### PR TITLE
Feature/BE/#285: 채팅 세션이 종료될 때 `unread`를 채팅방에 전송

### DIFF
--- a/backend/src/gateway/events.gateway.ts
+++ b/backend/src/gateway/events.gateway.ts
@@ -135,6 +135,8 @@ export class EventsGateway implements OnGatewayInit, OnGatewayConnection, OnGate
     delete this.socketsInrooms[roomId][client.id];
     delete this.socketToRoomId[client.id];
     await this.chatService.updateLastChatLogId(roomId, userId);
+
+    await this.server.to(roomId).emit('unread', await this.chatService.getUnreadCount(roomId));
   }
   afterInit(server: Server) {
     this.logger.log('Initialized!');

--- a/backend/src/modules/userModules/chat/chat.service.ts
+++ b/backend/src/modules/userModules/chat/chat.service.ts
@@ -24,28 +24,7 @@ export class ChatService {
       return isMe;
     });
 
-    const countMap: object = chatUsers
-      .filter((user: ChatUserInfoDto) => {
-        return !user.isMe && !!user.lastChatLogId;
-      })
-      .map(({ lastChatLogId }) => {
-        return lastChatLogId;
-      })
-      .reduce((acc, cur) => {
-        acc[cur] = acc[cur] ? acc[cur] + 1 : 1;
-        return acc;
-      }, {});
-
-    let count: number = 0;
-    const unreadCountMap = Object.entries(countMap)
-      .sort(([key1], [key2]) => {
-        return key1.localeCompare(key2);
-      })
-      .reduce((acc, [key, value]) => {
-        count += value;
-        acc[count] = key;
-        return acc;
-      }, {});
+    const unreadCountMap = this.makeUnreadCountMap(chatUsers);
 
     await this.chatRepository.updateRead(meUser.userId);
 
@@ -57,6 +36,37 @@ export class ChatService {
     });
 
     return { prevMessages, unreadCountMap, chatUsers };
+  }
+
+  async getUnreadCount(roomId: string) {
+    const chatUsers: ChatUserInfoDto[] = await this.chatRepository.findUserListByRoomId(roomId);
+
+    return this.makeUnreadCountMap(chatUsers);
+  }
+
+  private makeUnreadCountMap(chatUsers: ChatUserInfoDto[]) {
+    const countMap: { [k: string]: number } = chatUsers
+      .filter((user: ChatUserInfoDto) => {
+        return !!user.lastChatLogId;
+      })
+      .map(({ lastChatLogId }) => {
+        return lastChatLogId;
+      })
+      .reduce((acc, cur) => {
+        acc[cur] = acc[cur] ? acc[cur] + 1 : 1;
+        return acc;
+      }, {});
+
+    let count: number = 0;
+    return Object.entries(countMap)
+      .sort(([key1], [key2]) => {
+        return key1.localeCompare(key2);
+      })
+      .reduce((acc, [key, value]) => {
+        count += value;
+        acc[count] = key;
+        return acc;
+      }, {});
   }
 
   async validateLeader(roomId: string, userId: string) {


### PR DESCRIPTION
## 🤷‍♂️ Description
채팅 세션이 종료될 때(disconnect) 해당 채팅방에 `unread` 이벤트를 다시 보내서 안읽은 수를 갱신시켜줘요.

<!-- 구현 한 기능에 대해 작성해 주세요. -->

## 📝 Primary Commits

<!-- 세부 구현 사항을 리스트로 작성해주세요. -->

- [X] 기존 입장할 때 사용한 unreadCount를 계산하는 로직을 분리해서 함수로 사용했어요.
  - [X] DB 조회까지 포함하면 안되서 계산 로직은 함수로 분리하고, 디비 조회는 각 함수에서 진행해요.

## 📷 Screenshots

<!--스크린샷으로 보여줄 수 있는 이미지가 있다면 첨부해주세요!-->

<!--BE의 경우 API 테스트 결과를 첨부해주세요-->

<!--마지막으로 이슈 생성 시 우측의 옵션들을 체크했는지 확인해주세요!-->

<!-- 이슈번호를 작성해주세요. -->
<!-- 여러 이슈를 입력시 comma(,) 단위로 구분해주세요 -->
<!-- ex) close #10, resolves #123 -->


<!-- ex) -->
<!-- closes #1 --> 
closes #285
