### PR TITLE
Feature/BE/#373: 테마 시간표 API에 캐싱 적용

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -22,6 +22,7 @@
   },
   "dependencies": {
     "@nestjs/axios": "^3.0.1",
+    "@nestjs/cache-manager": "^2.1.1",
     "@nestjs/common": "^10.0.0",
     "@nestjs/config": "^3.1.1",
     "@nestjs/core": "^10.0.0",
@@ -35,6 +36,7 @@
     "@nestjs/websockets": "^10.2.10",
     "@socket.io/redis-adapter": "^8.2.1",
     "axios": "^1.6.2",
+    "cache-manager": "^5.3.1",
     "cheerio": "^1.0.0-rc.12",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.0",

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -1,8 +1,10 @@
-import { DataSourceOptions, DataSource } from 'typeorm';
+import { DataSource, DataSourceOptions } from 'typeorm';
 import { MiddlewareConsumer, Module, NestModule } from '@nestjs/common';
 import { ConfigModule, ConfigService } from '@nestjs/config';
 import { MongooseModule } from '@nestjs/mongoose';
 import { TypeOrmModule } from '@nestjs/typeorm';
+import { CacheInterceptor, CacheModule } from '@nestjs/cache-manager';
+import { APP_INTERCEPTOR } from '@nestjs/core';
 import { AppController } from '@src/app.controller';
 import { AppService } from '@src/app.service';
 import { LoggerMiddleware } from '@src/utils/logger.middleware';
@@ -17,6 +19,7 @@ import { BrandModule } from '@brand/brand.module';
 import { ChatModule } from '@chat/chat.module';
 import { GroupModule } from '@group/group.module';
 import { EventsModule } from '@src/gateway/events.module';
+import { SEC_TO_MILLI } from '@constants/time.converter';
 
 @Module({
   imports: [
@@ -50,9 +53,19 @@ import { EventsModule } from '@src/gateway/events.module';
       },
       inject: [ConfigService],
     }),
+    CacheModule.register({
+      ttl: 5 * SEC_TO_MILLI,
+      isGlobal: true,
+    }),
   ],
   controllers: [AppController],
-  providers: [AppService],
+  providers: [
+    AppService,
+    {
+      provide: APP_INTERCEPTOR,
+      useClass: CacheInterceptor,
+    },
+  ],
 })
 export class AppModule implements NestModule {
   configure(consumer: MiddlewareConsumer) {

--- a/backend/src/constants/time.converter.ts
+++ b/backend/src/constants/time.converter.ts
@@ -1,0 +1,4 @@
+export const SEC_TO_MILLI = 1000;
+export const MIN_TO_MILLI = 60 * SEC_TO_MILLI;
+export const HOUR_TO_MILLI = 60 * MIN_TO_MILLI;
+export const DAY_TO_MILLI = 24 * HOUR_TO_MILLI;

--- a/backend/src/modules/themeModules/theme/theme.controller.ts
+++ b/backend/src/modules/themeModules/theme/theme.controller.ts
@@ -1,4 +1,12 @@
-import { Controller, DefaultValuePipe, Get, Param, ParseIntPipe, Query } from '@nestjs/common';
+import {
+  Controller,
+  DefaultValuePipe,
+  Get,
+  Param,
+  ParseIntPipe,
+  Query,
+  UseInterceptors,
+} from '@nestjs/common';
 import { ApiOkResponse, ApiOperation, ApiParam, ApiQuery, ApiTags } from '@nestjs/swagger';
 import { ThemeService } from '@theme/theme.service';
 import { GenreThemesResponseDto } from '@theme/dtos/genre.themes.response.dto';
@@ -12,8 +20,12 @@ import { ThemeBranchThemesDetailsResponseDto } from '@theme/dtos/theme.branch.de
 import { ThemeSearchRequestDto } from '@theme/dtos/theme.serach.request.dto';
 import { ThemeSearchResponseDto } from '@theme/dtos/theme.search.response.dto';
 import { DateRequestDto } from '@theme/dtos/date.request.dto';
+import { CacheInterceptor, CacheTTL } from '@nestjs/cache-manager';
+import { TimeTableDto } from '@crawlerUtils/dtos/timetable.response.dto';
+import { MIN_TO_MILLI } from '@constants/time.converter';
 
 const DEFAULT_THEME_COUNT = 10;
+const TIMETABLE_TTL = MIN_TO_MILLI * 5;
 
 @ApiTags('themes')
 @Controller('themes')
@@ -171,10 +183,12 @@ export class ThemeController {
     type: Date,
     example: new Date(),
   })
+  @UseInterceptors(CacheInterceptor)
+  @CacheTTL(TIMETABLE_TTL)
   async getTimeTable(
     @Param('themeId', ParseIntPipe) themeId: number,
     @Query() { date }: DateRequestDto
-  ) {
+  ): Promise<TimeTableDto[]> {
     return await this.themeService.getTimeTable(themeId, date);
   }
 }

