### PR TITLE
Feature/FE/#303: 이전 채팅기록 로딩 후 기존에 보던 채팅 유지하기

### DIFF
--- a/frontend/src/pages/ChatRoom/components/ChatPanel/ChatPanel.tsx
+++ b/frontend/src/pages/ChatRoom/components/ChatPanel/ChatPanel.tsx
@@ -234,10 +234,3 @@ const HorizontalLine = styled.div([
 ]);
 
 const DateDisplay = styled.div([]);
-
-const ChatVirtualizedContainer = styled.div([
-  css`
-    width: 100%;
-    height: 20rem;
-  `,
-]);

--- a/frontend/src/pages/ChatRoom/components/ChatPanel/ChatPanel.tsx
+++ b/frontend/src/pages/ChatRoom/components/ChatPanel/ChatPanel.tsx
@@ -30,6 +30,7 @@ const ChatPanel = ({ roomId, sendChat, getPastChat }: ChatPanelProps) => {
   const lastScrollRef = useRef<HTMLDivElement>(null);
 
   const [isScrollToTop, setIsScrollToTop] = useState<boolean>(false);
+  const [prevScrollHeight, setPrevScrollHeight] = useState<number | null>(null);
 
   useIntersectionObserverSocket({
     eventHandler: getPastChat,
@@ -67,6 +68,10 @@ const ChatPanel = ({ roomId, sendChat, getPastChat }: ChatPanelProps) => {
     if (lastScrollRef.current && !isScrollToTop) {
       lastScrollRef.current.scrollIntoView({ behavior: 'smooth' });
     }
+    if (prevScrollHeight && scrollRef.current) {
+      scrollRef.current.scrollTop = scrollRef.current?.scrollHeight - prevScrollHeight;
+      return setPrevScrollHeight(null);
+    }
   }, [chatLogData]);
 
   const handleScroll = () => {
@@ -77,6 +82,10 @@ const ChatPanel = ({ roomId, sendChat, getPastChat }: ChatPanelProps) => {
       if (Math.abs(target1 - target2) < 20) {
         setIsScrollToTop(false);
         return;
+      }
+
+      if (target2 < 20) {
+        setPrevScrollHeight(scrollRef.current?.scrollHeight);
       }
 
       setIsScrollToTop(true);
@@ -225,3 +234,10 @@ const HorizontalLine = styled.div([
 ]);
 
 const DateDisplay = styled.div([]);
+
+const ChatVirtualizedContainer = styled.div([
+  css`
+    width: 100%;
+    height: 20rem;
+  `,
+]);


### PR DESCRIPTION
## 🤷‍♂️ Description
- 이전 채팅기록 로딩 후 기존에 보던 채팅 유지할 수 있게 했어요.
- 스크롤이 제일 위로 올라갔을때 현재 스크롤 Height을 저장해놓고, 채팅 데이터 로딩 후 변경된 scrollHeight에서 이전의 scrollHeight 차이만큼 스크롤을 내리게 했어요.

<!-- 구현 한 기능에 대해 작성해 주세요. -->

## 📝 Primary Commits

<!-- 세부 구현 사항을 리스트로 작성해주세요. -->

- [X] 채팅데이터 로딩 후 기존에 보던 채팅으로 스크롤 내리기
## 📷 Screenshots

https://github.com/boostcampwm2023/web03-LockFestival/assets/82202370/4d238b5e-aeba-43e8-b0cb-9f14168ff15c


<!--스크린샷으로 보여줄 수 있는 이미지가 있다면 첨부해주세요!-->

<!--BE의 경우 API 테스트 결과를 첨부해주세요-->

<!--마지막으로 이슈 생성 시 우측의 옵션들을 체크했는지 확인해주세요!-->

<!-- 이슈번호를 작성해주세요. -->
<!-- 여러 이슈를 입력시 comma(,) 단위로 구분해주세요 -->
<!-- ex) close #10, resolves #123 -->


<!-- ex) -->
<!-- closes #1 --> 

