### PR TITLE
Feature/FE/#368 동료 학습 피드백 수용 및 nav menu 이름 변경

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -27,6 +27,7 @@
     "react-icons": "^4.12.0",
     "react-router-dom": "^6.18.0",
     "react-slick": "^0.29.0",
+    "react-toastify": "^9.1.3",
     "recoil": "^0.7.7",
     "slick-carousel": "^1.8.1",
     "socket.io-client": "^4.7.2"

--- a/frontend/src/components/Card/GroupInfoCard/HeadCard/HeadCardContent.tsx
+++ b/frontend/src/components/Card/GroupInfoCard/HeadCard/HeadCardContent.tsx
@@ -8,6 +8,7 @@ import { FaRegUser } from 'react-icons/fa6';
 import { useNavigate } from 'react-router-dom';
 import fetchEnterRoom from '@apis/fetchEnterRoom';
 import { isAxiosError } from 'axios';
+import { toast } from 'react-toastify';
 
 const HeadCardContent = ({
   themeDetail,
@@ -27,7 +28,7 @@ const HeadCardContent = ({
       navigate(`/chat-room/${groudId}`);
     } catch (error) {
       if (isAxiosError(error)) {
-        alert(error.response?.data.message);
+        toast.error(error.response?.data.message);
       }
     }
   };

--- a/frontend/src/components/Header/HeaderNav/HeaderNav.tsx
+++ b/frontend/src/components/Header/HeaderNav/HeaderNav.tsx
@@ -21,13 +21,13 @@ const HeaderNav = () => {
           onClick={() => handleSelectedItem('/recruitment')}
           isSelected={location.pathname === '/recruitment'}
         >
-          탈출러 모집
+          모집 리스트
         </NavItem>
         <NavItem
           onClick={() => handleSelectedItem('/room-list')}
           isSelected={location.pathname === '/room-list'}
         >
-          그룹 채팅방
+          나의 채팅방
         </NavItem>
       </NavContainer>
     </Nav>

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -1,8 +1,9 @@
-import tw, { styled } from 'twin.macro';
+import tw, { styled, css } from 'twin.macro';
 import Header from './Header/Header';
 import { Outlet } from 'react-router-dom';
 import Modals from './Modals/Modals';
-
+import { ToastContainer } from 'react-toastify';
+import 'react-toastify/dist/ReactToastify.css';
 const Layout = () => {
   return (
     <Container>
@@ -10,6 +11,7 @@ const Layout = () => {
       <Main>
         <Modals />
         <Outlet />
+        <CustomToastContainer theme="dark" position="bottom-center" autoClose={3000} />
       </Main>
     </Container>
   );
@@ -18,5 +20,14 @@ const Layout = () => {
 const Container = styled.div([tw`bg-gray-dark h-auto w-full min-h-screen mobile:(min-w-[34rem])`]);
 
 const Main = styled.main([]);
+
+const CustomToastContainer = styled(ToastContainer)([
+  css`
+    .Toastify__toast {
+      font-family: 'MaplestoryOTFLight';
+      font-size: 1.6rem;
+    }
+  `,
+]);
 
 export default Layout;

--- a/frontend/src/hooks/mutation/useJoinMutation.tsx
+++ b/frontend/src/hooks/mutation/useJoinMutation.tsx
@@ -3,6 +3,7 @@ import QUERY_MANAGEMENT from '@constants/queryManagement';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { isAxiosError } from 'axios';
 import { JoinData } from 'types/profile';
+import { toast } from 'react-toastify';
 
 const useJoinMutation = (joinData: JoinData | undefined) => {
   const queryClient = useQueryClient();
@@ -17,7 +18,7 @@ const useJoinMutation = (joinData: JoinData | undefined) => {
     },
     onError: (error) => {
       if (isAxiosError(error)) {
-        alert(error.response?.data.message);
+        toast.error(error.response?.data.message);
       }
     },
   });

--- a/frontend/src/hooks/mutation/useLeaveRoomMutation.tsx
+++ b/frontend/src/hooks/mutation/useLeaveRoomMutation.tsx
@@ -2,6 +2,7 @@ import MUTATION_MANAGEMENT from '@constants/mutationManagement';
 import QUERY_MANAGEMENT from '@constants/queryManagement';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { isAxiosError } from 'axios';
+import { toast } from 'react-toastify';
 
 const useLeaveRoomMutation = (groupId: number) => {
   const queryClient = useQueryClient();
@@ -11,11 +12,11 @@ const useLeaveRoomMutation = (groupId: number) => {
     mutationFn: (groupId: number) => MUTATION_MANAGEMENT['leaveRoom'].fn(groupId),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: [QUERY_MANAGEMENT['roomList'].key] });
-      alert('정상적으로 나가셨습니다!');
+      toast.success('방을 나왔습니다!');
     },
     onError: (error) => {
       if (isAxiosError(error)) {
-        alert(error.response?.data.message);
+        toast.error(error.response?.data.message);
       }
     },
   });

--- a/frontend/src/hooks/socket/useSocket.ts
+++ b/frontend/src/hooks/socket/useSocket.ts
@@ -5,6 +5,7 @@ import useChatLog from './useChatLog';
 import { useSetRecoilState } from 'recoil';
 import { chatUnreadAtom } from '@store/chatRoom';
 import { useNavigate } from 'react-router-dom';
+import { toast } from 'react-toastify';
 
 const useSocket = (roomId: string) => {
   const { socket, connecting } = useSocketConnection(roomId);
@@ -57,7 +58,7 @@ const useSocket = (roomId: string) => {
       });
 
       socket.on('kick', (res) => {
-        alert(res.message);
+        toast.info('방장에 의해 강퇴당하셨습니다!');
         navigate('/room-list');
       });
     }

--- a/frontend/src/pages/Auth/Auth.tsx
+++ b/frontend/src/pages/Auth/Auth.tsx
@@ -4,6 +4,7 @@ import fetchLogin from '@apis/fetchLogin';
 import { useSetRecoilState } from 'recoil';
 import userAtom from 'store/userAtom';
 import fetchUserProfile from '@apis/fetchUserProfile';
+import { toast } from 'react-toastify';
 
 const Auth = () => {
   const navigate = useNavigate();
@@ -26,7 +27,7 @@ const Auth = () => {
 
       navigate(localStorage.getItem('lastVisited') || '/');
     } catch (error) {
-      alert('서버 에러 발생!!');
+      toast.error('서버 에러 발생!!');
     }
   };
 

--- a/frontend/src/pages/Recruitment/components/RecruitmentLayout.tsx
+++ b/frontend/src/pages/Recruitment/components/RecruitmentLayout.tsx
@@ -50,12 +50,6 @@ const RecruitmentLayout = () => {
 
   return (
     <Container>
-      <AddButton isIcon={false} size="l" onClick={checkIsLogin}>
-        <>
-          모집글 작성하기
-          <FaPlus color="white" />
-        </>
-      </AddButton>
       <RecruitList>
         {data?.pages.map((page) => {
           return page.data.map((list) => {
@@ -63,6 +57,14 @@ const RecruitmentLayout = () => {
           });
         })}
       </RecruitList>
+      <ButtonPosition>
+        <AddButton isIcon={false} size="l" onClick={checkIsLogin}>
+          <>
+            모집글 작성하기
+            <FaPlus color="white" />
+          </>
+        </AddButton>
+      </ButtonPosition>
       {isFetching && <TextContainer>모집글을 불러오는중 ...</TextContainer>}
       {data?.pages[0]?.data?.length === 0 && (
         <TextContainer>모집글이 하나도 없어요. ㅁ_ㅁ</TextContainer>
@@ -89,7 +91,7 @@ const RecruitList = styled.div([
 ]);
 
 const TextContainer = styled.div([
-  tw`w-full mx-auto text-white text-l pt-4 max-w-[102.4rem] border-t border-white border-solid`,
+  tw`w-full mx-auto text-white text-l pt-4 max-w-[102.4rem] border-t border-white border-solid font-pretendard`,
   css`
     display: flex;
     align-items: center;
@@ -97,11 +99,20 @@ const TextContainer = styled.div([
   `,
 ]);
 
+const ButtonPosition = styled.div([
+  tw`mx-auto w-4/5 py-[2rem] px-4`,
+  tw`desktop:(w-[102.4rem])`,
+  css`
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+  `,
+]);
+
 const AddButton = styled(Button)([
   css`
     position: fixed;
     bottom: 1rem;
-    right: 1rem;
     z-index: 3;
   `,
 ]);

--- a/frontend/src/pages/RoomList/components/RoomListLayout.tsx
+++ b/frontend/src/pages/RoomList/components/RoomListLayout.tsx
@@ -59,7 +59,7 @@ const Container = styled.div([
 ]);
 
 const TextContainer = styled.div([
-  tw`w-full mx-auto text-white text-l pt-4 max-w-[102.4rem] border-t border-white border-solid`,
+  tw`w-full mx-auto text-white text-l pt-4 max-w-[102.4rem] border-t border-white border-solid font-pretendard`,
   css`
     display: flex;
     align-items: center;

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -2896,6 +2896,11 @@ clone@^1.0.2:
   resolved "https://registry.yarnpkg.com/clone/-/clone-1.0.4.tgz#da309cc263df15994c688ca902179ca3c7cd7c7e"
   integrity sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==
 
+clsx@^1.1.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/clsx/-/clsx-1.2.1.tgz#0ddc4a20a549b59c93a4116bb26f5294ca17dc12"
+  integrity sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==
+
 clsx@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/clsx/-/clsx-2.0.0.tgz#12658f3fd98fafe62075595a5c30e43d18f3d00b"
@@ -5847,6 +5852,13 @@ react-slick@^0.29.0:
     json2mq "^0.2.0"
     lodash.debounce "^4.0.8"
     resize-observer-polyfill "^1.5.0"
+
+react-toastify@^9.1.3:
+  version "9.1.3"
+  resolved "https://registry.yarnpkg.com/react-toastify/-/react-toastify-9.1.3.tgz#1e798d260d606f50e0fab5ee31daaae1d628c5ff"
+  integrity sha512-fPfb8ghtn/XMxw3LkxQBk3IyagNpF/LIKjOBflbexr2AWxAH1MJgvnESwEwBn9liLFXgTKWgBSdZpw9m4OTHTg==
+  dependencies:
+    clsx "^1.1.1"
 
 react@^18.2.0:
   version "18.2.0"


### PR DESCRIPTION
## 🤷‍♂️ Description

navbar 내용 변경
- 탈출러 모집. 그룹 채팅방 이라는 이름이 모호해서 모집 리스트, 나의 채팅방으로 변경했어요.

alert 대신 react-toastify 사용
- alert가 불편하다는 의견이 많아서 react-toastify로 변경했어요! 디자인때문에 커스텀 토스트 컴포넌트를 만들었어요.

사용법은 아래와 같아요.

```typescript
toast.success('방을 나왔습니다!');
toast.error(error.response?.data.message);
```


모집글 작성 버튼 위치 변경
- 모집글 작성 버튼이 원래 가장 우측에 있었는데 모니터가 커지면 커질수록 너무 구석에 있어서 카드 컴포넌트 위치에 두도록 했어요.

그리고 모집 리스트, 나의채팅방에 무한스크롤이 끝났을 때 보여주는 텍스트의 폰트가 적용되어있지 않아서 저희가 사용하는 폰트를 적용했어요. 추후에 css 중복을 제거해야할 것 같아요!!


위의 사항은 아래의 스크린샷에서 확인해주세요!

<!-- 구현 한 기능에 대해 작성해 주세요. -->

## 📝 Primary Commits

<!-- 세부 구현 사항을 리스트로 작성해주세요. -->

- [X] navbar 내용 변경
- [X] alert 대신 react-toastify 사용
- [X] 모집글 작성 버튼 위치 변경

## 📷 Screenshots

탈출러 모집, 그룹 채팅방을 모집 리스트, 나의 채팅방으로 변경

<img width="799" alt="5" src="https://github.com/boostcampwm2023/web03-LockFestival/assets/100738049/e5e2b3c4-449c-4007-aac6-d350367ddfe8">


react-toastify 사용

<img width="872" alt="강퇴" src="https://github.com/boostcampwm2023/web03-LockFestival/assets/100738049/ce62bbe8-6f2f-4fa7-8b87-a1ae08d11487">

<img width="517" alt="33" src="https://github.com/boostcampwm2023/web03-LockFestival/assets/100738049/eb3e8c05-5ed1-479b-bef0-3ea5482084d4">


모집글 등록 버튼 위치 변경

<img width="787" alt="네브바 위치" src="https://github.com/boostcampwm2023/web03-LockFestival/assets/100738049/b9c39bb8-b669-419e-a5fa-86e9c8a20852">



<!--스크린샷으로 보여줄 수 있는 이미지가 있다면 첨부해주세요!-->

<!--BE의 경우 API 테스트 결과를 첨부해주세요-->

<!--마지막으로 이슈 생성 시 우측의 옵션들을 체크했는지 확인해주세요!-->

<!-- 이슈번호를 작성해주세요. -->
<!-- 여러 이슈를 입력시 comma(,) 단위로 구분해주세요 -->
<!-- ex) close #10, resolves #123 -->


<!-- ex) -->
<!-- closes #1 --> 
closes #368
