### PR TITLE
Feature/FE/#297: 채팅 날짜, 프로필, 시각 표시 중복 제거

### DIFF
--- a/frontend/src/pages/ChatRoom/components/ChatPanel/MessageBox/BoxType/MyChatBox.tsx
+++ b/frontend/src/pages/ChatRoom/components/ChatPanel/MessageBox/BoxType/MyChatBox.tsx
@@ -5,15 +5,16 @@ interface BoxProps {
   message: string;
   time: Date;
   unreadCount: number | undefined;
+  isLastChat: boolean;
 }
 
-const MyChatBox = ({ message, time, unreadCount }: BoxProps) => {
+const MyChatBox = ({ message, time, unreadCount, isLastChat }: BoxProps) => {
   return (
     <Container>
       <TextContainer>
         <RestContent>
           {unreadCount !== 0 && <UnreadContent>{unreadCount}</UnreadContent>}
-          <DateContent>{getTimeByDate(new Date(time))}</DateContent>
+          {isLastChat && <DateContent>{getTimeByDate(new Date(time))}</DateContent>}
         </RestContent>
         <MessageContent>{message}</MessageContent>
       </TextContainer>

--- a/frontend/src/pages/ChatRoom/components/ChatPanel/MessageBox/BoxType/OtherChatBox.tsx
+++ b/frontend/src/pages/ChatRoom/components/ChatPanel/MessageBox/BoxType/OtherChatBox.tsx
@@ -8,24 +8,37 @@ interface BoxProps {
   message: string;
   time: Date;
   unreadCount: number | undefined;
+  isFirstChat: boolean;
+  isLastChat: boolean;
 }
 
-const OtherChatBox = ({ message, time, profileImg, nickname, unreadCount }: BoxProps) => {
+const OtherChatBox = ({
+  message,
+  time,
+  profileImg,
+  nickname,
+  unreadCount,
+  isFirstChat,
+  isLastChat,
+}: BoxProps) => {
   return (
     <Container>
-      <ProfileContainer>
-        {profileImg ? (
-          <ProfileImg src={profileImg} alt="profileImg" />
-        ) : (
-          <FaCircleUser size="30" color="gray" />
-        )}
-        <ProfileText>{nickname}</ProfileText>
-      </ProfileContainer>
+      {isFirstChat && (
+        <ProfileContainer>
+          {profileImg ? (
+            <ProfileImg src={profileImg} alt="profileImg" />
+          ) : (
+            <FaCircleUser size="30" color="gray" />
+          )}
+          <ProfileText>{nickname}</ProfileText>
+        </ProfileContainer>
+      )}
+
       <TextContainer>
         <MessageContent>{message}</MessageContent>
         <RestContent>
           {unreadCount !== 0 && <UnreadContent>{unreadCount}</UnreadContent>}
-          <DateContent>{getTimeByDate(new Date(time))}</DateContent>
+          {isLastChat && <DateContent>{getTimeByDate(new Date(time))}</DateContent>}
         </RestContent>
       </TextContainer>
     </Container>

--- a/frontend/src/pages/ChatRoom/components/ChatPanel/MessageBox/MessageBox.tsx
+++ b/frontend/src/pages/ChatRoom/components/ChatPanel/MessageBox/MessageBox.tsx
@@ -8,9 +8,11 @@ import SystemChatBox from './BoxType/SystemChatBox';
 import { useMemo } from 'react';
 interface Props extends ChatLog {
   logId: string;
+  isFirstChat: boolean;
+  isLastChat: boolean;
 }
 
-const MessageBox = ({ logId, message, userId, type, time }: Props) => {
+const MessageBox = ({ logId, message, userId, type, time, isFirstChat, isLastChat }: Props) => {
   const chatUnread = useRecoilValue(chatUnreadAtom);
   const userData = useRecoilValue(userListInfoAtom);
   const myData = userData?.get(userId) || {
@@ -50,7 +52,12 @@ const MessageBox = ({ logId, message, userId, type, time }: Props) => {
     <Layout type={type} isMe={isMe}>
       {type !== 'message' && <SystemChatBox message={message} />}
       {type === 'message' && isMe && (
-        <MyChatBox message={message} time={time} unreadCount={unreadCount} />
+        <MyChatBox
+          message={message}
+          time={time}
+          unreadCount={unreadCount}
+          isLastChat={isLastChat}
+        />
       )}
       {type === 'message' && !isMe && (
         <OtherChatBox
@@ -59,6 +66,8 @@ const MessageBox = ({ logId, message, userId, type, time }: Props) => {
           nickname={nickname}
           profileImg={profileImg}
           unreadCount={unreadCount}
+          isFirstChat={isFirstChat}
+          isLastChat={isLastChat}
         />
       )}
     </Layout>

--- a/frontend/src/utils/chatMessageUtil.ts
+++ b/frontend/src/utils/chatMessageUtil.ts
@@ -1,0 +1,14 @@
+import { ChatLog } from 'types/chat';
+import { checkDateIsSameDate } from './dateUtil';
+
+// 특정 날짜의 첫 번째 채팅인지 확인한다.
+const checkIsFirstChatToday = (targetIndex: number, chatLogData: [string, ChatLog][]): boolean => {
+  if (targetIndex === 0) {
+    return false;
+  }
+  const prevTime = chatLogData[targetIndex - 1][1].time;
+  const targetTime = chatLogData[targetIndex][1].time;
+  return checkDateIsSameDate(new Date(prevTime), new Date(targetTime));
+};
+
+export { checkIsFirstChatToday };

--- a/frontend/src/utils/chatMessageUtil.ts
+++ b/frontend/src/utils/chatMessageUtil.ts
@@ -1,5 +1,5 @@
 import { ChatLog } from 'types/chat';
-import { checkDateIsSameDate } from './dateUtil';
+import { checkDateIsSameDate, getTimeByDate } from './dateUtil';
 
 // 특정 날짜의 첫 번째 채팅인지 확인한다.
 const checkIsFirstChatToday = (targetIndex: number, chatLogData: [string, ChatLog][]): boolean => {
@@ -11,4 +11,34 @@ const checkIsFirstChatToday = (targetIndex: number, chatLogData: [string, ChatLo
   return checkDateIsSameDate(new Date(prevTime), new Date(targetTime));
 };
 
-export { checkIsFirstChatToday };
+// 프로필 표시 여부
+const checkIsFirstChatFromUser = (
+  targetIndex: number,
+  chatLogData: [string, ChatLog][]
+): boolean => {
+  if (targetIndex === 0) {
+    return true;
+  }
+
+  const prevData = chatLogData[targetIndex - 1][1];
+  const targetData = chatLogData[targetIndex][1];
+
+  const prevUser = prevData.userId;
+  const prevTime = getTimeByDate(new Date(prevData.time));
+  const targetUser = targetData.userId;
+  const targetTime = getTimeByDate(new Date(targetData.time));
+
+  // 특정 유저의 채팅이 해당 시각에 첫 번째 채팅이면
+  if (prevTime !== targetTime) {
+    return true;
+  }
+
+  // 같은 시각이지만 사용자가 다르면
+  if (prevUser !== targetUser) {
+    return true;
+  }
+
+  return false;
+};
+
+export { checkIsFirstChatToday, checkIsFirstChatFromUser };

--- a/frontend/src/utils/chatMessageUtil.ts
+++ b/frontend/src/utils/chatMessageUtil.ts
@@ -28,12 +28,10 @@ const checkIsFirstChatFromUser = (
   const targetUser = targetData.userId;
   const targetTime = getTimeByDate(new Date(targetData.time));
 
-  // 특정 유저의 채팅이 해당 시각에 첫 번째 채팅이면
   if (prevTime !== targetTime) {
     return true;
   }
 
-  // 같은 시각이지만 사용자가 다르면
   if (prevUser !== targetUser) {
     return true;
   }
@@ -41,4 +39,33 @@ const checkIsFirstChatFromUser = (
   return false;
 };
 
-export { checkIsFirstChatToday, checkIsFirstChatFromUser };
+// 시각 표시 여부
+const checkIsLastChatFromUser = (
+  targetIndex: number,
+  chatLogData: [string, ChatLog][]
+): boolean => {
+  if (targetIndex === chatLogData.length - 1) {
+    return true;
+  }
+
+  const targetData = chatLogData[targetIndex][1];
+  const nextData = chatLogData[targetIndex + 1][1];
+
+  const targetTime = getTimeByDate(new Date(targetData.time));
+  const nextTime = getTimeByDate(new Date(nextData.time));
+
+  const targetUser = targetData.userId;
+  const nextUser = nextData.userId;
+
+  if (targetTime !== nextTime) {
+    return true;
+  }
+
+  if (targetUser !== nextUser) {
+    return true;
+  }
+
+  return false;
+};
+
+export { checkIsFirstChatToday, checkIsFirstChatFromUser, checkIsLastChatFromUser };

--- a/frontend/src/utils/dateUtil.ts
+++ b/frontend/src/utils/dateUtil.ts
@@ -37,4 +37,13 @@ const isTodayByDate = (targetDate: Date): boolean => {
   return false;
 };
 
-export { getStringByDate, getTimeByDate, isTodayByDate };
+// 입력한 두 날짜가 같은 날짜인지
+const checkDateIsSameDate = (firstDate: Date, secondDate: Date): boolean => {
+  if (firstDate.toDateString() === secondDate.toDateString()) {
+    return true;
+  }
+
+  return false;
+};
+
+export { getStringByDate, getTimeByDate, isTodayByDate, checkDateIsSameDate };


### PR DESCRIPTION
## 🤷‍♂️ Description
- 채팅방에서 날짜 구분선을 보여주는 경우
    - 현재 채팅의 년,월,일이 이전 채팅의 년,월,일과 다르면 표시해요.
- 채팅방에서 메세지의 프로필을 보여주는 경우
    - 특정 유저의 채팅이 해당 시각에 첫 번째 채팅이면 표시해요.
    - 특정 유저의 채팅이 해당 시각에 첫 번째 채팅이 아니지만 중간에 다른 사용자의 채팅이 있는 경우 표시해요.
    - 시간대(시, 분)이 다르면 표시해요.
- 시각을 보여주는 경우
    - 특정 유저의 채팅이 해당 시각에 마지막 채팅이면 표시해요.
    - 특정 유저의 채팅이 해당 시각에 마지막 채팅이 아니지만 뒷 채팅과 유저 정보가 다른경우 표시해요.
    - 시간대가 다르면 표시해요.

<!-- 구현 한 기능에 대해 작성해 주세요. -->

## 📝 Primary Commits

<!-- 세부 구현 사항을 리스트로 작성해주세요. -->

- [X] 날짜 구분선, 프로필, 시각 표시 여부 util 함수 만들기
- [x] 구분선 UI 추가하기
- [x] 채팅방 페이지에 적용하기

## 📷 Screenshots
![캡처_2023_12_06_12_16_59_383](https://github.com/boostcampwm2023/web03-LockFestival/assets/82202370/cf926367-4829-457e-ad40-9b5374cf0158)

https://github.com/boostcampwm2023/web03-LockFestival/assets/82202370/5e114772-c19a-4398-b546-c5e7f5762592


<!--스크린샷으로 보여줄 수 있는 이미지가 있다면 첨부해주세요!-->

<!--BE의 경우 API 테스트 결과를 첨부해주세요-->

<!--마지막으로 이슈 생성 시 우측의 옵션들을 체크했는지 확인해주세요!-->

<!-- 이슈번호를 작성해주세요. -->
<!-- 여러 이슈를 입력시 comma(,) 단위로 구분해주세요 -->
<!-- ex) close #10, resolves #123 -->


<!-- ex) -->
<!-- closes #1 --> 

