### PR TITLE
Feature/BE/#302: 채팅방 강퇴 이벤트 생성

### DIFF
--- a/backend/src/gateway/events.gateway.ts
+++ b/backend/src/gateway/events.gateway.ts
@@ -113,9 +113,9 @@ export class EventsGateway implements OnGatewayInit, OnGatewayConnection, OnGate
       await this.chatService.deleteRoomByLeader(roomId);
       return;
     }
-    const chatUser = await this.chatService.getChatUserIdByNicknameAndRoomId(roomId, nickname);
+    const chatUserId = await this.chatService.getChatUserIdByNicknameAndRoomId(roomId, nickname);
     const message = await this.chatService.leaveChatRoom(
-      new ChatLeaveRoomDto(roomId, nickname, chatUser._id, ChatType.out)
+      new ChatLeaveRoomDto(roomId, nickname, chatUserId, ChatType.out)
     );
 
     await this.sendChangeUserBroadcastMessage(roomId, message);

--- a/backend/src/gateway/events.gateway.ts
+++ b/backend/src/gateway/events.gateway.ts
@@ -187,7 +187,6 @@ export class EventsGateway implements OnGatewayInit, OnGatewayConnection, OnGate
   async handleDisconnect(client: Socket) {
     this.logger.log('by' + client.id);
     const roomId = this.socketToRoomId[client.id];
-    console.log('disconnect', roomId, client.id);
     if (!roomId) {
       return;
     }

--- a/backend/src/modules/userModules/chat/chat.service.ts
+++ b/backend/src/modules/userModules/chat/chat.service.ts
@@ -74,7 +74,7 @@ export class ChatService {
       }, {});
   }
 
