### PR TITLE
Refactor/FE/#375 채팅 렌더링 최적화

### DIFF
--- a/frontend/src/pages/ChatRoom/components/ChatPanel/MessageBox/BoxType/MyChatBox.tsx
+++ b/frontend/src/pages/ChatRoom/components/ChatPanel/MessageBox/BoxType/MyChatBox.tsx
@@ -1,5 +1,6 @@
 import { getTimeByDate } from '@utils/dateUtil';
 import tw, { css, styled } from 'twin.macro';
+import { memo } from 'react';
 
 interface BoxProps {
   message: string;
@@ -8,7 +9,7 @@ interface BoxProps {
   isLastChat: boolean;
 }
 
-const MyChatBox = ({ message, time, unreadCount, isLastChat }: BoxProps) => {
+const MyChatBox = memo(function MyChatBox({ message, time, unreadCount, isLastChat }: BoxProps) {
   return (
     <Container>
       <TextContainer>
@@ -20,7 +21,7 @@ const MyChatBox = ({ message, time, unreadCount, isLastChat }: BoxProps) => {
       </TextContainer>
     </Container>
   );
-};
+});
 
 const Container = styled.div([
   tw`w-full my-2`,

--- a/frontend/src/pages/ChatRoom/components/ChatPanel/MessageBox/BoxType/OtherChatBox.tsx
+++ b/frontend/src/pages/ChatRoom/components/ChatPanel/MessageBox/BoxType/OtherChatBox.tsx
@@ -1,6 +1,7 @@
 import { getTimeByDate } from '@utils/dateUtil';
 import { FaCircleUser } from 'react-icons/fa6';
 import tw, { css, styled } from 'twin.macro';
+import { memo } from 'react';
 
 interface BoxProps {
   nickname: string;
@@ -12,7 +13,7 @@ interface BoxProps {
   isLastChat: boolean;
 }
 
-const OtherChatBox = ({
+const OtherChatBox = memo(function OtherChatBox({
   message,
   time,
   profileImg,
@@ -20,7 +21,7 @@ const OtherChatBox = ({
   unreadCount,
   isFirstChat,
   isLastChat,
-}: BoxProps) => {
+}: BoxProps) {
   return (
     <Container>
       {isFirstChat && (
@@ -43,7 +44,7 @@ const OtherChatBox = ({
       </TextContainer>
     </Container>
   );
-};
+});
 
 const Container = styled.div([
   tw`w-full my-2`,

--- a/frontend/src/pages/ChatRoom/components/ChatPanel/MessageBox/BoxType/SystemChatBox.tsx
+++ b/frontend/src/pages/ChatRoom/components/ChatPanel/MessageBox/BoxType/SystemChatBox.tsx
@@ -1,10 +1,11 @@
 import tw, { css, styled } from 'twin.macro';
+import { memo } from 'react';
 
 interface BoxProps {
   message: string;
 }
 
-const SystemChatBox = ({ message }: BoxProps) => {
+const SystemChatBox = memo(function SystemChatBox({ message }: BoxProps) {
   return (
     <Container>
       <TextContainer>
@@ -12,7 +13,7 @@ const SystemChatBox = ({ message }: BoxProps) => {
       </TextContainer>
     </Container>
   );
-};
+});
 
 const Container = styled.div([
   tw`w-full my-2`,

--- a/frontend/src/pages/ChatRoom/components/ChatPanel/MessageBox/MessageBox.tsx
+++ b/frontend/src/pages/ChatRoom/components/ChatPanel/MessageBox/MessageBox.tsx
@@ -1,60 +1,34 @@
 import { styled, css } from 'twin.macro';
 import { ChatLog } from 'types/chat';
-import { chatUnreadAtom, userListInfoAtom } from '@store/chatRoom';
+import { userListInfoAtom } from '@store/chatRoom';
 import { useRecoilValue } from 'recoil';
 import MyChatBox from './BoxType/MyChatBox';
 import OtherChatBox from './BoxType/OtherChatBox';
 import SystemChatBox from './BoxType/SystemChatBox';
-import { useMemo, memo } from 'react';
+import { memo } from 'react';
 interface Props extends ChatLog {
   logId: string;
   isFirstChat: boolean;
   isLastChat: boolean;
+  unreadCount: number;
 }
 
 const MessageBox = memo(function MessageBox({
-  logId,
   message,
   userId,
   type,
   time,
   isFirstChat,
   isLastChat,
+  unreadCount,
 }: Props) {
-  const chatUnread = useRecoilValue(chatUnreadAtom);
   const userData = useRecoilValue(userListInfoAtom);
-  const myData = userData?.get(userId) || {
+
+  const { nickname, isMe, profileImg } = userData?.get(userId) || {
     nickname: '알 수 없는 사용자',
     isMe: false,
     profileImg: '',
   };
-  const { nickname, isMe, profileImg } = myData;
-
-  const unreadCount = useMemo(() => {
-    if (!chatUnread) {
-      return 0;
-    }
-    const mapArr = new Array(...chatUnread).sort(([key1], [key2]) => {
-      return key1.localeCompare(key2);
-    });
-
-    for (let i = 0; i < mapArr.length; i++) {
-      if (logId <= mapArr[i][1]) {
-        if (i === 0) {
-          return 0;
-        }
-        return Number(mapArr[i - 1][0]);
-      }
-    }
-
-    if (mapArr.length === 0) {
-      return 0;
-    }
-
-    return Number(mapArr[mapArr.length - 1][0]);
-  }, [chatUnread]);
-
-  // 같은 년 월 일, 시각 분, 사용자가 같으면 하나의 nickname만
 
   return (
     <Layout type={type} isMe={isMe}>


### PR DESCRIPTION
## 🤷‍♂️ Description
기존에는 각각의 채팅 box에서 unreadAtom을 가져와서 자신의 unreadCount를 계산했는데 이로 인해 발생한 문제점이 unreadCount가 바뀌면 모든 채팅 box가 자신의 unreadCount를 재계산하는 문제가 발생했어요.

따라서 부모에서 unreadAtom을 가져와서 부모에서 unreadCount를 계산하고 자식한테 내려주는 방식으로 변경했어요.
자식은 memo를 사용하여 unreadCount가 바뀌었을때만 렌더링하도록 했고 약 60퍼센트의 성능 향상이 일어났습니다.!


아직 채팅을 입력하거나 나갔다 들어왔을 때, 다른 컴포넌트가 렌더링 되는 문제가 있어서 이 부분도 최적화가 필요합니다.!! 같이 해봐야할 것 같아요

<!-- 구현 한 기능에 대해 작성해 주세요. -->

## 📝 Primary Commits

<!-- 세부 구현 사항을 리스트로 작성해주세요. -->


- [X] 부모에서 unreadCount 계산하도록 변경
- [X] 자식에 memo 적용

## 📷 Screenshots

unreadCount가 바뀌지 않아도 렌더링 했음

![녹화_2023_12_10_14_29_41_244](https://github.com/boostcampwm2023/web03-LockFestival/assets/100738049/04b48ff9-d2f6-45ac-a4ea-0de8b4fd2c5f)


![전체 렌더링](https://github.com/boostcampwm2023/web03-LockFestival/assets/100738049/23c892dc-29a6-44b4-a3f5-9cf60da261aa)


unreadCount가 바뀌었을 때만 렌더링

![바뀐 부분만 렌더링](https://github.com/boostcampwm2023/web03-LockFestival/assets/100738049/ba9c1db6-dcfb-42fd-9276-713b19c6796d)


![바뀐 채팅만 렌더링](https://github.com/boostcampwm2023/web03-LockFestival/assets/100738049/b654c0fe-da0c-43c9-8d53-76c3c9cb2356)




<!--스크린샷으로 보여줄 수 있는 이미지가 있다면 첨부해주세요!-->

<!--BE의 경우 API 테스트 결과를 첨부해주세요-->

<!--마지막으로 이슈 생성 시 우측의 옵션들을 체크했는지 확인해주세요!-->

<!-- 이슈번호를 작성해주세요. -->
<!-- 여러 이슈를 입력시 comma(,) 단위로 구분해주세요 -->
<!-- ex) close #10, resolves #123 -->


<!-- ex) -->
<!-- closes #1 --> 

