### PR TITLE
Feature/FE/#342: 헤더 태블릿 사이즈 반응형 및 focus 오류 수정

### DIFF
--- a/frontend/src/components/Header/HeaderNav/HeaderNav.tsx
+++ b/frontend/src/components/Header/HeaderNav/HeaderNav.tsx
@@ -1,14 +1,12 @@
 import tw, { css, styled } from 'twin.macro';
-import { useState } from 'react';
 import { NavMenu } from 'types/navMenu';
-import { useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 const HeaderNav = () => {
   const navigate = useNavigate();
-  const [selectedItem, setSelectedItem] = useState<NavMenu>('');
+  const location = useLocation();
 
   const handleSelectedItem = (item: NavMenu) => {
-    setSelectedItem(item);
-    navigate(`/${item}`);
+    navigate(`${item}`);
   };
 
   return (
@@ -16,18 +14,18 @@ const HeaderNav = () => {
       <HeaderLogo
         src="/assets/images/logo/Big-Dark.png"
         alt="logo"
-        onClick={() => handleSelectedItem('')}
+        onClick={() => handleSelectedItem('/')}
       />
       <NavContainer>
         <NavItem
-          onClick={() => handleSelectedItem('recruitment')}
-          isSelected={selectedItem === 'recruitment'}
+          onClick={() => handleSelectedItem('/recruitment')}
+          isSelected={location.pathname === '/recruitment'}
         >
           탈출러 모집
         </NavItem>
         <NavItem
-          onClick={() => handleSelectedItem('room-list')}
-          isSelected={selectedItem === 'room-list'}
+          onClick={() => handleSelectedItem('/room-list')}
+          isSelected={location.pathname === '/room-list'}
         >
           그룹 채팅방
         </NavItem>
@@ -37,6 +35,7 @@ const HeaderNav = () => {
 };
 
 const Nav = styled.nav([
+  tw`text-l`,
   css`
     display: flex;
     align-items: center;
@@ -45,15 +44,17 @@ const Nav = styled.nav([
 
 const HeaderLogo = styled.img([
   tw`desktop:(w-[18rem] h-[3.6rem])`,
-  tw`mobile:(w-[18rem] h-[3.2rem])`,
+  tw`tablet:(w-[14rem] h-[3.2rem])`,
+  tw`mobile:(w-[10rem] h-[2.8rem])`,
   css`
     cursor: pointer;
   `,
 ]);
 
 const NavContainer = styled.ul([
-  tw`border border-white border-solid`,
-  tw`desktop:(w-[40rem] h-[3.6rem] mx-4 rounded-[4rem])`,
+  tw`border border-white border-solid rounded-[4rem]`,
+  tw`desktop:(w-[40rem] h-[3.6rem] mx-4)`,
+  tw`tablet:(w-[32rem] h-[3.2rem] mx-2)`,
   tw`mobile:(hidden)`,
   css`
     display: grid;
@@ -68,7 +69,8 @@ const NavItem = styled.li<{ isSelected: boolean }>(({ isSelected }) => [
   tw`
     h-full px-5
   `,
-  tw`desktop:(rounded-[4rem])`,
+  tw`rounded-[4rem]`,
+
   css`
     display: flex;
     align-items: center;

--- a/frontend/src/types/navMenu.ts
+++ b/frontend/src/types/navMenu.ts
@@ -1,1 +1,8 @@
-export type NavMenu = '' | 'recruitment' | 'room-list' | 'diary' | 'search' | 'mypage';
+export type NavMenu =
+  | '/'
+  | '/recruitment'
+  | '/room-list'
+  | '/diary'
+  | '/search'
+  | '/mypage'
+  | '/chat-room';


### PR DESCRIPTION
## 🤷‍♂️ Description
헤더에 태블릿 사이즈가 적용되어있지 않았어요. 따라서 아주 간단하게 적용했어요.
현재 모바일의 경우 NavMenu를 보여주지 않는데 이 부분도 추후 수정이 필요해요!

그리고 그룹 페이지, 탈출러 모집 페이지를 눌렀을 땐 NavMenu의 focus가 제대로 이동되었는데 헤더를 클릭하지 않고 페이지를 이동할 때(ex: 모집글 작성후 리스트 페이지 이동)는 focus가 옮겨지지 않는 문제가 있어서 해결했어요

<!-- 구현 한 기능에 대해 작성해 주세요. -->

## 📝 Primary Commits

<!-- 세부 구현 사항을 리스트로 작성해주세요. -->


- [X] 헤더에 태블릿 사이즈가 적용
- [x] focus 문제 해결

## 📷 Screenshots

- 헤더 반응형 

![녹화_2023_12_08_02_24_24_812](https://github.com/boostcampwm2023/web03-LockFestival/assets/100738049/e8260fcc-1c08-4e58-aec2-47acb0e9ac59)

- 이전
글 작성후 NavMenu focus가 옮겨지지 않음

![이전](https://github.com/boostcampwm2023/web03-LockFestival/assets/100738049/0bb67f24-fd2c-480f-98b7-43dabbfd807f)

- 이후
글 작성후 NavMenu focus가 옮겨짐


![이후](https://github.com/boostcampwm2023/web03-LockFestival/assets/100738049/578938f7-dae7-4c74-8c59-bc27506a9740)

<!--스크린샷으로 보여줄 수 있는 이미지가 있다면 첨부해주세요!-->

<!--BE의 경우 API 테스트 결과를 첨부해주세요-->

<!--마지막으로 이슈 생성 시 우측의 옵션들을 체크했는지 확인해주세요!-->

<!-- 이슈번호를 작성해주세요. -->
<!-- 여러 이슈를 입력시 comma(,) 단위로 구분해주세요 -->
<!-- ex) close #10, resolves #123 -->


<!-- ex) -->
<!-- closes #1 --> 
closes #342 
