### PR TITLE
Fix/BE/#365: 채팅방 중복 세션시 초기 데이터를 못불러오는 버그 수정

### DIFF
--- a/backend/src/modules/userModules/chat/chat.repository.ts
+++ b/backend/src/modules/userModules/chat/chat.repository.ts
@@ -164,13 +164,13 @@ export class ChatRepository {
     );
   }
 
-  async findLastChatLogIdByRoomId(roomId: string) {
+  async findLastChatLogIdByRoomId(roomId: string): Promise<string> {
     const roomInfo = await this.roomModel.findOne({ group_id: roomId });
     if (!roomInfo) {
       throw new Error('방 정보를 찾을 수 없습니다.');
     }
     if (!roomInfo.last_chat) {
-      return false;
+      return undefined;
     }
     return roomInfo.last_chat.toString();
   }

--- a/backend/src/modules/userModules/chat/chat.service.ts
+++ b/backend/src/modules/userModules/chat/chat.service.ts
@@ -34,7 +34,8 @@ export class ChatService {
     await this.chatRepository.updateRead(meUser.userId);
 
     const prevMessages: ChatMessageResponseDto = await this.findMessagesByLogId({
-      cursorLogId: meUser.lastChatLogId,
+      cursorLogId:
+        meUser.lastChatLogId || (await this.chatRepository.findLastChatLogIdByRoomId(roomId)),
       count: 0,
       direction: 1,
       roomId,


### PR DESCRIPTION
## 🤷‍♂️ Description
채팅방에 중복으로 접속시 초기 데이터를 못불러오는 버그가 있어요.
![image](https://github.com/boostcampwm2023/web03-LockFestival/assets/44056518/c42f8fbe-aad7-4ea4-baab-ba5a25c7ad67)

<!-- 구현 한 기능에 대해 작성해 주세요. -->

## 📝 Primary Commits

<!-- 세부 구현 사항을 리스트로 작성해주세요. -->

- 기존에는 채팅방 최초 접속시 유저의 마지막 읽은 메세지 id 값을 기준으로 안읽은 메세지 전체를 반환해요.
- 같은 채팅방에 중복으로 접속 시 유저의 마지막 읽은 메세지 id가 없어요.
- 그래서 반환되는 메세지 id가 없어서 프론트에서 이전 데이터를 요청할 수 없어요.
- 이를 해소하기 위해 유저의 마지막 읽은 메세지 id 가 없으면 채팅방의 제일 최신 채팅 id 값을 기준으로 반환해요.
  - ChatService
  ```ts
  //AS-IS
  const prevMessages: ChatMessageResponseDto = await this.findMessagesByLogId({
    cursorLogId: meUser.lastChatLogId,
    count: 0,
    direction: 1,
    roomId,
  });
  //TO-BE
  const prevMessages: ChatMessageResponseDto = await this.findMessagesByLogId({
    cursorLogId:
      meUser.lastChatLogId || (await this.chatRepository.findLastChatLogIdByRoomId(roomId)),
    count: 0,
    direction: 1,
    roomId,
  });
  ```

## 📷 Screenshots
![image](https://github.com/boostcampwm2023/web03-LockFestival/assets/44056518/c98256b7-1c94-45b1-a5e9-aa8b235ea88a)


<!--스크린샷으로 보여줄 수 있는 이미지가 있다면 첨부해주세요!-->

<!--BE의 경우 API 테스트 결과를 첨부해주세요-->

<!--마지막으로 이슈 생성 시 우측의 옵션들을 체크했는지 확인해주세요!-->

<!-- 이슈번호를 작성해주세요. -->
<!-- 여러 이슈를 입력시 comma(,) 단위로 구분해주세요 -->
<!-- ex) close #10, resolves #123 -->


<!-- ex) -->
<!-- closes #1 --> 
closes #365
