### PR TITLE
Feature/FE/#335: memo 적용

### DIFF
--- a/frontend/src/pages/ChatRoom/components/ChatPanel/MessageBox/MessageBox.tsx
+++ b/frontend/src/pages/ChatRoom/components/ChatPanel/MessageBox/MessageBox.tsx
@@ -5,14 +5,22 @@ import { useRecoilValue } from 'recoil';
 import MyChatBox from './BoxType/MyChatBox';
 import OtherChatBox from './BoxType/OtherChatBox';
 import SystemChatBox from './BoxType/SystemChatBox';
-import { useMemo } from 'react';
+import { useMemo, memo } from 'react';
 interface Props extends ChatLog {
   logId: string;
   isFirstChat: boolean;
   isLastChat: boolean;
 }
 
-const MessageBox = ({ logId, message, userId, type, time, isFirstChat, isLastChat }: Props) => {
+const MessageBox = memo(function MessageBox({
+  logId,
+  message,
+  userId,
+  type,
+  time,
+  isFirstChat,
+  isLastChat,
+}: Props) {
   const chatUnread = useRecoilValue(chatUnreadAtom);
   const userData = useRecoilValue(userListInfoAtom);
   const myData = userData?.get(userId) || {
@@ -72,7 +80,7 @@ const MessageBox = ({ logId, message, userId, type, time, isFirstChat, isLastCha
       )}
     </Layout>
   );
-};
+});
 
 const Layout = styled.div<{ isMe: boolean; type: string }>(({ isMe, type }) => [
   css`


### PR DESCRIPTION
## 🤷‍♂️ Description
MessageBox의 경우 채팅 데이터만 가지고있는데 채팅 데이터가 변하지 않으므로 부모가 변하더라도 리렌더링이 되지 않아도 돼요.(ex 채팅 입력할 때)

읽음 처리할때만 리렌더링이 일어나야해요! 따라서 메모를 적용했어요.

<!-- 구현 한 기능에 대해 작성해 주세요. -->

## 📝 Primary Commits

<!-- 세부 구현 사항을 리스트로 작성해주세요. -->

- [X] memo 적용


## 📷 Screenshots

- 이전
![녹화_2023_12_07_22_01_25_317](https://github.com/boostcampwm2023/web03-LockFestival/assets/100738049/7e883024-a4f7-4078-8ab8-c10985ce6a8d)


- 이후
![녹화_2023_12_07_22_03_41_275](https://github.com/boostcampwm2023/web03-LockFestival/assets/100738049/3681f8f7-132f-4d6c-9950-a152c1fb4ba4)


<!--스크린샷으로 보여줄 수 있는 이미지가 있다면 첨부해주세요!-->

<!--BE의 경우 API 테스트 결과를 첨부해주세요-->

<!--마지막으로 이슈 생성 시 우측의 옵션들을 체크했는지 확인해주세요!-->

<!-- 이슈번호를 작성해주세요. -->
<!-- 여러 이슈를 입력시 comma(,) 단위로 구분해주세요 -->
<!-- ex) close #10, resolves #123 -->


<!-- ex) -->
<!-- closes #1 --> 

