### PR TITLE
Feature/FE/#322: 탈출러 모집 페이지 참여중인 방 표시

### DIFF
--- a/frontend/src/components/Card/GroupInfoCard/EnterDisplay/EnterDisplay.tsx
+++ b/frontend/src/components/Card/GroupInfoCard/EnterDisplay/EnterDisplay.tsx
@@ -1,0 +1,27 @@
+import { keyframes } from '@emotion/react';
+import tw, { styled, css } from 'twin.macro';
+
+const EnterDisplay = () => {
+  return <BlinkText>참여중인 방</BlinkText>;
+};
+
+export default EnterDisplay;
+
+const blink = keyframes`
+  0% {
+      opacity: 0;
+  }
+  50% {
+    opacity: 1;
+  }
+  100% {
+    opacity: 0;
+  }
+`;
+
+const BlinkText = styled.div([
+  css`
+    animation: ${blink} 2s infinite;
+  `,
+  tw`font-pretendard text-l text-green-light`,
+]);

--- a/frontend/src/components/Card/GroupInfoCard/HeadCard/HeadCard.tsx
+++ b/frontend/src/components/Card/GroupInfoCard/HeadCard/HeadCard.tsx
@@ -14,6 +14,7 @@ const HeadCard = ({ leader, themeDetail, groupDetail, handleClickFlipButton }: H
         nickname={leader.nickname}
         profileImageUrl={leader.profileImageUrl}
         hasPassword={groupDetail.hasPassword}
+        isEnter={groupDetail.isEnter}
       />
       <HeadCardContent
         themeDetail={themeDetail}

--- a/frontend/src/components/Card/GroupInfoCard/HeadCard/HeadCardHeader.tsx
+++ b/frontend/src/components/Card/GroupInfoCard/HeadCard/HeadCardHeader.tsx
@@ -1,14 +1,16 @@
 import tw, { styled, css } from 'twin.macro';
 import { FaRegUser } from 'react-icons/fa6';
 import { FaLock } from 'react-icons/fa6';
+import EnterDisplay from '../EnterDisplay/EnterDisplay';
 
 interface Props {
   profileImageUrl: string;
   nickname: string;
   hasPassword: boolean;
+  isEnter: boolean;
 }
 
-const HeadCardHeader = ({ profileImageUrl, nickname, hasPassword }: Props) => {
+const HeadCardHeader = ({ profileImageUrl, nickname, hasPassword, isEnter }: Props) => {
   return (
     <Header>
       <UserContainer>
@@ -21,6 +23,7 @@ const HeadCardHeader = ({ profileImageUrl, nickname, hasPassword }: Props) => {
         )}
         <Text>{nickname}</Text>
       </UserContainer>
+      {isEnter && <EnterDisplay />}
       {hasPassword && <FaLock size={16} />}
     </Header>
   );


### PR DESCRIPTION
## 🤷‍♂️ Description
- 탈출러 모집 페이지에서 사용자가 참여하고 있는 방을 카드 앞면에 표시하는 컴포넌트를 만들고, 적용했어요.

<!-- 구현 한 기능에 대해 작성해 주세요. -->

## 📝 Primary Commits

<!-- 세부 구현 사항을 리스트로 작성해주세요. -->

- [X] 참여중인 방 표시 UI 마크업
- [x] 카드 앞면에 적용

## 📷 Screenshots

![녹화_2023_12_08_02_59_28_58](https://github.com/boostcampwm2023/web03-LockFestival/assets/82202370/d8c287a3-4a4f-4f1f-878b-7877a161d6f7)

<!--스크린샷으로 보여줄 수 있는 이미지가 있다면 첨부해주세요!-->

<!--BE의 경우 API 테스트 결과를 첨부해주세요-->

<!--마지막으로 이슈 생성 시 우측의 옵션들을 체크했는지 확인해주세요!-->

<!-- 이슈번호를 작성해주세요. -->
<!-- 여러 이슈를 입력시 comma(,) 단위로 구분해주세요 -->
<!-- ex) close #10, resolves #123 -->


<!-- ex) -->
<!-- closes #1 --> 