-  async validateLeader(roomId: string, userId: string) {
+  async validateLeader(roomId: string, userId: string): Promise<boolean> {
     this.logger.log(`roomId: ${roomId}, userId: ${userId}`);
     return await this.chatRepository.validateLeaderByRoomId(roomId, userId);
   }

--- a/backend/src/modules/userModules/chat/chat.service.ts
+++ b/backend/src/modules/userModules/chat/chat.service.ts
@@ -123,7 +123,7 @@ export class ChatService {
   }
 
   async getChatUserIdByNicknameAndRoomId(roomId: string, nickname: string): Promise<ChatUser> {
-    return await this.chatRepository.validateRoomAndGetChatUser(roomId, nickname);
+    return (await this.chatRepository.validateRoomAndGetChatUser(roomId, nickname))._id;
   }
 
   async leaveChatRoom(dto: ChatLeaveRoomDto): Promise<ChatMessageDto> {

--- a/backend/src/modules/userModules/chat/chat.service.ts
+++ b/backend/src/modules/userModules/chat/chat.service.ts
@@ -7,7 +7,6 @@ import { ChatUserInfoDto } from '@chat/dtos/chat.user.info.dto';
 import { ChatMessageResponseDto } from '@chat/dtos/chat.mesage.response.dto';
 import { ChatUser } from '@chat/entities/chat.user.schema';
 import { EnteredChatMessageResponseDto } from '@chat/dtos/chat.entered.response.dto';
-import { ChatLeaveRoomResponseDto } from '@chat/dtos/chat.leave.response.dto';
 import { ChatLeaveRoomDto } from '@chat/dtos/chat.leave.dto';
 
 @Injectable()
@@ -127,16 +126,14 @@ export class ChatService {
     return await this.chatRepository.validateRoomAndGetChatUser(roomId, nickname);
   }
 
-  async leaveChatRoom(dto: ChatLeaveRoomDto): Promise<ChatLeaveRoomResponseDto> {
+  async leaveChatRoom(dto: ChatLeaveRoomDto): Promise<ChatMessageDto> {
     await this.chatRepository.updateUserInfoOnLeave(dto.userChatId);
-    const message = await this.chatRepository.createMessageByLeaveEvent(
+    const message: ChatMessageDto = await this.chatRepository.createMessageByLeaveEvent(
       dto.roomId,
       dto.nickname,
       dto.chatType
     );
-    const chatUsers = await this.chatRepository.findUserListByRoomId(dto.roomId);
-    const unreadCountMap = this.makeUnreadCountMap(chatUsers);
-    return { chatUsers, unreadCountMap, message };
+    return message;
   }
 
   async deleteRoomByLeader(roomId: string): Promise<void> {

--- a/backend/src/modules/userModules/chat/chat.service.ts
+++ b/backend/src/modules/userModules/chat/chat.service.ts
@@ -22,8 +22,8 @@ export class ChatService {
       return chatUser.updateIsMe(chatUser.nickname === nickname);
     });
 
-    const meUser: ChatUserInfoDto = chatUsers.find(({ isMe }) => {
-      return isMe;
+    const meUser: ChatUserInfoDto = chatUsers.find(({ isMe, isLeave }) => {
+      return isMe && !isLeave;
     });
 
     const unreadCountMap = this.makeUnreadCountMap(

--- a/backend/src/modules/userModules/chat/dtos/chat.leave.dto.ts
+++ b/backend/src/modules/userModules/chat/dtos/chat.leave.dto.ts
@@ -1,0 +1,14 @@
+import { ChatType } from '@enum/chat.type';
+
+export class ChatLeaveRoomDto {
+  roomId: string;
+  nickname: string;
+  userChatId: string;
+  chatType: ChatType;
+  constructor(roomId, nickname, userChatId, chatType) {
+    this.roomId = roomId;
+    this.nickname = nickname;
+    this.userChatId = userChatId;
+    this.chatType = chatType;
+  }
+}

--- a/backend/src/modules/userModules/chat/dtos/chat.leave.response.dto.ts
+++ b/backend/src/modules/userModules/chat/dtos/chat.leave.response.dto.ts
@@ -1,8 +1,0 @@
-import { ChatMessageDto } from '@chat/dtos/chat.message.dto';
-import { ChatUserInfoDto } from '@chat/dtos/chat.user.info.dto';
-
-export class ChatLeaveRoomResponseDto {
-  chatUsers: ChatUserInfoDto[];
-  unreadCountMap: Record<string, string>;
-  message: ChatMessageDto;
-}

--- a/backend/src/modules/userModules/chat/dtos/chat.leave.response.dto.ts
+++ b/backend/src/modules/userModules/chat/dtos/chat.leave.response.dto.ts
@@ -1,0 +1,8 @@
+import { ChatMessageDto } from '@chat/dtos/chat.message.dto';
+import { ChatUserInfoDto } from '@chat/dtos/chat.user.info.dto';
+
+export class ChatLeaveRoomResponseDto {
+  chatUsers: ChatUserInfoDto[];
+  unreadCountMap: Record<string, string>;
+  message: ChatMessageDto;
+}

--- a/backend/src/modules/userModules/group/group.controller.ts
+++ b/backend/src/modules/userModules/group/group.controller.ts
@@ -119,7 +119,7 @@ export class GroupController {
   })
   @ApiBearerAuth('Authorization')
   async exitGroup(@Param('groupId', ParseIntPipe) groupId: number, @Req() { user }) {
-    const leaderFlag = await this.groupService.leaveGroup(groupId, user.nickname);
+    const leaderFlag = await this.groupService.deleteGroupOnOut(groupId, user.nickname);
     await this.eventsGateway.leave(String(groupId), user.nickname, leaderFlag);
   }
 }

--- a/backend/src/modules/userModules/group/group.service.ts
+++ b/backend/src/modules/userModules/group/group.service.ts
@@ -91,7 +91,10 @@ export class GroupService {
   async getGroupInfo(groupId: number): Promise<GroupInfoResponseDto> {
     return await this.groupRepository.getGroupInfo(groupId);
   }
-  async leaveGroup(groupId: number, nickname: string) {
-    return await this.groupRepository.deleteGroupByNicknameAndGroupId(groupId, nickname);
+  async deleteGroupOnOut(groupId: number, nickname: string) {
+    return await this.groupRepository.deleteGroupOnOut(groupId, nickname);
+  }
+  async deleteGroupOnKick(groupId: number, nickname: string) {
+    return await this.groupRepository.deleteGroupOnKick(groupId, nickname);
   }
 }


### PR DESCRIPTION
## 🤷‍♂️ Description
- 채팅방 강퇴 이벤트를 만들었어요
<!-- 구현 한 기능에 대해 작성해 주세요. -->

## 📝 Primary Commits

<!-- 세부 구현 사항을 리스트로 작성해주세요. -->
- 강퇴 이벤트를 생성했어요.
  - 강퇴 당하는 유저가 채팅방에 있다면 연결을 끊어줬어요
```typescript
  @SubscribeMessage('kick')
  async handleKick(@MessageBody('userId') kickUserId: string, @ConnectedSocket() client: Socket) {
    const roomId = this.socketToRoomId[client.id];

    const nickname = await this.chatService.getNicknameByChatUserId(kickUserId);
    await this.groupService.deleteGroupOnKick(Number(roomId), nickname);
    const { unreadCountMap, chatUsers, message } = await this.chatService.leaveChatRoom(
      new ChatLeaveRoomDto(roomId, nickname, kickUserId, ChatType.kick)
    );
    const groupInfo = await this.groupService.getGroupInfo(Number(roomId));

    const socketId = Object.keys(this.socketsInRooms[roomId]).find((clientId) => {
      const sessionUserId = this.socketsInRooms[roomId][clientId];
      return sessionUserId === kickUserId;
    });

    const kickSocket = this.server.sockets.sockets.get(socketId);

    this.server.to(roomId).emit('roomInfo', groupInfo);
    this.server.to(roomId).emit('unread', unreadCountMap);
    this.server.to(roomId).emit('userListInfo', chatUsers);
    this.server.to(roomId).emit('chat', message);

    if (!kickSocket) {
      return;
    }
    delete this.socketsInRooms[roomId][socketId];
    delete this.socketToRoomId[socketId];
    await this.handleDisconnect(kickSocket);
  }

```
- 함수명을 변경했어요
  - leave(out,kick) 
```
deleteGroupByNickname -> deleteGroupOnOut
```
- 강퇴 당하는 유저의 정보를 mysql에서 삭제했어요
```typescript
  async deleteGroupOnKick(groupId: number, nickname: string) {
    const queryRunner = this.dataSource.createQueryRunner();
    try {
      await queryRunner.startTransaction();
      const group = await queryRunner.manager.findOne(Group, {
        where: { id: groupId },
      });
      await queryRunner.manager
        .createQueryBuilder(UserGroup, 'user_group')
        .delete()
        .where('user_group.group_id = :groupId', { groupId })
        .andWhere('user_group.user_id IN (SELECT id FROM `user` WHERE nickname = :nickname)', {
          nickname,
        })
        .execute();
      group.currentMembers -= 1;
      await queryRunner.manager.save(group);
      await queryRunner.commitTransaction();
    } catch (error) {
      await queryRunner.rollbackTransaction();
      throw error;
    } finally {
      await queryRunner.release();
    }
```
- 나가기와 강퇴를 같은 서비스 함수를 사용했어요
  - 인자가 많아져 dto을 추가했어요 
```typescript
  async leaveChatRoom(dto: ChatLeaveRoomDto): Promise<ChatLeaveRoomResponseDto> {
    await this.chatRepository.updateUserInfoOnLeave(dto.userChatId);
    const message = await this.chatRepository.createMessageByLeaveEvent(
      dto.roomId,
      dto.nickname,
      dto.chatType
    );
    const chatUsers = await this.chatRepository.findUserListByRoomId(dto.roomId);
    const unreadCountMap = this.makeUnreadCountMap(chatUsers);
    return { chatUsers, unreadCountMap, message };
  }
```
- updateUserInfoOnLeave 함수에서 유저 아이디를 찾는 로직을 분리 했어요
```typescript
  async getNicknameByChatUserId(chatUserId: string) {
    const chatUser = await this.chatUserModel.findOne({ _id: chatUserId });
    if (!chatUser) {
      throw new HttpException('유저가 방에 없습니다.', HttpStatus.BAD_REQUEST);
    }
    return chatUser.user_nickname;
  }

  async updateUserInfoOnLeave(chatUserId: string) {
    await this.chatUserModel.updateOne(
      { _id: chatUserId },
      {
        $set: {
          is_leave: true,
        },
        $unset: {
          last_chat_log_id: true,
        },
      }
    );
  }
```

closes #302 

