### PR TITLE
Feature/BE/#323: 모집 정보 수정 

### DIFF
--- a/backend/src/modules/userModules/group/dtos/group.create.dto.ts
+++ b/backend/src/modules/userModules/group/dtos/group.create.dto.ts
@@ -1,17 +1,40 @@
+import { Type } from 'class-transformer';
+import { IsBoolean, IsString, IsNumber, IsDate } from 'class-validator';
 import { ApiProperty } from '@nestjs/swagger';
 
 export class GroupRequestDto {
   @ApiProperty({ description: '모집 인원', example: 4 })
+  @Type(() => {
+    return Number;
+  })
+  @IsNumber()
   recruitmentMembers: number;
+
   @ApiProperty({
     description: '모집 내용',
     example: '(테마 변경 가능)11월 5일 오후 5시에 갈사람 구해요. ',
   })
+  @IsString()
   recruitmentContent: string;
+
   @ApiProperty({ description: '예약 완료 여부', example: false })
+  @Type(() => {
+    return Boolean;
+  })
+  @IsBoolean()
   appointmentCompleted: boolean;
+
   @ApiProperty({ description: '예약 날짜' })
+  @Type(() => {
+    return Date;
+  })
+  @IsDate()
   appointmentDate: Date;
+
   @ApiProperty({ description: '모집하는 테마의 테마 id', example: 1 })
+  @Type(() => {
+    return Number;
+  })
+  @IsNumber()
   themeId: number;
 }

--- a/backend/src/modules/userModules/group/dtos/group.edit.dto.ts
+++ b/backend/src/modules/userModules/group/dtos/group.edit.dto.ts
@@ -1,0 +1,17 @@
+import { Type } from 'class-transformer';
+import { IsBoolean, IsOptional } from 'class-validator';
+import { GroupRequestDto } from '@group/dtos/group.create.dto';
+
+export class GroupEditDto extends GroupRequestDto {
+  @Type(() => {
+    return Boolean;
+  })
+  @IsBoolean()
+  recruitmentCompleted: boolean;
+
+  @IsOptional()
+  leaderNickname?: string;
+
+  @IsOptional()
+  groupId?: number;
+}

--- a/backend/src/modules/userModules/group/group.repository.ts
+++ b/backend/src/modules/userModules/group/group.repository.ts
@@ -10,6 +10,7 @@ import { Theme } from '@theme/entities/theme.entity';
 import { Branch } from '@branch/entities/branch.entity';
 import { Brand } from '@brand/entities/brand.entity';
 import { GroupInfoResponseDto } from '@group/dtos/group.info.response.dto';
