### PR TITLE
Feature/FE/#311 채팅방 리스트 페이지에서 나가기 기능 및 리스트 재요청

### DIFF
--- a/frontend/src/constants/mutationManagement.ts
+++ b/frontend/src/constants/mutationManagement.ts
@@ -1,0 +1,10 @@
+import deleteGroupByGroupId from '@apis/deleteGroupByGroupId';
+
+const MUTATION_MANAGEMENT = {
+  leaveRoom: {
+    key: 'leaveRoom',
+    fn: (groudId: number) => deleteGroupByGroupId(groudId),
+  },
+};
+
+export default MUTATION_MANAGEMENT;

--- a/frontend/src/hooks/mutation/useLeaveRoomMutation.tsx
+++ b/frontend/src/hooks/mutation/useLeaveRoomMutation.tsx
@@ -1,0 +1,26 @@
+import MUTATION_MANAGEMENT from '@constants/mutationManagement';
+import QUERY_MANAGEMENT from '@constants/queryManagement';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { isAxiosError } from 'axios';
+
+const useLeaveRoomMutation = (groupId: number) => {
+  const queryClient = useQueryClient();
+
+  const { data, mutate, status } = useMutation({
+    mutationKey: [MUTATION_MANAGEMENT['leaveRoom'].key, groupId],
+    mutationFn: (groupId: number) => MUTATION_MANAGEMENT['leaveRoom'].fn(groupId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: [QUERY_MANAGEMENT['roomList'].key] });
+      alert('정상적으로 나가셨습니다!');
+    },
+    onError: (error) => {
+      if (isAxiosError(error)) {
+        alert(error.response?.data.message);
+      }
+    },
+  });
+
+  return { data, mutate, status };
+};
+
+export default useLeaveRoomMutation;

--- a/frontend/src/pages/RoomList/components/Room/RoomFooter.tsx
+++ b/frontend/src/pages/RoomList/components/Room/RoomFooter.tsx
@@ -1,5 +1,5 @@
-import deleteGroupByGroupId from '@apis/deleteGroupByGroupId';
 import Button from '@components/Button/Button';
+import useLeaveRoomMutation from '@hooks/mutation/useLeaveRoomMutation';
 import { useNavigate } from 'react-router-dom';
 import tw, { styled, css } from 'twin.macro';
 import { GroupProps } from 'types/group';
@@ -7,11 +7,13 @@ import { GroupProps } from 'types/group';
 const RoomFooter = ({ groupId }: Pick<GroupProps, 'groupId'>) => {
   const navigate = useNavigate();
 
-  const handleLeaveRoom = async () => {
+  const { mutate } = useLeaveRoomMutation(groupId);
+
+  const handleLeaveRoom = () => {
     if (!window.confirm('정말로 방을 나가시겠습니까?\n나간 이후 복구할 수 없습니다.')) {
       return;
     }
-    await deleteGroupByGroupId(groupId);
+    mutate(groupId);
   };
 
   return (


### PR DESCRIPTION
## 🤷‍♂️ Description
useMutation을 사용해서 채팅방 나가기 기능을 추가했어요.
채팅방을 나가면 현재 해당 채팅방을 리스트에서 없애야해서 `invalidateQueries`로 기존 list query를 전부 무효화 시키고 다시 받아오도록 했어요.

앞으로 mutation key와 fn은 `mutationManagement.ts`에서 관리해주세요!

<!-- 구현 한 기능에 대해 작성해 주세요. -->

## 📝 Primary Commits

<!-- 세부 구현 사항을 리스트로 작성해주세요. -->

- [X] useMutation으로 채팅방 나가기 기능 추가
- [X] 채팅방을 나가면 채팅 목록 다시 불러오기 기능

## 📷 Screenshots

![녹화_2023_12_07_01_16_00_652](https://github.com/boostcampwm2023/web03-LockFestival/assets/100738049/623d6ecb-c602-4b5e-a38c-9da31e914740)


<!--스크린샷으로 보여줄 수 있는 이미지가 있다면 첨부해주세요!-->

<!--BE의 경우 API 테스트 결과를 첨부해주세요-->

<!--마지막으로 이슈 생성 시 우측의 옵션들을 체크했는지 확인해주세요!-->

<!-- 이슈번호를 작성해주세요. -->
<!-- 여러 이슈를 입력시 comma(,) 단위로 구분해주세요 -->
<!-- ex) close #10, resolves #123 -->


<!-- ex) -->
<!-- closes #1 --> 

closes #311 
