### PR TITLE
Fix/FE/#338: 맥에서 한글 채팅만 2번 전송되는 문제 및 \n 줄바꿈 적용

### DIFF
--- a/frontend/src/pages/ChatRoom/components/ChatPanel/ChatPanel.tsx
+++ b/frontend/src/pages/ChatRoom/components/ChatPanel/ChatPanel.tsx
@@ -42,7 +42,7 @@ const ChatPanel = ({ roomId, sendChat, getPastChat }: ChatPanelProps) => {
   const [inputValue, handleValue, resetValue] = useInput('');
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
-    if (e.key === 'Enter' && !e.shiftKey) {
+    if (e.key === 'Enter' && !e.shiftKey && !e.nativeEvent.isComposing) {
       e.preventDefault();
       handleSubmit();
     }

--- a/frontend/src/pages/ChatRoom/components/ChatPanel/MessageBox/BoxType/MyChatBox.tsx
+++ b/frontend/src/pages/ChatRoom/components/ChatPanel/MessageBox/BoxType/MyChatBox.tsx
@@ -53,6 +53,7 @@ const MessageContent = styled.div([
     max-width: 25rem;
     width: fit-content;
     word-break: break-all;
+    white-space: pre-wrap;
   `,
 ]);
 

--- a/frontend/src/pages/ChatRoom/components/ChatPanel/MessageBox/BoxType/OtherChatBox.tsx
+++ b/frontend/src/pages/ChatRoom/components/ChatPanel/MessageBox/BoxType/OtherChatBox.tsx
@@ -87,6 +87,7 @@ const MessageContent = styled.div([
     max-width: 25rem;
     width: fit-content;
     word-break: break-all;
+    white-space: pre-wrap;
   `,
 ]);
 

--- a/frontend/src/pages/ChatRoom/components/ChatPanel/MessageBox/BoxType/SystemChatBox.tsx
+++ b/frontend/src/pages/ChatRoom/components/ChatPanel/MessageBox/BoxType/SystemChatBox.tsx
@@ -36,6 +36,7 @@ const MessageContent = styled.div([
   css`
     text-align: center;
     word-break: break-all;
+    white-space: pre-wrap;
   `,
 ]);
 


### PR DESCRIPTION
## 🤷‍♂️ Description
맥에서 한글 채팅만 2번 전송되는 문제가 있었어요. 해당 부분을 isComposing을 사용해서 해결했어요!

또, textarea에서 \n을 입력해도 표시되는 곳에서는 단순 공백으로 표시가 되었는데 `white-space: pre-wrap;`을 써서 해결했어요!


<!-- 구현 한 기능에 대해 작성해 주세요. -->

## 📝 Primary Commits

<!-- 세부 구현 사항을 리스트로 작성해주세요. -->

- [X] isComposing을 사용하여 이벤트 2번 발생막음
- [X] textarea 줄바꿈 표시
## 📷 Screenshots

- 한글 두번 발생

![Dec-08-2023 00-08-35](https://github.com/boostcampwm2023/web03-LockFestival/assets/100738049/d68aa947-cf98-442e-af0b-5e3553d55d01)




- isComposing을 사용 후 한글을 입력해도 한번만 이벤트가 발생
![22'](https://github.com/boostcampwm2023/web03-LockFestival/assets/100738049/68bc2b65-12de-4ff2-9e05-afbf527d5656)



- \n을 화면에 표시
![Dec-08-2023 00-19-31](https://github.com/boostcampwm2023/web03-LockFestival/assets/100738049/f223a418-a28a-49cb-ab36-dc72c31f56ba)




<!--스크린샷으로 보여줄 수 있는 이미지가 있다면 첨부해주세요!-->

<!--BE의 경우 API 테스트 결과를 첨부해주세요-->

<!--마지막으로 이슈 생성 시 우측의 옵션들을 체크했는지 확인해주세요!-->

<!-- 이슈번호를 작성해주세요. -->
<!-- 여러 이슈를 입력시 comma(,) 단위로 구분해주세요 -->
<!-- ex) close #10, resolves #123 -->


<!-- ex) -->
<!-- closes #1 --> 

