### PR TITLE
Fix/BE/#291: 채팅방 리스트 조회 API에서 채팅방에 채팅이 없는 경우 에외처리 추가

### DIFF
--- a/backend/src/modules/userModules/user/user.service.ts
+++ b/backend/src/modules/userModules/user/user.service.ts
@@ -118,6 +118,17 @@ export class UserService {
         const roomId: string = String(userRoom.groupId);
 
         const lastChat: ChatMessage = await this.chatRepository.findLastChatByRoomId(roomId);
+
+        if (!lastChat) {
+          return new UsersRoomsDetailsDto({
+            ...userRoom,
+            lastChatMessage: '',
+            lastChatTime: '',
+            hasNewChat: false,
+            newChatCount: 0,
+          });
+        }
+
         const userInRoom: ChatUser = await this.chatRepository.validateRoomAndGetChatUser(
           roomId,
           nickname


### PR DESCRIPTION
## 🤷‍♂️ Description
현재 채팅방이 생성되고 채팅을 한 번도 입력하지 않으면 마지막 채팅이 비어있어서 에러가 발생해요.
이를 해결하기 위해 마지막 채팅이 없으면 early return 하도록 수정해요.

<!-- 구현 한 기능에 대해 작성해 주세요. -->

## 📝 Primary Commits

<!-- 세부 구현 사항을 리스트로 작성해주세요. -->

- [X] 채팅방의 마지막 채팅이 존재하지 않으면 비워서 반환하도록 추가
  ```ts
  const lastChat: ChatMessage = await this.chatRepository.findLastChatByRoomId(roomId);

  if (!lastChat) {
    return new UsersRoomsDetailsDto({
      ...userRoom,
      lastChatMessage: '',
      lastChatTime: '',
      hasNewChat: false,
      newChatCount: 0,
    });
  }
   ```

## 📷 Screenshots

<!--스크린샷으로 보여줄 수 있는 이미지가 있다면 첨부해주세요!-->

<!--BE의 경우 API 테스트 결과를 첨부해주세요-->

<!--마지막으로 이슈 생성 시 우측의 옵션들을 체크했는지 확인해주세요!-->

<!-- 이슈번호를 작성해주세요. -->
<!-- 여러 이슈를 입력시 comma(,) 단위로 구분해주세요 -->
<!-- ex) close #10, resolves #123 -->


<!-- ex) -->
<!-- closes #1 --> 
closes #291 
