### PR TITLE
Feature/FE/#313 로그인 여부에 따른 모집글 작성 모달 표시 및 로그인 컴포넌트 변경

### DIFF
--- a/frontend/src/components/LoginModal/LoginModal.tsx
+++ b/frontend/src/components/LoginModal/LoginModal.tsx
@@ -1,21 +1,25 @@
-import { ModalProps } from 'types/modal';
 import NaverLogin from '@components/LoginModal/NaverLogin/NaverLogin';
 import tw, { css, styled } from 'twin.macro';
 import ModalCloseButton from '@components/Button/ModalCloseButton';
 
-function LoginModal(onClose: ModalProps['onClose']) {
+interface Props {
+  onClose: () => void;
+  explainText?: string;
+}
+
+function LoginModal({ onClose, explainText }: Props) {
   return (
     <Layout>
       <ModalCloseButton onClose={onClose} />
+
       <BottomWrapper>
+        {explainText && <ChildrenText>{explainText}</ChildrenText>}
         Lock Festival 로그인
         <NaverLogin />
       </BottomWrapper>
     </Layout>
   );
 }
-
-export default LoginModal;
 
 const Layout = styled.div([tw`p-6`]);
 
@@ -30,3 +34,11 @@ const BottomWrapper = styled.div([
     align-items: center;
   `,
 ]);
+
+const ChildrenText = styled.div([
+  css`
+    text-align: center;
+  `,
+]);
+
+export default LoginModal;

--- a/frontend/src/pages/Recruitment/components/RecruitmentLayout.tsx
+++ b/frontend/src/pages/Recruitment/components/RecruitmentLayout.tsx
@@ -8,9 +8,14 @@ import Button from '@components/Button/Button';
 import useModal from '@hooks/useModal';
 import Modal from '@components/Modal/Modal';
 import MakeGroupModal from '@components/Modal/MakeGroupModal/MakeGroupModal';
+import { useRecoilValue } from 'recoil';
+import userAtom from '@store/userAtom';
+import LoginModal from '@components/LoginModal/LoginModal';
 
 const RecruitmentLayout = () => {
   const targetRef = useRef<HTMLDivElement>(null);
+
+  const user = useRecoilValue(userAtom);
 
   const { openModal, closeModal } = useModal();
 
@@ -21,19 +26,31 @@ const RecruitmentLayout = () => {
     targetRef,
   });
 
+  const checkIsLogin = () => {
+    if (!user.nickname) {
+      openModal(Modal, {
+        children: (
+          <LoginModal
+            onClose={() => closeModal(Modal)}
+            explainText="로그인 이후 모집글을 작성할 수 있어요!"
+          />
+        ),
+        onClose: () => closeModal(Modal),
+        closeOnExternalClick: true,
+      });
+      return;
+    }
+
+    openModal(Modal, {
+      children: <MakeGroupModal onClose={() => closeModal(Modal)} />,
+      onClose: () => closeModal(Modal),
+      closeOnExternalClick: false,
+    });
+  };
+
   return (
     <Container>
-      <AddButton
-        isIcon={false}
-        size="l"
-        onClick={() =>
-          openModal(Modal, {
-            children: <MakeGroupModal onClose={() => closeModal(Modal)} />,
-            onClose: () => closeModal(Modal),
-            closeOnExternalClick: false,
-          })
-        }
-      >
+      <AddButton isIcon={false} size="l" onClick={checkIsLogin}>
         <>
           모집글 작성하기
           <FaPlus color="white" />


### PR DESCRIPTION
## 🤷‍♂️ Description
로그인 여부에 따라 모집글 작성 모달 표시했어요.
- 만약 로그인되어있지 않다면 로그인 모달을 띄워요!

로그인 모달 컴포넌트 수정
- 현재 로그인 모달 컴포넌트는 같은 메세지만 보여주고 있어요. 하지만 각 페이지에서 로그인 모달을 띄울 때 ~~ 기능을 이용하려면 로그인을 해야한다. 이런 문구를 유동적으로 작성할 수 있도록하기 위해서 explainText라는 props를 추가적으로 전달 할 수 있도록 했어요!

<!-- 구현 한 기능에 대해 작성해 주세요. -->

## 📝 Primary Commits

<!-- 세부 구현 사항을 리스트로 작성해주세요. -->

- [X] 로그인 여부에 따라 모집글 작성 모달 표시
- [ ] 로그인 컴포넌트 변경

## 📷 Screenshots

![녹화_2023_12_07_01_33_33_419](https://github.com/boostcampwm2023/web03-LockFestival/assets/100738049/ffc59aca-97f1-4a51-846a-96b048fb6230)

<!--스크린샷으로 보여줄 수 있는 이미지가 있다면 첨부해주세요!-->

<!--BE의 경우 API 테스트 결과를 첨부해주세요-->

<!--마지막으로 이슈 생성 시 우측의 옵션들을 체크했는지 확인해주세요!-->

<!-- 이슈번호를 작성해주세요. -->
<!-- 여러 이슈를 입력시 comma(,) 단위로 구분해주세요 -->
<!-- ex) close #10, resolves #123 -->


<!-- ex) -->
<!-- closes #1 --> 
closes #313 
