### PR TITLE
Feature/FE/#358: 채팅방 실시간 시간표 API 연동

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,5 @@
 import CustomRouter from '@components/Router/CustomRouter';
+import './styles/Calendar.css';
 
 function App() {
   return <CustomRouter />;

--- a/frontend/src/apis/fetchThemeTimeTable.ts
+++ b/frontend/src/apis/fetchThemeTimeTable.ts
@@ -1,0 +1,9 @@
+import userInstance from '@config/userInstance';
+import { Value } from 'react-calendar/dist/cjs/shared/types';
+
+const fetchThemeTimeTable = async (themeId: number, date: Value) => {
+  return (await userInstance({ method: 'get', url: `/themes/${themeId}/timetable?date=${date}` }))
+    .data;
+};
+
+export default fetchThemeTimeTable;

--- a/frontend/src/components/Modal/MakeGroupModal/FormElement/CalendarContainer.tsx
+++ b/frontend/src/components/Modal/MakeGroupModal/FormElement/CalendarContainer.tsx
@@ -28,6 +28,9 @@ const CalendarContainer = ({ isClickCalendar, setIsClickCalendar, date, setDate 
             value={date}
             onClickDay={() => setIsClickCalendar(false)}
             minDate={new Date()}
+            formatDay={(_, date) =>
+              date.toLocaleDateString('ko-KR', { day: '2-digit' }).slice(0, -1)
+            }
           />
         </CalendarWrapper>
       )}

--- a/frontend/src/constants/queryManagement.ts
+++ b/frontend/src/constants/queryManagement.ts
@@ -5,6 +5,8 @@ import fetchThemeDetails from '@apis/fetchThemeDetails';
 import fetchRoomList from '@apis/fetchRoomList';
 import fetchUserProfile from '@apis/fetchUserProfile';
 import fetchThemesByPage from './../apis/fetchThemesByPage';
+import fetchThemeTimeTable from '@apis/fetchThemeTimeTable';
+import { Value } from 'react-calendar/dist/cjs/shared/types';
 
 const QUERY_MANAGEMENT = {
   geolocation: {
@@ -34,6 +36,10 @@ const QUERY_MANAGEMENT = {
   themeSearchResult: {
     key: 'themeSearchResult',
     fn: fetchThemesByPage,
+  },
+  themeTimeTable: {
+    key: 'themeTimeTable',
+    fn: (themeId: number, date: Value) => fetchThemeTimeTable(themeId, date),
   },
 };
 

--- a/frontend/src/hooks/useTimeTableQuery.tsx
+++ b/frontend/src/hooks/useTimeTableQuery.tsx
@@ -1,0 +1,15 @@
+import { useQuery } from '@tanstack/react-query';
+import QUERY_MANAGEMENT from '@constants/queryManagement';
+import { TimeTable } from 'types/chat';
+import { Value } from 'react-calendar/dist/cjs/shared/types';
+
+const useTimeTableQuery = (themeId: number, date: Value) => {
+  const { data, isSuccess, isLoading, isError } = useQuery<TimeTable[]>({
+    queryKey: [QUERY_MANAGEMENT['themeTimeTable'].key, themeId, date],
+    queryFn: () => QUERY_MANAGEMENT['themeTimeTable'].fn(themeId, date),
+  });
+
+  return { data, isSuccess, isLoading, isError };
+};
+
+export default useTimeTableQuery;

--- a/frontend/src/pages/ChatRoom/components/RoomInfoPanel/RoomInfoPanel.tsx
+++ b/frontend/src/pages/ChatRoom/components/RoomInfoPanel/RoomInfoPanel.tsx
@@ -102,6 +102,7 @@ const Layout = styled.div([
   css`
     display: flex;
     flex-direction: column;
+    justify-content: space-between;
     width: 34rem;
     height: 100vh;
     padding: 2rem;
@@ -149,7 +150,12 @@ const ThemeInfoWrapper = styled.div([
   `,
 ]);
 
-const ThemeInfo = styled.div([tw`font-pretendard text-m text-white`]);
+const ThemeInfo = styled.div([
+  tw`font-pretendard text-m text-white`,
+  css`
+    text-align: center;
+  `,
+]);
 
 const RoomInfoWrapper = styled.div([
   css`

--- a/frontend/src/pages/ChatRoom/components/RoomInfoPanel/RoomInfoPanel.tsx
+++ b/frontend/src/pages/ChatRoom/components/RoomInfoPanel/RoomInfoPanel.tsx
@@ -102,10 +102,10 @@ const Layout = styled.div([
   css`
     display: flex;
     flex-direction: column;
-    justify-content: space-between;
     width: 34rem;
     height: 100vh;
     padding: 2rem;
+    gap: 1.6rem;
   `,
   tw`bg-gray-light rounded-[2rem] h-[calc(90vh - 6rem)]`,
 ]);
@@ -114,7 +114,7 @@ const RoomInfoTopContainer = styled.div([
   css`
     display: flex;
     flex-direction: column;
-    gap: 2rem;
+    gap: 1.2rem;
   `,
 ]);
 

--- a/frontend/src/pages/ChatRoom/components/RoomInfoPanel/RoomInfoPanel.tsx
+++ b/frontend/src/pages/ChatRoom/components/RoomInfoPanel/RoomInfoPanel.tsx
@@ -128,12 +128,13 @@ const SettingButton = styled.div([
 ]);
 
 const HeadContainer = styled.div([
-  tw`w-[27rem] h-[14.2rem] bg-gray rounded-[2rem]`,
+  tw`w-[full] h-[14.2rem] bg-gray rounded-[2rem]`,
   css`
     display: flex;
     justify-content: space-between;
     align-items: center;
     padding: 2rem;
+    gap: 1.2rem;
   `,
 ]);
 
@@ -142,7 +143,7 @@ const ThemePoster = styled.img([tw`w-[10rem] h-[10.7rem] rounded-[2rem]`]);
 const ThemeInfoWrapper = styled.div([
   css`
     display: flex;
-    width: 12rem;
+    flex: 1;
     flex-direction: column;
     justify-content: center;
     align-items: center;

--- a/frontend/src/pages/ChatRoom/components/RoomInfoPanel/TimeTable/TimeTable.tsx
+++ b/frontend/src/pages/ChatRoom/components/RoomInfoPanel/TimeTable/TimeTable.tsx
@@ -12,7 +12,7 @@ const TimeTable = ({ themeId }: { themeId: number }) => {
   const [date, setDate] = useState<Value>(today);
   const oneWeekLater = new Date(today);
   oneWeekLater.setDate(today.getDate() + 7);
-  const { data, isSuccess, isLoading, isError } = useTimeTableQuery(themeId, date);
+  const { data, isLoading } = useTimeTableQuery(themeId, date);
 
   return (
     <Container>

--- a/frontend/src/pages/ChatRoom/components/RoomInfoPanel/TimeTable/TimeTable.tsx
+++ b/frontend/src/pages/ChatRoom/components/RoomInfoPanel/TimeTable/TimeTable.tsx
@@ -24,7 +24,7 @@ const TimeTable = ({ themeId }: { themeId: number }) => {
           onChange={setDate}
           formatDay={(_, date) => date.toLocaleDateString('ko-KR', { day: '2-digit' }).slice(0, -1)}
           value={date}
-          minDate={new Date()}
+          minDate={today}
           maxDate={oneWeekLater}
           minDetail="month"
           maxDetail="month"

--- a/frontend/src/pages/ChatRoom/components/RoomInfoPanel/TimeTable/TimeTable.tsx
+++ b/frontend/src/pages/ChatRoom/components/RoomInfoPanel/TimeTable/TimeTable.tsx
@@ -1,41 +1,55 @@
 import tw, { css, styled } from 'twin.macro';
-import { FaArrowRotateRight } from 'react-icons/fa6';
 import { useState } from 'react';
-import { mockTimeTableData } from '@pages/ChatRoom/mock/mockTimeTableData';
 import Label from '@components/Label/Label';
+import { Value } from 'react-calendar/dist/cjs/shared/types';
+import Calendar from 'react-calendar';
+import useTimeTableQuery from '@hooks/useTimeTableQuery';
+import { FaArrowsRotate } from 'react-icons/fa6';
+import { keyframes } from '@emotion/react';
 
 const TimeTable = ({ themeId }: { themeId: number }) => {
-  const [rotation, setRotation] = useState<number>(0);
-
-  const handlerGetTime = (e: React.MouseEvent) => {
-    if (e.currentTarget instanceof HTMLButtonElement) {
-      const currentRotation = rotation + 360;
-      e.currentTarget.style.transform = `rotate(${currentRotation}deg)`;
-      setRotation(currentRotation);
-
-      //TODO: 실시간 시간표 불러오는 API 추가
-    }
-  };
+  const today = new Date();
+  const [date, setDate] = useState<Value>(today);
+  const oneWeekLater = new Date(today);
+  oneWeekLater.setDate(today.getDate() + 7);
+  const { data, isSuccess, isLoading, isError } = useTimeTableQuery(themeId, date);
 
   return (
     <Container>
       <TopWrapper>
         <Text>실시간 시간표 확인하기</Text>
-        <IconButton onClick={handlerGetTime}>
-          <FaArrowRotateRight color="white" size={16} />
-        </IconButton>
       </TopWrapper>
+      <CalendarWrapper>
+        <Calendar
+          onChange={setDate}
+          formatDay={(_, date) => date.toLocaleDateString('ko-KR', { day: '2-digit' }).slice(0, -1)}
+          value={date}
+          minDate={new Date()}
+          maxDate={oneWeekLater}
+          minDetail="month"
+          maxDetail="month"
+          showNavigation={false}
+        />
+      </CalendarWrapper>
       <BottomWrapper>
-        {mockTimeTableData.map((timeData) =>
-          timeData.possible ? (
-            <Label isBorder={false} width="6rem" backgroundColor="green-light">
-              <LableText>{timeData.time}</LableText>
-            </Label>
-          ) : (
-            <Label isBorder={false} width="6rem" backgroundColor="green-dark">
-              <LableText>{timeData.time}</LableText>
-            </Label>
-          )
+        {isLoading ? (
+          <Loading>
+            <FaArrowsRotate size="30" />
+          </Loading>
+        ) : (
+          <>
+            {data?.map((timeData) =>
+              timeData.possible ? (
+                <Label isBorder={false} width="6rem" backgroundColor="green-light">
+                  <LabelText>{timeData.time}</LabelText>
+                </Label>
+              ) : (
+                <Label isBorder={false} width="6rem" backgroundColor="green-dark">
+                  <LabelText>{timeData.time}</LabelText>
+                </Label>
+              )
+            )}
+          </>
         )}
       </BottomWrapper>
     </Container>
@@ -48,6 +62,7 @@ const Container = styled.div([
   css`
     display: flex;
     flex-direction: column;
+    align-items: center;
     gap: 1.2rem;
   `,
 ]);
@@ -60,16 +75,28 @@ const TopWrapper = styled.div([
   tw`text-white`,
 ]);
 
-const Text = styled.div([tw`font-pretendard text-l`]);
+const Text = styled.div([tw`font-pretendard text-m`]);
 
-const IconButton = styled.button([
+const BottomWrapper = styled.div([tw`grid grid-cols-4 gap-4`]);
+const LabelText = styled.div(tw`mx-auto`);
+
+const CalendarWrapper = styled.div([tw`font-pretendard text-s w-full`]);
+
+const rotate = keyframes`
+    from {
+        transform: rotate(0deg);
+    }
+    to {
+        transform: rotate(360deg);
+    }
+`;
+
+const Loading = styled.div([
+  tw`w-[30rem] h-[12.8rem] text-white`,
   css`
-    transition: transform 1s ease;
-    cursor: pointer;
-    background-color: transparent;
-    padding: 0;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    animation: ${rotate} 1s infinite linear;
   `,
 ]);
-
-const BottomWrapper = styled.div([tw`grid grid-cols-4 gap-2`]);
-const LableText = styled.div(tw`mx-auto`);

--- a/frontend/src/styles/Calendar.css
+++ b/frontend/src/styles/Calendar.css
@@ -1,0 +1,85 @@
+.react-calendar {
+  width: 30rem;
+  max-width: 100%;
+  background-color: #fff;
+  color: #222;
+  border-radius: 0.6rem;
+  font-family: Pretendard-Regular;
+}
+
+.react-calendar__navigation {
+  height: 2rem;
+  margin: 0;
+}
+.react-calendar__month-view__weekdays__weekday {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 2rem;
+}
+
+.react-calendar__tile {
+  padding: 0.6rem;
+}
+
+.react-calendar__tile:disabled:nth-last-child(7) {
+  border-bottom-left-radius: 0.6rem;
+}
+
+.react-calendar__tile:disabled:nth-last-child(1) {
+  border-bottom-right-radius: 0.6rem;
+}
+
+.react-calendar__tile:enabled:hover,
+.react-calendar__tile:enabled:focus {
+  background: #f8f8fa;
+  color: #1ab93d;
+  border-radius: 0.6rem;
+}
+.react-calendar__tile--now {
+  background: #1f371d8e;
+  border-radius: 0.6rem;
+  font-weight: bold;
+  color: #1ab93d;
+}
+.react-calendar__tile--now:enabled:hover,
+.react-calendar__tile--now:enabled:focus {
+  background: #1f371d;
+  border-radius: 0.6rem;
+  font-weight: bold;
+  color: #1ab93d;
+}
+.react-calendar__tile--hasActive:enabled:hover,
+.react-calendar__tile--hasActive:enabled:focus {
+  background: #f8f8fa;
+}
+.react-calendar__tile--active {
+  background: #1ab93d;
+  border-radius: 0.6rem;
+  font-weight: bold;
+  color: white;
+}
+.react-calendar__tile--active:enabled:hover,
+.react-calendar__tile--active:enabled:focus {
+  background: #1ab93d;
+  color: white;
+}
+
+.react-calendar--selectRange .react-calendar__tile--hover {
+  background-color: #f8f8fa;
+}
+.react-calendar__tile--range {
+  background: #f8f8fa;
+  color: #1ab93d;
+  border-radius: 0;
+}
+.react-calendar__tile--rangeStart {
+  border-radius: 0.6rem;
+  background: #1ab93d;
+  color: white;
+}
+.react-calendar__tile--rangeEnd {
+  border-radius: 0.6rem;
+  background: #1ab93d;
+  color: white;
+}


### PR DESCRIPTION
## 🤷‍♂️ Description
1. 실시간 시간표 불러오는 API를 연동했어요.
    - 예약한 날짜와 상관없이 오늘 날짜로부터 일주일이내만 선택하게 했어요.
    - 처음 방 진입시 오늘 날짜의 시간표를 불러오고 다른 날짜를 선택하면 다른 날짜의 시간표를 불러와요.

2. react-calendar 커스터마이징을 했어요.
    - 페이지 메인 컬러인 초록색 계열 색상을 사용했어요.

3. 피드백에서 받았던, 테마 정보가 중앙 정렬이 되지 않는 버그를 수정했어요.

<!-- 구현 한 기능에 대해 작성해 주세요. -->

## 📝 Primary Commits

<!-- 세부 구현 사항을 리스트로 작성해주세요. -->

- [X] react-calendar 커스터마이징
- [x] 실시간 시간표 api, query 생성
- [x] 방정보 패널에 적용 및  css 수정

## 📷 Screenshots
1. 실시간 시간표 불러오기 (Fast 3G 버전)
    - 로딩 애니메이션 보여주기 위해 네트워크 속도 변경
![녹화_2023_12_09_23_20_10_561](https://github.com/boostcampwm2023/web03-LockFestival/assets/82202370/2657a06b-fea4-456b-960c-5c5bd386238c)

3. 피드백에서 문자열 정렬이 안맞는다해서, css를 조정했어요. 
![image](https://github.com/boostcampwm2023/web03-LockFestival/assets/82202370/43b12238-d456-4727-86ba-b6025afe46e5)

<!--스크린샷으로 보여줄 수 있는 이미지가 있다면 첨부해주세요!-->

<!--BE의 경우 API 테스트 결과를 첨부해주세요-->

<!--마지막으로 이슈 생성 시 우측의 옵션들을 체크했는지 확인해주세요!-->

<!-- 이슈번호를 작성해주세요. -->
<!-- 여러 이슈를 입력시 comma(,) 단위로 구분해주세요 -->
<!-- ex) close #10, resolves #123 -->


<!-- ex) -->
<!-- closes #1 --> 
close #358 