### PR TITLE
Fix/FE/#354: 간헐적으로 로그인이 되지 않는 문제 해결

### DIFF
--- a/frontend/src/pages/Auth/Auth.tsx
+++ b/frontend/src/pages/Auth/Auth.tsx
@@ -25,7 +25,9 @@ const Auth = () => {
       const res = await fetchUserProfile();
       setProfile(res);
 
-      navigate(localStorage.getItem('lastVisited') || '/');
+      navigate(localStorage.getItem('lastVisited') || '/', {
+        replace: true,
+      });
     } catch (error) {
       toast.error('서버 에러 발생!!');
     }


### PR DESCRIPTION
## 🤷‍♂️ Description
정확한 이유를 알지 못하지만 로그인이 되지 않는 문제 중 하나는 code를 받는 `/auth`가 history에 쌓여서 그랬어요.

즉, 사용자가 로그인을 하면  `/auth?code=123ava`가 history stack에 쌓이고 뒤로가기를 하면 해당 페이지로 돌아가서 123ava라는 code를 가지고 서버에 요청을 해요. 서버는 직전에 해당 code로 토큰을 발급해서 해당 code는 더 이상 유효하지 않으므로 에러가 발생했어요.

따라서 `/auth`에서 다른 페이지로 이동하면 `/auth`가 history stack에 쌓이지 않도록 변경했어요.


<!-- 구현 한 기능에 대해 작성해 주세요. -->

## 📝 Primary Commits

<!-- 세부 구현 사항을 리스트로 작성해주세요. -->

- [X] navigate 옵션 추가


## 📷 Screenshots

- 이전

<img width="483" alt="vv" src="https://github.com/boostcampwm2023/web03-LockFestival/assets/100738049/13476258-aba4-4c72-bec1-bd9de348d3b6">

- 이후

<img width="419" alt="22" src="https://github.com/boostcampwm2023/web03-LockFestival/assets/100738049/2f703395-632d-4ead-a304-b165c5bbceea">



<!--스크린샷으로 보여줄 수 있는 이미지가 있다면 첨부해주세요!-->

<!--BE의 경우 API 테스트 결과를 첨부해주세요-->

<!--마지막으로 이슈 생성 시 우측의 옵션들을 체크했는지 확인해주세요!-->

<!-- 이슈번호를 작성해주세요. -->
<!-- 여러 이슈를 입력시 comma(,) 단위로 구분해주세요 -->
<!-- ex) close #10, resolves #123 -->


<!-- ex) -->
<!-- closes #1 --> 
closes #354 
