### PR TITLE
Fix/FE/#329 react-query의 gcTime 설정

### DIFF
--- a/frontend/src/hooks/query/useSearchSimpleThemeQuery.tsx
+++ b/frontend/src/hooks/query/useSearchSimpleThemeQuery.tsx
@@ -5,6 +5,7 @@ const useSearchSimpleThemeQuery = (value: string) => {
     queryKey: ['qwe', value],
     queryFn: () => fetchThemeByName(value),
     staleTime: 60 * 60 * 3600,
+    gcTime: 60 * 60 * 3600,
     enabled: value !== '',
   });
 

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -16,7 +16,7 @@ async function deferRender() {
 }
 
 const queryClient = new QueryClient({
-  defaultOptions: { queries: { retry: false } },
+  defaultOptions: { queries: { retry: false, staleTime: 0, gcTime: 0 } },
 });
 
 deferRender().then(() => {


### PR DESCRIPTION
## 🤷‍♂️ Description
그룹 채팅방 페이지에서 데이터를 불러오지 못하는 문제가 cache문제라서 cacheTime을 설정하려고했는데 cacheTime이 gcTIme으로 명칭이 바껴서 gcTime의 default를 0으로 설정했습니다.

또, simple theme input에서 gcTime을 1시간으로 설정했습니다.

<!-- 구현 한 기능에 대해 작성해 주세요. -->

## 📝 Primary Commits

<!-- 세부 구현 사항을 리스트로 작성해주세요. -->

- [X] gcTime 설정
- [X] simple theme input에서 gcTime을 1시간으로 설정

## 📷 Screenshots

<!--스크린샷으로 보여줄 수 있는 이미지가 있다면 첨부해주세요!-->

<!--BE의 경우 API 테스트 결과를 첨부해주세요-->

<!--마지막으로 이슈 생성 시 우측의 옵션들을 체크했는지 확인해주세요!-->

<!-- 이슈번호를 작성해주세요. -->
<!-- 여러 이슈를 입력시 comma(,) 단위로 구분해주세요 -->
<!-- ex) close #10, resolves #123 -->


<!-- ex) -->
<!-- closes #1 --> 

