### PR TITLE
Feature/FE/#327: 테마 상세 모달, 검색페이지 카드 모집 바로가기 기능 추가

### DIFF
--- a/frontend/src/components/Card/SimpleThemeCard/SimpleThemeCard.tsx
+++ b/frontend/src/components/Card/SimpleThemeCard/SimpleThemeCard.tsx
@@ -31,6 +31,7 @@ const SimpleThemeCard = ({ themeId, themeName, posterImageUrl }: SimpleThemeCard
 const CardContainer = styled.div([
   tw`font-pretendard text-white bg-gray`,
   tw`desktop:(text-s h-[28.4rem] w-[18.2rem] rounded-[2rem])`,
+  tw`tablet:(text-s h-[20.6rem] w-[14.2rem] rounded-[2rem])`,
   tw`mobile:(text-xs h-[20.3rem] w-[12.8rem] rounded-[1.4rem])`,
   css`
     display: flex;
@@ -44,6 +45,7 @@ const CardContainer = styled.div([
 const CardImg = styled.img([
   tw`mb-2 rounded-[1.5rem]`,
   tw`desktop:(w-[15.6rem] h-[23.6rem])`,
+  tw`tablet:(w-[12.6rem] h-[18.6rem])`,
   tw`mobile:(w-[10rem] h-[16rem])`,
 ]);
 const CardText = styled.span([

--- a/frontend/src/components/Carousel/Carousel.tsx
+++ b/frontend/src/components/Carousel/Carousel.tsx
@@ -35,6 +35,7 @@ const Carousel = ({ children }: CarouselProps) => {
 const CarouselContainer = styled.div([
   tw`w-full bg-gray-light rounded-default`,
   tw`desktop:(max-w-[102.4rem] h-[32.4rem])`,
+  tw`tablet:(max-w-[78rem] h-[32.4rem])`,
   tw`mobile:(max-w-[43rem] h-[21.6rem])`,
   css`
     display: flex;

--- a/frontend/src/components/List/SimpleThemeCardList/SimpleThemeCardList.tsx
+++ b/frontend/src/components/List/SimpleThemeCardList/SimpleThemeCardList.tsx
@@ -30,11 +30,12 @@ const SimpleThemeCardList = ({ themes }: SimpleThemeCardListProps) => {
   );
 };
 
-const CardContainer = styled.div([tw`desktop:(mx-4)`, tw`mobile:(mx-2)`]);
+const CardContainer = styled.div([tw`desktop:(mx-4)`, tw`tablet:(mx-4)`, tw`mobile:(mx-2)`]);
 
 const NoThemeContainer = styled.div([
   tw`w-full overflow-hidden bg-gray-light text-[4rem] text-white rounded-default`,
   tw`desktop:(max-w-[102.4rem] h-[32.4rem])`,
+  tw`tablet:(max-w-[80rem] h-[28.4rem])`,
   tw`mobile:(max-w-[43rem] h-[21.6rem])`,
   css`
     display: flex;

--- a/frontend/src/components/ThemeDetailsModal/ThemeDetailsModal.tsx
+++ b/frontend/src/components/ThemeDetailsModal/ThemeDetailsModal.tsx
@@ -53,21 +53,23 @@ function ThemeDetailsModal({ themeId, onClose }: ThemeDetailsModalProps) {
                 <Button
                   isIcon={false}
                   size="m"
+                  width="10rem"
                   onClick={() => {
                     window.open(data.website);
                   }}
                 >
-                  <>예약바로가기</>
+                  <Text>예약바로가기</Text>
                 </Button>
                 <Button
                   isIcon={false}
                   size="m"
+                  width="10rem"
                   onClick={() => {
                     onClose();
                     navigate('/recruitment');
                   }}
                 >
-                  <>모집바로가기</>
+                  <Text>모집바로가기</Text>
                 </Button>
               </ButtonWrapper>
             </MainWrapper>
@@ -114,7 +116,7 @@ const DetailModalContainer = styled.div([
     display: flex;
     flex-direction: column;
   `,
-  tw`p-6 bg-gray-light rounded-default`,
+  tw`p-6 bg-gray-light rounded-default w-[75rem] tablet:(w-[60rem] p-4) mobile:(w-[34rem] p-2)`,
 ]);
 
 const HeadWrapper = styled.div([
@@ -130,13 +132,13 @@ const HeadWrapper = styled.div([
 const MainWrapper = styled.div([
   css`
     display: flex;
-    justify-content: flex-start;
+    justify-content: space-between;
     margin-bottom: 1.6rem;
   `,
 ]);
 
 const MainThemePosterBox = styled.div([
-  tw`bg-gray-dark rounded-[2rem]`,
+  tw`bg-gray-dark rounded-[2rem] mobile:(hidden)`,
   css`
     width: 18.5rem;
     height: 27.2rem;
@@ -156,6 +158,7 @@ const InfoWrapper = styled.div([
   css`
     display: flex;
     flex-direction: column;
+    flex: 1;
     gap: 0.8rem;
   `,
   tw`ml-4`,
@@ -176,6 +179,7 @@ const BottomWrapper = styled.div([
     display: flex;
     flex-direction: column;
   `,
+  tw`mobile:(hidden)`,
 ]);
 
 const OtherThemeList = styled.div([
@@ -185,3 +189,5 @@ const OtherThemeList = styled.div([
     gap: 1.2rem;
   `,
 ]);
+
+const Text = styled.div([tw`mx-auto`]);

--- a/frontend/src/components/ThemeDetailsModal/ThemeDetailsModal.tsx
+++ b/frontend/src/components/ThemeDetailsModal/ThemeDetailsModal.tsx
@@ -66,7 +66,9 @@ function ThemeDetailsModal({ themeId, onClose }: ThemeDetailsModalProps) {
                   width="10rem"
                   onClick={() => {
                     onClose();
-                    navigate('/recruitment');
+                    navigate(
+                      `/recruitment?smallRegion=${data.smallRegion}&bigRegion=${data.bigRegion}&themeName=${data.themeName}`
+                    );
                   }}
                 >
                   <Text>모집바로가기</Text>

--- a/frontend/src/components/ThemeDetailsModal/components/ThemeInfoItem.tsx
+++ b/frontend/src/components/ThemeDetailsModal/components/ThemeInfoItem.tsx
@@ -4,9 +4,11 @@ import tw, { styled, css } from 'twin.macro';
 export const ThemeInfoItem = (labelName: string, infoContent: string) => {
   return (
     <InfoItem>
-      <Label isBorder={true} size="m-bold" width="10rem">
-        <FlexCenter>{labelName}</FlexCenter>
-      </Label>
+      <LabelWrapper>
+        <Label isBorder={true} size="m-bold" width="10rem">
+          <FlexCenter>{labelName}</FlexCenter>
+        </Label>
+      </LabelWrapper>
       <InfoContent>{infoContent}</InfoContent>
     </InfoItem>
   );
@@ -17,6 +19,12 @@ const FlexCenter = styled.div([
     display: flex;
     width: 100%;
     justify-content: center;
+  `,
+]);
+
+const LabelWrapper = styled.div([
+  css`
+    min-width: 10rem;
   `,
 ]);
 

--- a/frontend/src/config/carouselConfig.ts
+++ b/frontend/src/config/carouselConfig.ts
@@ -7,13 +7,6 @@ export const carouselConfig = {
   initialSlide: 0,
   responsive: [
     {
-      breakpoint: 1480,
-      settings: {
-        slidesToShow: 6,
-        slidesToScroll: 5,
-      },
-    },
-    {
       breakpoint: 1024,
       settings: {
         slidesToShow: 5,

--- a/frontend/src/hooks/query/useRecruitmentListInfiniteQuery.tsx
+++ b/frontend/src/hooks/query/useRecruitmentListInfiniteQuery.tsx
@@ -1,11 +1,22 @@
 import QUERY_MANAGEMENT from '@constants/queryManagement';
 import { useInfiniteQuery } from '@tanstack/react-query';
+import { useSearchParams } from 'react-router-dom';
 
 const useRecruitmentListInfiniteQuery = () => {
+  const [searchParams] = useSearchParams();
+  const themeName = searchParams.get('themeName') || '';
+  const smallRegion = searchParams.get('smallRegion') || '';
+  const bigRegion = searchParams.get('bigRegion') || '';
+
   const { data, error, fetchNextPage, hasNextPage, isFetching } = useInfiniteQuery({
-    queryKey: [QUERY_MANAGEMENT['recruitmentList'].key],
+    queryKey: [QUERY_MANAGEMENT['recruitmentList'].key, themeName + bigRegion + smallRegion],
     queryFn: ({ pageParam }) =>
-      QUERY_MANAGEMENT['recruitmentList'].fn({ cursorGroupId: pageParam }),
+      QUERY_MANAGEMENT['recruitmentList'].fn({
+        cursorGroupId: pageParam,
+        themeName,
+        smallRegion,
+        bigRegion,
+      }),
     initialPageParam: -1,
     getNextPageParam: (lastPage) => {
       return lastPage._meta.nextCursor;

--- a/frontend/src/hooks/useRandomThemesQuery.tsx
+++ b/frontend/src/hooks/useRandomThemesQuery.tsx
@@ -1,4 +1,4 @@
-import { useQuery, useSuspenseQuery } from '@tanstack/react-query';
+import { useSuspenseQuery } from '@tanstack/react-query';
 import QUERY_MANAGEMENT from '@constants/queryManagement';
 
 const useRandomThemesQuery = () => {

--- a/frontend/src/hooks/useRandomThemesQuery.tsx
+++ b/frontend/src/hooks/useRandomThemesQuery.tsx
@@ -1,8 +1,8 @@
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, useSuspenseQuery } from '@tanstack/react-query';
 import QUERY_MANAGEMENT from '@constants/queryManagement';
 
 const useRandomThemesQuery = () => {
-  const { data, isSuccess, isError, isLoading } = useQuery({
+  const { data, isSuccess, isError, isLoading } = useSuspenseQuery({
     queryKey: [QUERY_MANAGEMENT['randomThemes'].key],
     queryFn: QUERY_MANAGEMENT['randomThemes'].fn,
   });

--- a/frontend/src/pages/Root/components/GeoLocationThemeListContainer.tsx
+++ b/frontend/src/pages/Root/components/GeoLocationThemeListContainer.tsx
@@ -49,6 +49,7 @@ const Text = styled.div([
     display: flex;
     align-items: center;
     justify-self: center;
+    align-self: flex-start;
   `,
 ]);
 

--- a/frontend/src/pages/Root/components/RandomThemeListContainer.tsx
+++ b/frontend/src/pages/Root/components/RandomThemeListContainer.tsx
@@ -1,4 +1,4 @@
-import tw, { styled } from 'twin.macro';
+import tw, { css, styled } from 'twin.macro';
 import Label from '@components/Label/Label';
 import useRandomThemesQuery from '@hooks/useRandomThemesQuery';
 import SimpleThemeCardList from '@components/List/SimpleThemeCardList/SimpleThemeCardList';
@@ -15,9 +15,11 @@ const RandomThemeListContainer = () => {
       {data.map((ele) => {
         return (
           <Fragment key={ele.genreName}>
-            <Label isBorder={true} font="maplestory" size="l">
-              <>{ele.genreName}</>
-            </Label>
+            <LabelWrapper>
+              <Label isBorder={true} font="maplestory" size="l">
+                <>{ele.genreName}</>
+              </Label>
+            </LabelWrapper>
             <SimpleCardContainer>
               <SimpleThemeCardList themes={ele.themes} />
             </SimpleCardContainer>
@@ -27,6 +29,10 @@ const RandomThemeListContainer = () => {
     </>
   );
 };
+
+const LabelWrapper = styled.div(css`
+  align-self: flex-start;
+`);
 
 const SimpleCardContainer = styled.div([tw`my-2 mt-[-0.5rem]`]);
 

--- a/frontend/src/pages/Root/components/RootLayout.tsx
+++ b/frontend/src/pages/Root/components/RootLayout.tsx
@@ -1,12 +1,16 @@
 import tw, { styled, css } from 'twin.macro';
 import RandomThemeListContainer from './RandomThemeListContainer';
 import GeoLocationThemeListContainer from './GeoLocationThemeListContainer';
+import { Suspense } from 'react';
+import RootSkeletonComponent from './RootSkeletonComponent';
 
 const RootLayout = () => {
   return (
     <Container>
-      <RandomThemeListContainer />
-      <GeoLocationThemeListContainer />
+      <Suspense fallback={<RootSkeletonComponent />}>
+        <RandomThemeListContainer />
+        <GeoLocationThemeListContainer />
+      </Suspense>
     </Container>
   );
 };

--- a/frontend/src/pages/Root/components/RootLayout.tsx
+++ b/frontend/src/pages/Root/components/RootLayout.tsx
@@ -18,9 +18,12 @@ const RootLayout = () => {
 const Container = styled.div([
   tw`w-full mx-auto mt-[4rem]`,
   tw`desktop:(max-w-[102.4rem] pb-[10rem])`,
+  tw`tablet:(max-w-[78rem])`,
+  tw`mobile:(max-w-[80%])`,
   css`
     display: flex;
     flex-direction: column;
+    align-items: center;
     gap: 1.5rem;
   `,
 ]);

--- a/frontend/src/pages/Root/components/RootSkeletonComponent.tsx
+++ b/frontend/src/pages/Root/components/RootSkeletonComponent.tsx
@@ -42,7 +42,8 @@ const RootSkeletonComponent = () => {
 
 const CardListContainer = styled.div([
   tw`bg-gray-light rounded-default `,
-  tw`desktop:(px-4 h-[32.4rem])`,
+  tw`desktop:(px-4 h-[32.4rem] gap-[3.4rem])`,
+  tw`tablet:(px-4 h-[32.4rem])`,
   tw`mobile:(px-2  h-[21.6rem])`,
   css`
     display: flex;
@@ -69,6 +70,7 @@ const SkeletonLabel = styled.div([
     background: #f2f2f2;
     position: relative;
     overflow: hidden;
+    align-self: flex-start;
 
     &::before {
       content: '';
@@ -87,6 +89,7 @@ const SkeletonLabel = styled.div([
 const SkeletonCard = styled.div`
   ${tw`mb-2 rounded-[1.5rem] bg-gray`}
   ${tw`desktop:(w-[16.8rem] h-[26.4rem])`}
+  ${tw`tablet:(w-[14.2rem] h-[20.4rem])`}
   ${tw`mobile:(w-[10rem] h-[16rem])`}
   background: #222222;
   position: relative;

--- a/frontend/src/pages/Search/components/Card.tsx
+++ b/frontend/src/pages/Search/components/Card.tsx
@@ -20,6 +20,8 @@ const Card = ({ theme }: { theme: ThemeDetailsData }) => {
     website,
     phone,
     address,
+    smallRegion,
+    bigRegion,
   } = theme;
 
   const handleClickFlipButton = () => {
@@ -34,6 +36,8 @@ const Card = ({ theme }: { theme: ThemeDetailsData }) => {
           themeName={themeName}
           posterImageUrl={posterImageUrl}
           brandBranchName={brandBranchName}
+          smallRegion={smallRegion}
+          bigRegion={bigRegion}
           handleClickFlipButton={handleClickFlipButton}
         />
       ) : (

--- a/frontend/src/pages/Search/components/Card/HeadCard/HeadCard.tsx
+++ b/frontend/src/pages/Search/components/Card/HeadCard/HeadCard.tsx
@@ -11,6 +11,8 @@ interface Props {
   posterImageUrl: string;
   brandBranchName: string;
   themeName: string;
+  smallRegion: string | undefined;
+  bigRegion: string | undefined;
   handleClickFlipButton: () => void;
 }
 
@@ -19,13 +21,17 @@ const HeadCard = ({
   posterImageUrl,
   brandBranchName,
   themeName,
+  smallRegion,
+  bigRegion,
   handleClickFlipButton,
 }: Props) => {
   const navigate = useNavigate();
   const { openModal, closeModal } = useModal();
 
   const handleGoRecruitment = () => {
-    navigate('/recruitment');
+    navigate(
+      `/recruitment?smallRegion=${smallRegion}&bigRegion=${bigRegion}&themeName=${themeName}`
+    );
   };
 
   const handleCreateRoom = () => {


### PR DESCRIPTION
## 🤷‍♂️ Description
- 테마 상세 모달과 검색페이지 카드에서 모집 바로가기 버튼을 기존에 전체 모집글을 보여줬다면, 해당 테마로 모집중인 모집글을 필터링해서 보여주도록 했어요.

<!-- 구현 한 기능에 대해 작성해 주세요. -->

## 📝 Primary Commits

<!-- 세부 구현 사항을 리스트로 작성해주세요. -->

- [X] useRecruitmentListInfiniteQuery 필터로직 추가
- [X] 테마 상세 모달 모집 바로가기 버튼에 적용
- [X] 검색페이지 카드 모집 바로가기 버튼에 적용

## 📷 Screenshots

https://github.com/boostcampwm2023/web03-LockFestival/assets/82202370/cbb55f05-6dfa-43c5-83a6-c0ff54af61ac


<!--스크린샷으로 보여줄 수 있는 이미지가 있다면 첨부해주세요!-->

<!--BE의 경우 API 테스트 결과를 첨부해주세요-->

<!--마지막으로 이슈 생성 시 우측의 옵션들을 체크했는지 확인해주세요!-->

<!-- 이슈번호를 작성해주세요. -->
<!-- 여러 이슈를 입력시 comma(,) 단위로 구분해주세요 -->
<!-- ex) close #10, resolves #123 -->


<!-- ex) -->
<!-- closes #1 --> 

closes #327 