### PR TITLE
Feature/FE/#253: 채팅방 페이지 시간표 UI 마크업

### DIFF
--- a/frontend/src/pages/ChatRoom/components/RoomInfoPanel/RoomInfoPanel.tsx
+++ b/frontend/src/pages/ChatRoom/components/RoomInfoPanel/RoomInfoPanel.tsx
@@ -22,7 +22,7 @@ const RoomInfoPanel = ({ settingMode }: { settingMode: boolean }) => {
     themeName,
     posterImageUrl,
     recruitmentContent,
-    // appointmentDate,
+    appointmentDate,
     recruitmentMembers,
     currentMembers,
     recruitmentCompleted,
@@ -68,12 +68,7 @@ const RoomInfoPanel = ({ settingMode }: { settingMode: boolean }) => {
         <Label isBorder={true} width="10rem">
           <LabelText>날짜</LabelText>
         </Label>
-        <RoomInfoContent>
-          {
-            //TODO: 현재 방정보가 Mock데이터 여서 이후에 appointmentDate로 변경
-            getStringByDate(new Date())
-          }
-        </RoomInfoContent>
+        <RoomInfoContent>{getStringByDate(new Date(appointmentDate))}</RoomInfoContent>
       </RoomInfoWrapper>
       <RoomInfoWrapper>
         <Label isBorder={true} width="10rem">

--- a/frontend/src/pages/ChatRoom/components/RoomInfoPanel/RoomInfoPanel.tsx
+++ b/frontend/src/pages/ChatRoom/components/RoomInfoPanel/RoomInfoPanel.tsx
@@ -10,6 +10,7 @@ import RoomSettingModal from './RoomSettingModal/RoomSettingModal';
 import { useRecoilValue } from 'recoil';
 import { roomInfoAtom } from '@store/chatRoom';
 import { getStringByDate } from '@utils/dateUtil';
+import TimeTable from './TimeTable/TimeTable';
 
 const RoomInfoPanel = ({ settingMode }: { settingMode: boolean }) => {
   const { openModal, closeModal } = useModal();
@@ -27,66 +28,70 @@ const RoomInfoPanel = ({ settingMode }: { settingMode: boolean }) => {
     currentMembers,
     recruitmentCompleted,
     appointmentCompleted,
+    themeId,
   } = roomInfo as RoomInfo;
 
   return (
     <Layout>
-      {settingMode ? (
-        <SettingButton>
-          <Button
-            isIcon={true}
-            onClick={() =>
-              openModal(Modal, {
-                children: <RoomSettingModal onClose={() => closeModal(Modal)} />,
-                onClose: () => closeModal(Modal),
-                closeOnExternalClick: true,
-              })
-            }
-          >
-            <FaGear />
-          </Button>
-        </SettingButton>
-      ) : (
-        ''
-      )}
-      <HeadContainer>
-        <ThemePoster src={posterImageUrl} alt="테마_포스터" />
-        <ThemeInfoWrapper>
-          <ThemeInfo>{regionName}</ThemeInfo>
-          <ThemeInfo>{brandName}</ThemeInfo>
-          <ThemeInfo>{branchName}</ThemeInfo>
-          <ThemeInfo>{themeName}</ThemeInfo>
-        </ThemeInfoWrapper>
-      </HeadContainer>
-      <RoomInfoWrapper>
-        <Label isBorder={true} width="10rem">
-          <LabelText>모집내용</LabelText>
-        </Label>
-        <RoomInfoContent>{recruitmentContent}</RoomInfoContent>
-      </RoomInfoWrapper>
-      <RoomInfoWrapper>
-        <Label isBorder={true} width="10rem">
-          <LabelText>날짜</LabelText>
-        </Label>
-        <RoomInfoContent>{getStringByDate(new Date(appointmentDate))}</RoomInfoContent>
-      </RoomInfoWrapper>
-      <RoomInfoWrapper>
-        <Label isBorder={true} width="10rem">
-          <LabelText>인원</LabelText>
-        </Label>
-        <RoomInfoContent>
-          {currentMembers}명/{recruitmentMembers}명
-        </RoomInfoContent>
-      </RoomInfoWrapper>
-      <RoomInfoWrapper>
-        <Label isBorder={true} width="10rem">
-          <LabelText>상태</LabelText>
-        </Label>
-        <RoomInfoContent>
-          <StateLabel text="예약" state={appointmentCompleted} />
-          <StateLabel text="모집" state={recruitmentCompleted} />
-        </RoomInfoContent>
-      </RoomInfoWrapper>
+      <RoomInfoTopContainer>
+        {settingMode ? (
+          <SettingButton>
+            <Button
+              isIcon={true}
+              onClick={() =>
+                openModal(Modal, {
+                  children: <RoomSettingModal onClose={() => closeModal(Modal)} />,
+                  onClose: () => closeModal(Modal),
+                  closeOnExternalClick: true,
+                })
+              }
+            >
+              <FaGear />
+            </Button>
+          </SettingButton>
+        ) : (
+          ''
+        )}
+        <HeadContainer>
+          <ThemePoster src={posterImageUrl} alt="테마_포스터" />
+          <ThemeInfoWrapper>
+            <ThemeInfo>{regionName}</ThemeInfo>
+            <ThemeInfo>{brandName}</ThemeInfo>
+            <ThemeInfo>{branchName}</ThemeInfo>
+            <ThemeInfo>{themeName}</ThemeInfo>
+          </ThemeInfoWrapper>
+        </HeadContainer>
+        <RoomInfoWrapper>
+          <Label isBorder={true} width="10rem">
+            <LabelText>모집내용</LabelText>
+          </Label>
+          <RoomInfoContent>{recruitmentContent}</RoomInfoContent>
+        </RoomInfoWrapper>
+        <RoomInfoWrapper>
+          <Label isBorder={true} width="10rem">
+            <LabelText>날짜</LabelText>
+          </Label>
+          <RoomInfoContent>{getStringByDate(new Date(appointmentDate))}</RoomInfoContent>
+        </RoomInfoWrapper>
+        <RoomInfoWrapper>
+          <Label isBorder={true} width="10rem">
+            <LabelText>인원</LabelText>
+          </Label>
+          <RoomInfoContent>
+            {currentMembers}명/{recruitmentMembers}명
+          </RoomInfoContent>
+        </RoomInfoWrapper>
+        <RoomInfoWrapper>
+          <Label isBorder={true} width="10rem">
+            <LabelText>상태</LabelText>
+          </Label>
+          <RoomInfoContent>
+            <StateLabel text="예약" state={appointmentCompleted} />
+            <StateLabel text="모집" state={recruitmentCompleted} />
+          </RoomInfoContent>
+        </RoomInfoWrapper>
+      </RoomInfoTopContainer>
+      <TimeTable themeId={themeId} />
     </Layout>
   );
 };
@@ -97,12 +102,20 @@ const Layout = styled.div([
   css`
     display: flex;
     flex-direction: column;
-    gap: 2rem;
+    justify-content: space-between;
     width: 34rem;
     height: 100vh;
     padding: 2rem;
   `,
   tw`bg-gray-light rounded-[2rem] h-[calc(90vh - 6rem)]`,
+]);
+
+const RoomInfoTopContainer = styled.div([
+  css`
+    display: flex;
+    flex-direction: column;
+    gap: 2rem;
+  `,
 ]);
 
 const SettingButton = styled.div([

--- a/frontend/src/pages/ChatRoom/components/RoomInfoPanel/TimeTable/TimeTable.tsx
+++ b/frontend/src/pages/ChatRoom/components/RoomInfoPanel/TimeTable/TimeTable.tsx
@@ -1,0 +1,75 @@
+import tw, { css, styled } from 'twin.macro';
+import { FaArrowRotateRight } from 'react-icons/fa6';
+import { useState } from 'react';
+import { mockTimeTableData } from '@pages/ChatRoom/mock/mockTimeTableData';
+import Label from '@components/Label/Label';
+
+const TimeTable = ({ themeId }: { themeId: number }) => {
+  const [rotation, setRotation] = useState<number>(0);
+
+  const handlerGetTime = (e: React.MouseEvent) => {
+    if (e.currentTarget instanceof HTMLButtonElement) {
+      const currentRotation = rotation + 360;
+      e.currentTarget.style.transform = `rotate(${currentRotation}deg)`;
+      setRotation(currentRotation);
+
+      //TODO: 실시간 시간표 불러오는 API 추가
+    }
+  };
+
+  return (
+    <Container>
+      <TopWrapper>
+        <Text>실시간 시간표 확인하기</Text>
+        <IconButton onClick={handlerGetTime}>
+          <FaArrowRotateRight color="white" size={16} />
+        </IconButton>
+      </TopWrapper>
+      <BottomWrapper>
+        {mockTimeTableData.map((timeData) =>
+          timeData.possible ? (
+            <Label isBorder={false} width="6rem" backgroundColor="green-light">
+              <LableText>{timeData.time}</LableText>
+            </Label>
+          ) : (
+            <Label isBorder={false} width="6rem" backgroundColor="green-dark">
+              <LableText>{timeData.time}</LableText>
+            </Label>
+          )
+        )}
+      </BottomWrapper>
+    </Container>
+  );
+};
+
+export default TimeTable;
+
+const Container = styled.div([
+  css`
+    display: flex;
+    flex-direction: column;
+    gap: 1.2rem;
+  `,
+]);
+const TopWrapper = styled.div([
+  css`
+    display: flex;
+    align-items: center;
+    gap: 1.2rem;
+  `,
+  tw`text-white`,
+]);
+
+const Text = styled.div([tw`font-pretendard text-l`]);
+
+const IconButton = styled.button([
+  css`
+    transition: transform 1s ease;
+    cursor: pointer;
+    background-color: transparent;
+    padding: 0;
+  `,
+]);
+
+const BottomWrapper = styled.div([tw`grid grid-cols-4 gap-2`]);
+const LableText = styled.div(tw`mx-auto`);

--- a/frontend/src/pages/ChatRoom/mock/mockTimeTableData.ts
+++ b/frontend/src/pages/ChatRoom/mock/mockTimeTableData.ts
@@ -1,0 +1,11 @@
+import { TimeTable } from 'types/chat';
+
+export const mockTimeTableData: TimeTable[] = [
+  { time: '14:50', possible: true },
+  { time: '16:00', possible: true },
+  { time: '17:10', possible: false },
+  { time: '18:20', possible: true },
+  { time: '19:30', possible: true },
+  { time: '20:40', possible: false },
+  { time: '21:50', possible: true },
+];

--- a/frontend/src/types/chat.ts
+++ b/frontend/src/types/chat.ts
@@ -47,3 +47,8 @@ export type RoomThemeType = Pick<
   RoomInfo,
   'brandName' | 'branchName' | 'themeName' | 'posterImageUrl' | 'themeId'
 >;
+
+export interface TimeTable {
+  time: string;
+  possible: boolean;
+}


### PR DESCRIPTION
## 🤷‍♂️ Description
- 채팅방 페이지 방 정보 패널에 실시간 시간표 UI를 마크업 했어요.
-  이후에 원형 화살표 버튼으로 API를 호출할 수 있게 해야해요.

<!-- 구현 한 기능에 대해 작성해 주세요. -->

## 📝 Primary Commits

<!-- 세부 구현 사항을 리스트로 작성해주세요. -->

- [X] 타임 테이블 컴포넌트 UI 마크업
- [x] 방정보 패널에 타임 테이블 컴포넌트 추가

## 📷 Screenshots

![녹화_2023_12_08_03_49_23_732](https://github.com/boostcampwm2023/web03-LockFestival/assets/82202370/c6642cfe-d005-4e7c-bf25-96996834cd6b)

<!--BE의 경우 API 테스트 결과를 첨부해주세요-->

<!--마지막으로 이슈 생성 시 우측의 옵션들을 체크했는지 확인해주세요!-->

<!-- 이슈번호를 작성해주세요. -->
<!-- 여러 이슈를 입력시 comma(,) 단위로 구분해주세요 -->
<!-- ex) close #10, resolves #123 -->


<!-- ex) -->
<!-- closes #1 --> 

close #253 