+import { GroupEditDto } from '@group/dtos/group.edit.dto';
 
 @Injectable()
 export class GroupRepository extends Repository<Group> {
@@ -271,6 +272,73 @@ export class GroupRepository extends Repository<Group> {
       group.currentMembers -= 1;
       await queryRunner.manager.save(group);
       await queryRunner.commitTransaction();
+    } catch (error) {
+      await queryRunner.rollbackTransaction();
+      throw error;
+    } finally {
+      await queryRunner.release();
+    }
+  }
+
+  async editGroupInfo(groupEditDto: GroupEditDto): Promise<GroupInfoResponseDto> {
+    const queryRunner = this.dataSource.createQueryRunner();
+    try {
+      await queryRunner.startTransaction();
+      const group = await queryRunner.manager.findOne(Group, {
+        where: { id: groupEditDto.groupId },
+        relations: ['leader', 'theme'],
+      });
+      const { theme, leader } = group;
+      if (leader.nickname !== groupEditDto.leaderNickname) {
+        throw new HttpException('방장만 정보 수정이 가능합니다.', HttpStatus.BAD_REQUEST);
+      }
+      if (theme.id !== groupEditDto.themeId) {
+        throw new HttpException('테마는 변경할 수 없습니다.', HttpStatus.BAD_REQUEST);
+      }
+      if (group.currentMembers > groupEditDto.recruitmentMembers) {
+        throw new HttpException(
+          '모집된 인원 수가 수정하려는 새로운 인원 수보다 많아 수정할 수 없습니다.',
+          HttpStatus.BAD_REQUEST
+        );
+      }
+
+      await queryRunner.manager
+        .createQueryBuilder(Group, 'group')
+        .update()
+        .set({
+          recruitmentMembers: groupEditDto.recruitmentMembers,
+          recruitmentContent: groupEditDto.recruitmentContent,
+          recruitmentCompleted: groupEditDto.recruitmentCompleted,
+          appointmentDate: groupEditDto.appointmentDate,
+          appointmentCompleted: groupEditDto.appointmentCompleted,
+        })
+        .where('group.id = :groupId', { groupId: groupEditDto.groupId })
+        .execute();
+
+      const editedGroupInfo = queryRunner.manager
+        .createQueryBuilder(Group, 'group')
+        .select([
+          'brand.brandName as brandName',
+          'branch.branchName as branchName',
+          "CONCAT(branch.big_region, ' ', branch.small_region) AS regionName",
+          'theme.name as themeName',
+          'theme.id as themeId',
+          'theme.poster_image_url as posterImageUrl',
+          'group.recruitment_content as recruitmentContent',
+          'group.appointment_date as appointmentDate',
+          'group.recruitment_members as recruitmentMembers',
+          'group.current_members as currentMembers',
+          'group.recruitment_completed as recruitmentCompleted',
+          'group.appointment_completed as appointmentCompleted',
+        ])
+        .where('group.id = :groupId', { groupId: groupEditDto.groupId })
+        .innerJoin(Theme, 'theme', 'group.theme_id = theme.id')
+        .innerJoin(Branch, 'branch', 'theme.branch_id = branch.id')
+        .innerJoin(Brand, 'brand', 'branch.brand_id = brand.id')
+        .getRawOne();
+
+      await queryRunner.commitTransaction();
+      return editedGroupInfo;
     } catch (error) {
       await queryRunner.rollbackTransaction();
       throw error;

--- a/backend/src/modules/userModules/group/group.service.ts
+++ b/backend/src/modules/userModules/group/group.service.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { GroupRepository } from '@group/group.repository';
+import { GroupEditDto } from '@group/dtos/group.edit.dto';
 import { GroupRequestDto } from '@group/dtos/group.create.dto';
 import { ThemeRepository } from '@theme/theme.repository';
 import { GroupFindOptionsDto } from '@group/dtos/group.findoptions.request.dto';
@@ -96,5 +97,8 @@ export class GroupService {
   }
   async deleteGroupOnKick(groupId: number, nickname: string) {
     return await this.groupRepository.deleteGroupOnKick(groupId, nickname);
+  }
+  async editGroupInfo(groupEditDto: GroupEditDto): Promise<GroupInfoResponseDto> {
+    return await this.groupRepository.editGroupInfo(groupEditDto);
   }
 }


### PR DESCRIPTION
## 🤷‍♂️ Description
- 채팅방에서 모집 정보를 수정할 수 있어요.

## 📝 Primary Commits
- Dto을 추가했어요.
  - GroupRequestDto을 상속받는 GroupEditDto을 만들었어요.
  - GroupRequestDto에 데이터를 변환하고 유효성 검사를 해주었어요.
  - leaderNickname과 groupId는 서버에서 지정해주기 때문에 IsOptional를 적용했어요.
- 그룹 정보를 업데이트 했어요.
  - 요청한 사람이 리더인지 확인했어요.
  - 테마가 다른 경우와 모집된 인원 수가 수정할 인원수보다 많을 때 예외처리를 했어요.
  - 업데이트 후 변경된 데이터와 함께 필요한 정보를 반환했어요.
 ```typescript
await queryRunner.manager
        .createQueryBuilder(Group, 'group')
        .update()
        .set({
          recruitmentMembers: groupEditDto.recruitmentMembers,
          recruitmentContent: groupEditDto.recruitmentContent,
          recruitmentCompleted: groupEditDto.recruitmentCompleted,
          appointmentDate: groupEditDto.appointmentDate,
          appointmentCompleted: groupEditDto.appointmentCompleted,
        })
        .where('group.id = :groupId', { groupId: groupEditDto.groupId })
        .execute();
```
- ` await queryRunner.manager.save(group);` 처음에는 save을 사용해 업데이트 했어요  
```mysql
query : 
SELECT 
  `Group`.`created_at` AS `Group_created_at`, 
  `Group`.`updated_at` AS `Group_updated_at`, 
  `Group`.`id` AS `Group_id`, 
  `Group`.`current_members` AS `Group_current_members`, 
  `Group`.`diary_created` AS `Group_diary_created`, 
  `Group`.`recruitment_members` AS `Group_recruitment_members`, 
  `Group`.`recruitment_content` AS `Group_recruitment_content`, 
  `Group`.`recruitment_completed` AS `Group_recruitment_completed`, 
  `Group`.`password` AS `Group_password`, 
  `Group`.`appointment_date` AS `Group_appointment_date`, 
  `Group`.`appointment_time` AS `Group_appointment_time`, 
  `Group`.`appointment_completed` AS `Group_appointment_completed`, 
  `Group`.`leader_id` AS `Group_leader_id`, 
  `Group`.`theme_id` AS `Group_theme_id` 
FROM 
  `group` `Group` 
WHERE 
  `Group`.`id` IN (?) -- PARAMETERS: [170]
  query : 
UPDATE 
  `group` 
SET 
  `appointment_date` = ?, 
  `updated_at` = CURRENT_TIMESTAMP 
WHERE 
  `id` IN (?) -- PARAMETERS: ["2023-12-07T10:38:33.761Z",170]
  query : 
SELECT 
  `Group`.`updated_at` AS `Group_updated_at`, 
  `Group`.`id` AS `Group_id` 
FROM 
  `group` `Group` 
WHERE 
  `Group`.`id` = ? -- PARAMETERS: [170]
```
- 쿼리 빌더로 업데이트 시 
```mysql
query : 
UPDATE 
  `group` 
SET 
  `recruitment_members` = ?, 
  `recruitment_content` = ?, 
  `recruitment_completed` = ?, 
  `appointment_date` = ?, 
  `appointment_completed` = ?, 
  `updated_at` = CURRENT_TIMESTAMP 
WHERE 
  group.id = ? -- PARAMETERS: [5,"변경했어요7",1,"2023-12-07T10:39:51.401Z",1,170]
```
- 불필요한 select을 하는 쿼리들은 추후에 개선해볼게요 !
- 같은 방에 있는 사람들에게도 방 정보가 실시간으로 변경되는지 테스트가 필요해요!


<!-- ex) -->
<!-- closes #323 --> 

