### PR TITLE
Feature/FE/#308 공통 에러 바운더리 및 채팅방 리스트 페이지에 적용

### DIFF
--- a/frontend/src/hooks/query/useRoomListInfiniteQuery.tsx
+++ b/frontend/src/hooks/query/useRoomListInfiniteQuery.tsx
@@ -9,6 +9,7 @@ const useRoomListInfiniteQuery = () => {
     getNextPageParam: (lastPage) => {
       return lastPage._meta.nextCursor;
     },
+    throwOnError: true,
   });
 
   return { data, fetchNextPage, hasNextPage, error, isFetching };

--- a/frontend/src/pages/Error/CommonError.tsx
+++ b/frontend/src/pages/Error/CommonError.tsx
@@ -1,0 +1,78 @@
+import { FallbackProps } from 'react-error-boundary';
+import { isAxiosError } from 'axios';
+import tw, { css, styled } from 'twin.macro';
+import Button from '@components/Button/Button';
+import LoginModal from '@components/LoginModal/LoginModal';
+import useModal from '@hooks/useModal';
+import Modal from '@components/Modal/Modal';
+
+const CommonError = ({ error }: FallbackProps) => {
+  const { openModal, closeModal } = useModal();
+
+  const handleLogin = () => {
+    localStorage.setItem('lastVisited', location.pathname);
+
+    openModal(Modal, {
+      children: LoginModal(() => closeModal(Modal)),
+      onClose: () => closeModal(Modal),
+      closeOnExternalClick: true,
+    });
+  };
+
+  if (isAxiosError(error) && error.response) {
+    const { status } = error.response;
+
+    if (status === 401) {
+      return (
+        <ErrorLayout>
+          <ErrorContainer>
+            <ErrorContent>
+              <ErrorHeader>해당 기능을 이용하려면 로그인해주세요!</ErrorHeader>
+              <Button isIcon={false} font="maplestory" size="l-bold" onClick={handleLogin}>
+                <>로그인 하기</>
+              </Button>
+            </ErrorContent>
+          </ErrorContainer>
+        </ErrorLayout>
+      );
+    }
+  }
+
+  return <ErrorLayout>서버 에러</ErrorLayout>;
+};
+
+const ErrorLayout = styled.div([
+  tw`w-full text-xl text-white`,
+  css`
+    height: calc(100vh - 6rem);
+    display: flex;
+    align-items: center;
+    justify-self: center;
+  `,
+]);
+
+const ErrorContainer = styled.div([
+  tw`font-maplestory`,
+  css`
+    margin: 0 auto;
+  `,
+]);
+
+const ErrorContent = styled.div([
+  css`
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-direction: column;
+  `,
+]);
+
+const ErrorHeader = styled.h2([
+  tw`h-[6rem]`,
+  css`
+    display: flex;
+    align-items: center;
+  `,
+]);
+
+export default CommonError;

--- a/frontend/src/pages/Error/Error404.tsx
+++ b/frontend/src/pages/Error/Error404.tsx
@@ -1,5 +1,0 @@
-const Error404 = () => {
-  return <div>404 Not Found</div>;
-};
-
-export default Error404;

--- a/frontend/src/pages/GroupChat/GroupChat.tsx
+++ b/frontend/src/pages/GroupChat/GroupChat.tsx
@@ -1,5 +1,0 @@
-const GroupChat = () => {
-  return <div>그룹 챗</div>;
-};
-
-export default GroupChat;

--- a/frontend/src/pages/RoomList/RoomList.tsx
+++ b/frontend/src/pages/RoomList/RoomList.tsx
@@ -3,10 +3,11 @@ import { ErrorBoundary } from 'react-error-boundary';
 
 import tw, { css, styled } from 'twin.macro';
 import RoomListLayout from './components/RoomListLayout';
+import CommonError from '@pages/Error/CommonError';
 
 const RoomList = () => {
   return (
-    <ErrorBoundary fallback={<Error>그룹 채팅방을 불러오는데 에러가 발생했어요!</Error>}>
+    <ErrorBoundary FallbackComponent={(fallbackProps) => <CommonError {...fallbackProps} />}>
       <Suspense fallback={<div>로딩중...</div>}>
         <RoomListLayout />
       </Suspense>


### PR DESCRIPTION
## 🤷‍♂️ Description
공통 에러 바운더리를 CommonError.tsx로 만들었어요.
인증 관련된 에러(401, 403)은 여기서 처리하는 게 좋을 것 같아서 하위 컴포넌트에서 401, 403 에러라면 상위로 던져주세요!!

아래와 같이 각 페이지 컴포넌트에서 사용해주세요!

```typescript
<ErrorBoundary FallbackComponent={(fallbackProps) => <CommonError {...fallbackProps} />}>
  <Suspense fallback={<div>로딩중...</div>}>
    <RoomListLayout />
  </Suspense>
</ErrorBoundary>
```

미사용하는 파일을 삭제했어요!

<!-- 구현 한 기능에 대해 작성해 주세요. -->

## 📝 Primary Commits

<!-- 세부 구현 사항을 리스트로 작성해주세요. -->

- [X] 공통 에러 바운더리 생성
- [X] 채팅방 리스트 페이지에 적용 

## 📷 Screenshots

![녹화_2023_12_06_23_40_52_128](https://github.com/boostcampwm2023/web03-LockFestival/assets/100738049/d5447e2d-bad3-4c3c-a601-fa84db490a43)



<!--스크린샷으로 보여줄 수 있는 이미지가 있다면 첨부해주세요!-->

<!--BE의 경우 API 테스트 결과를 첨부해주세요-->

<!--마지막으로 이슈 생성 시 우측의 옵션들을 체크했는지 확인해주세요!-->

<!-- 이슈번호를 작성해주세요. -->
<!-- 여러 이슈를 입력시 comma(,) 단위로 구분해주세요 -->
<!-- ex) close #10, resolves #123 -->


<!-- ex) -->
<!-- closes #1 --> 
closes #308 

