### PR TITLE
Feature/BE/#288: 채팅방에서 중복으로 연결된 세션들을 검증하는 로직 추가

### DIFF
--- a/backend/src/modules/userModules/chat/chat.service.ts
+++ b/backend/src/modules/userModules/chat/chat.service.ts
@@ -39,7 +39,7 @@ export class ChatService {
       roomId,
     });
 
-    return { prevMessages, unreadCountMap, chatUsers };
+    return { prevMessages, unreadCountMap, chatUsers, meUser };
   }
 
   async getUnreadCount(roomId: string) {


### PR DESCRIPTION
## 🤷‍♂️ Description
채팅방에서 중복으로 연결된 세션들을 찾아서 있으면 `unread`와 `update` 가 발생하지 않도록 해요.

<!-- 구현 한 기능에 대해 작성해 주세요. -->

## 📝 Primary Commits

<!-- 세부 구현 사항을 리스트로 작성해주세요. -->

- [X] 입장(`join`)과 퇴장(`disconnect`)할 때 세션에 유저가 존재하는지 검증하는 로직을 추가했어요.
  ```ts

  ```

## 📷 Screenshots

<!--스크린샷으로 보여줄 수 있는 이미지가 있다면 첨부해주세요!-->

<!--BE의 경우 API 테스트 결과를 첨부해주세요-->

<!--마지막으로 이슈 생성 시 우측의 옵션들을 체크했는지 확인해주세요!-->

<!-- 이슈번호를 작성해주세요. -->
<!-- 여러 이슈를 입력시 comma(,) 단위로 구분해주세요 -->
<!-- ex) close #10, resolves #123 -->


<!-- ex) -->
<!-- closes #1 --> 

closes #288 