### PR TITLE
Feature/FE/#350: 참여중인 방이 없을 때, 모집중인 글이 없을 때 보여줄 컴포넌트 생성 및 새로고침 에러 처리

### DIFF
--- a/frontend/src/hooks/useHeaderSearchInput.tsx
+++ b/frontend/src/hooks/useHeaderSearchInput.tsx
@@ -6,7 +6,7 @@ const useHeaderSearchInput = () => {
   const navigate = useNavigate();
   const location = useLocation();
   const { debounceQuery, realInputQuery, setRealInputQuery, resetQuery } = useDebounceInput(200);
-  const [urlBeforeSearch, setUrlBeforeSearch] = useState<string>('/');
+  const [urlBeforeSearch, setUrlBeforeSearch] = useState<string>(location.pathname);
   const [isClickSearchButton, setIsClickSearchButton] = useState<boolean>(false);
 
   const handleSearchInput = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {

--- a/frontend/src/hooks/useThemesByGeolocationQuery.tsx
+++ b/frontend/src/hooks/useThemesByGeolocationQuery.tsx
@@ -10,7 +10,7 @@ const useThemesByGeolocationQuery = () => {
   const { geolocation } = useGeolocation();
 
   const { data, refetch } = useQuery({
-    queryKey: [QUERY_MANAGEMENT['geolocation'].key],
+    queryKey: [QUERY_MANAGEMENT['geolocation'].key, geolocation.latitude, geolocation.longitude],
     queryFn: () => QUERY_MANAGEMENT['geolocation'].fn({ geolocation }),
     enabled: false,
   });

--- a/frontend/src/pages/Recruitment/components/RecruitmentLayout.tsx
+++ b/frontend/src/pages/Recruitment/components/RecruitmentLayout.tsx
@@ -62,10 +62,15 @@ const RecruitmentLayout = () => {
             return <GroupInfoCard {...list} key={list.groupDetail.groupId} />;
           });
         })}
-        <div ref={targetRef}></div>
       </RecruitList>
       {isFetching && <TextContainer>모집글을 불러오는중 ...</TextContainer>}
-      {data && !hasNextPage && <TextContainer>마지막 모집글입니다!</TextContainer>}
+      {data?.pages[0]?.data?.length === 0 && (
+        <TextContainer>모집글이 하나도 없어요. ㅁ_ㅁ</TextContainer>
+      )}
+      {data?.pages[0]?.data?.length && !hasNextPage && (
+        <TextContainer>마지막 모집글입니다!</TextContainer>
+      )}
+      <div ref={targetRef}></div>
     </Container>
   );
 };

--- a/frontend/src/pages/RoomList/components/RoomListLayout.tsx
+++ b/frontend/src/pages/RoomList/components/RoomListLayout.tsx
@@ -3,8 +3,12 @@ import Room from './Room/Room';
 import { useRef } from 'react';
 import useIntersectionObserver from '@hooks/intersectionObserver/useIntersectionObserver';
 import useRoomListInfiniteQuery from '@hooks/query/useRoomListInfiniteQuery';
+import Button from '@components/Button/Button';
+import { useNavigate } from 'react-router-dom';
 
 const RoomListLayout = () => {
+  const navigate = useNavigate();
+
   const targetRef = useRef<HTMLDivElement>(null);
 
   const { data, fetchNextPage, hasNextPage, isFetching } = useRoomListInfiniteQuery();
@@ -21,9 +25,25 @@ const RoomListLayout = () => {
           return <Room {...room} key={room.groupId} />;
         });
       })}
-      <div ref={targetRef}></div>
       {isFetching && <TextContainer>그룹 채팅방 목록을 불러오는 중...</TextContainer>}
-      {data && !hasNextPage && <TextContainer>마지막 채팅방입니다!</TextContainer>}
+      {data?.pages[0]?.data?.length === 0 && (
+        <NotFoundText>
+          <div>참여중인 채팅방이 없습니다!</div>
+          <br />
+          <Button
+            isIcon={false}
+            font="maplestory"
+            size="l-bold"
+            onClick={() => navigate('/recruitment')}
+          >
+            <>참여하러 가기</>
+          </Button>
+        </NotFoundText>
+      )}
+      {data?.pages[0]?.data?.length && !hasNextPage && (
+        <TextContainer>마지막 채팅방입니다!</TextContainer>
+      )}
+      <div ref={targetRef}></div>
     </Container>
   );
 };
@@ -44,6 +64,17 @@ const TextContainer = styled.div([
     display: flex;
     align-items: center;
     justify-content: center;
+  `,
+]);
+
+const NotFoundText = styled.div([
+  tw`w-full mx-auto text-white text-l pt-4 max-w-[102.4rem] font-pretendard`,
+  css`
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    text-align: center;
+    flex-direction: column;
   `,
 ]);
 


### PR DESCRIPTION
## 🤷‍♂️ Description
탈출러 모집페이지와 모집중인 글이 없으면 무한스크롤로 인해 마지막 모집글입니다.를 보여주고 있었고
그룹 채팅방 리스트페이지에서 참여중인 채팅방이 없으면 마지막 참여 방입니다를 보여주는데 문구가 어색해서

참여중인 방이 없습니다 와 모집글이 없습니다. 문구를 보여주도록 변경했어요.

또, 새로고침시 어떠한 페이지에 있어도 루트로 이동하는 문제가 있었는데 해결했어요!

마지막으로 gps 캐싱 처리로 인해 권한을 변경해도 이전 권한 기준 데이터를 불러와 key에 위.경도를 추가햇어요

크롬 브라우저에서는 권한을 거부한 상태로 허용했을 때 새로고침을 2번해야 사용자의 gps를 불러오는데 이 부분을 해결할 수 있을지 확인해봐야할 것 같아요!
<!-- 구현 한 기능에 대해 작성해 주세요. -->

## 📝 Primary Commits

<!-- 세부 구현 사항을 리스트로 작성해주세요. -->

- [X] 참여중인 방이 없을 때, 모집중인 글이 없을 때 보여줄 컴포넌트 생성
- [X] 새로고침 에러 처리
- [X] key에 위.경도를 추가

## 📷 Screenshots

이전
<img width="1074" alt="Screenshot 2023-12-08 at 9 19 58 PM" src="https://github.com/boostcampwm2023/web03-LockFestival/assets/100738049/8e49a1a1-28f0-4533-bfb9-966110455ca5">

이후
<img width="1067" alt="Screenshot 2023-12-08 at 9 20 29 PM" src="https://github.com/boostcampwm2023/web03-LockFestival/assets/100738049/af3d628b-f8dd-4787-9063-5d38f14adea6">



<!--스크린샷으로 보여줄 수 있는 이미지가 있다면 첨부해주세요!-->

<!--BE의 경우 API 테스트 결과를 첨부해주세요-->

<!--마지막으로 이슈 생성 시 우측의 옵션들을 체크했는지 확인해주세요!-->

<!-- 이슈번호를 작성해주세요. -->
<!-- 여러 이슈를 입력시 comma(,) 단위로 구분해주세요 -->
<!-- ex) close #10, resolves #123 -->


<!-- ex) -->
<!-- closes #1 --> 
closes #350 