--- a/backend/src/modules/themeModules/theme/theme.service.ts
+++ b/backend/src/modules/themeModules/theme/theme.service.ts
@@ -12,6 +12,7 @@ import { ThemeBranchThemesDetailsResponseDto } from '@theme/dtos/theme.branch.de
 import { ThemeSearchRequestDto } from '@theme/dtos/theme.serach.request.dto';
 import { ThemeSearchResponseDto } from '@theme/dtos/theme.search.response.dto';
 import { CrawlerFactory } from '@modules/themeModules/crawlerUtils/crawler.factory';
+import { TimeTableDto } from '@crawlerUtils/dtos/timetable.response.dto';
 
 @Injectable()
 export class ThemeService {
@@ -93,7 +94,7 @@ export class ThemeService {
     );
   }
 
-  public async getTimeTable(themeId: number, date: Date) {
+  public async getTimeTable(themeId: number, date: Date): Promise<TimeTableDto[]> {
     const { themeName, branchName, brandName } =
       await this.themeRepository.getThemeNameBranchNameBrandNameByThemeId(themeId);
 

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -22,6 +22,7 @@
       "@config/*": ["./src/config/*"],
       "@utils/*": ["./src/utils/*"],
       "@enum/*": ["./src/enum/*"],
+      "@constants/*": ["./src/constants/*"],
       "@modules/*": ["./src/modules/*"],
       "@auth/*": ["./src/modules/authModules/auth/*"],
       "@user/*": ["./src/modules/userModules/user/*"],

--- a/backend/yarn.lock
+++ b/backend/yarn.lock
@@ -706,6 +706,11 @@
   resolved "https://registry.yarnpkg.com/@nestjs/axios/-/axios-3.0.1.tgz#b006f81dd54a49def92cfaf9a8970434567e75ce"
   integrity sha512-VlOZhAGDmOoFdsmewn8AyClAdGpKXQQaY1+3PGB+g6ceurGIdTxZgRX3VXc1T6Zs60PedWjg3A82TDOB05mrzQ==
 
+"@nestjs/cache-manager@^2.1.1":
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/@nestjs/cache-manager/-/cache-manager-2.1.1.tgz#abc042c6ac83400c64fd293b48ddb2dec99f6096"
+  integrity sha512-oYfRys4Ng0zp2HTUPNjH7gizf4vvG3PQZZ+3yGemb3xrF+p3JxDSK0cDq9NTjHzD5UmhjiyAftB9GkuL+t3r9g==
+
 "@nestjs/cli@^10.0.0":
   version "10.2.1"
   resolved "https://registry.yarnpkg.com/@nestjs/cli/-/cli-10.2.1.tgz#a1d32c28e188f0fb4c3f54235c55745de4c6dd7f"
@@ -1934,6 +1939,15 @@ bytes@3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/bytes/-/bytes-3.1.2.tgz#8b0beeb98605adf1b128fa4386403c009e0221a5"
   integrity sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==
+
+cache-manager@^5.3.1:
+  version "5.3.1"
+  resolved "https://registry.yarnpkg.com/cache-manager/-/cache-manager-5.3.1.tgz#80e4edd593b2d7f7b2b2199dc6fbb4748432bc47"
+  integrity sha512-9HP6nc1ZqyZgcVEpy5XS2ns9MYE6cPEM6InA1wQhR6M7GviJzLH2NTFYnf3NEfRmLE351NCSkDo2VISX8dlG+w==
+  dependencies:
+    lodash.clonedeep "^4.5.0"
+    lru-cache "^10.0.2"
+    promise-coalesce "^1.1.1"
 
 call-bind@^1.0.0:
   version "1.0.5"
@@ -4266,6 +4280,11 @@ locate-path@^6.0.0:
   dependencies:
     p-locate "^5.0.0"
 
+lodash.clonedeep@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz#e23f3f9c4f8fbdde872529c1071857a086e5ccef"
+  integrity sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ==
+
 lodash.includes@^4.3.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/lodash.includes/-/lodash.includes-4.3.0.tgz#60bb98a87cb923c68ca1e51325483314849f553f"
@@ -4351,6 +4370,11 @@ long@^5.2.1:
   version "5.2.3"
   resolved "https://registry.yarnpkg.com/long/-/long-5.2.3.tgz#a3ba97f3877cf1d778eccbcb048525ebb77499e1"
   integrity sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q==
+
+lru-cache@^10.0.2:
+  version "10.1.0"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-10.1.0.tgz#2098d41c2dc56500e6c88584aa656c84de7d0484"
+  integrity sha512-/1clY/ui8CzjKFyjdvwPWJUYKiFVXG2I2cY0ssG7h4+hwk+XOIX7ZSG9Q7TW8TW3Kp3BUSqgFWBLgL4PJ+Blag==
 
 lru-cache@^5.1.1:
   version "5.1.1"
@@ -5065,6 +5089,11 @@ process-nextick-args@~2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.1.tgz#7820d9b16120cc55ca9ae7792680ae7dba6d7fe2"
   integrity sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==
+
+promise-coalesce@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/promise-coalesce/-/promise-coalesce-1.1.1.tgz#01f0d4c06060507fb0ca1f1cca8fa90ada1e22ba"
+  integrity sha512-k7+VaIwZc5dRfSF6RELqRY1+LCmcCkrnuNV9HzIpA6iwRHKke+j9yb0LBTTHQ2RRgf6AlMl9TntuTzcgV/BZwg==
 
 prompts@^2.0.1:
   version "2.4.2"


### PR DESCRIPTION
## 🤷‍♂️ Description
테마 시간표를 조회하는 API(`GET /themes/:themeId/timetable`)에 캐시를 적용해요.

<!-- 구현 한 기능에 대해 작성해 주세요. -->

## 📝 Primary Commits

<!-- 세부 구현 사항을 리스트로 작성해주세요. -->

- [X] 캐시 라이브러리를 추가해요.
  - cache-manager
  - @nestjs/cache-manager
- [X] AppModule에 CacheModule 등록
  - 캐시를 어디에 저장할 지 정할 수 있어요.
  - 현재 인메모리로 저장하는 기본값을 선택했어요.
- [X] 시간 단위를 밀리초로 변경하는 상수들을 추가했어요.
  - 이제서야(?) `constants` 디렉터리를 생성했어요.
  - cache-manager의 V5 버전에서는 TTL을 밀리초를 기준으로 사용해서 추가했어요.
  - 타입
    - `SEC_TO_MILLI = 1000;`
    - `MIN_TO_MILLI = 60 * SEC_TO_MILLI;`
    - `HOUR_TO_MILLI = 60 * MIN_TO_MILLI;`
    - `DAY_TO_MILLI = 24 * HOUR_TO_MILLI;`
- [X] `GET /themes/:themeId/timetable` 요청에 대한 캐싱을 적용해요.
  - `CacheInterceptor` 를 통해 설정해요.
  - TTL을 5분으로 설정했어요.
    `const TIMETABLE_TTL = MIN_TO_MILLI * 5;`
    `@CacheTTL(TIMETABLE_TTL)`
  - 최종
    ```ts
    @UseInterceptors(CacheInterceptor)
    @CacheTTL(TIMETABLE_TTL)
    async getTimeTable(
      @Param('themeId', ParseIntPipe) themeId: number,
      @Query() { date }: DateRequestDto
    ): Promise<TimeTableDto[]> {
      return await this.themeService.getTimeTable(themeId, date);
    }
    ```
- 자세한 사용법과 고민사항들을 노션에 정리했어요. [크롤러 캐싱 - 우리의 개발 과정](https://www.notion.so/08b5fb74c2de47469fbe55606b22ec68?pvs=4)

## 📷 Screenshots
* 동일한 요청에 대해 한 번의 쿼리만 수행 중인 모습을 볼 수 있어요.
![image](https://github.com/boostcampwm2023/web03-LockFestival/assets/44056518/74b878f3-5d2a-4b3b-bf77-85216891e5e7)

<!--스크린샷으로 보여줄 수 있는 이미지가 있다면 첨부해주세요!-->

<!--BE의 경우 API 테스트 결과를 첨부해주세요-->

<!--마지막으로 이슈 생성 시 우측의 옵션들을 체크했는지 확인해주세요!-->

<!-- 이슈번호를 작성해주세요. -->
<!-- 여러 이슈를 입력시 comma(,) 단위로 구분해주세요 -->
<!-- ex) close #10, resolves #123 -->


<!-- ex) -->
<!-- closes #1 --> 
closes #373
