### PR TITLE
Refactor/FE/#370: 스크롤이벤트 쓰로틀링 적용

### DIFF
--- a/frontend/src/pages/ChatRoom/components/ChatPanel/ChatPanel.tsx
+++ b/frontend/src/pages/ChatRoom/components/ChatPanel/ChatPanel.tsx
@@ -17,6 +17,7 @@ import {
 } from '@utils/chatMessageUtil';
 import useIsScrollTopObserver from '@hooks/intersectionObserver/useIsScrollTopObserver';
 import { useVirtualizer } from '@tanstack/react-virtual';
+import { throttle } from '@utils/throttle';
 
 interface ChatPanelProps {
   roomId: string;
@@ -25,8 +26,8 @@ interface ChatPanelProps {
 }
 
 const ChatPanel = ({ roomId, sendChat, getPastChat }: ChatPanelProps) => {
-  const chatLogData: Map<string, ChatLog> = useRecoilValue(chatLogAtom)[roomId];
   const navigate = useNavigate();
+  const chatLogData: Map<string, ChatLog> = useRecoilValue(chatLogAtom)[roomId];
   const targetRef = useRef<HTMLDivElement>(null);
   const parentRef = useRef<HTMLDivElement>(null);
   const lastScrollRef = useRef<HTMLDivElement>(null);
@@ -77,7 +78,7 @@ const ChatPanel = ({ roomId, sendChat, getPastChat }: ChatPanelProps) => {
     }
   }, [chatLogData]);
 
-  const handleScroll = () => {
+  const handleScroll = throttle(() => {
     if (!parentRef || !parentRef.current) {
       return;
     }
@@ -85,7 +86,7 @@ const ChatPanel = ({ roomId, sendChat, getPastChat }: ChatPanelProps) => {
     if (parentRef.current.scrollTop < 10) {
       setPrevScrollHeight(parentRef.current?.scrollHeight);
     }
-  };
+  }, 500);
 
   const chatArrayFromChatLogData = useMemo(() => {
     if (chatLogData) {

--- a/frontend/src/utils/throttle.ts
+++ b/frontend/src/utils/throttle.ts
@@ -1,0 +1,12 @@
+export const throttle = (callback: (...args: any[]) => void, delay: number) => {
+  let timeId: NodeJS.Timeout | null;
+  return (...args: any[]) => {
+    if (timeId) {
+      return;
+    }
+    timeId = setTimeout(() => {
+      callback(...args);
+      timeId = null;
+    }, delay);
+  };
+};


### PR DESCRIPTION
## 🤷‍♂️ Description
- 스크롤 이벤트는 스크롤시 짧은 시간이내에 연속적으로 발생하기 때문에, 성능 최적화를 위해 이벤트 주기를 조절하는 쓰로틀링 기법을 적용했어요.
- 자세한 설명은 노션 우리들의 개발 과정에 설명했어요.

<!-- 구현 한 기능에 대해 작성해 주세요. -->

## 📝 Primary Commits

<!-- 세부 구현 사항을 리스트로 작성해주세요. -->

- [X] 쓰로틀링 함수 구현
- [x] 채팅 패널 스크롤 이벤트에 쓰로틀링 적용

## 📷 Screenshots
1. 쓰로틀링 적용 전
 
![녹화_2023_12_10_14_51_52_308](https://github.com/boostcampwm2023/web03-LockFestival/assets/82202370/b68e27d9-461e-4409-a0d4-c3a39e324276)


2. 쓰로틀링 적용 후

![녹화_2023_12_10_16_29_58_952](https://github.com/boostcampwm2023/web03-LockFestival/assets/82202370/fdc55b01-d8b7-4b25-81a9-1789c5b3058d)


<!--스크린샷으로 보여줄 수 있는 이미지가 있다면 첨부해주세요!-->

<!--BE의 경우 API 테스트 결과를 첨부해주세요-->

<!--마지막으로 이슈 생성 시 우측의 옵션들을 체크했는지 확인해주세요!-->

<!-- 이슈번호를 작성해주세요. -->
<!-- 여러 이슈를 입력시 comma(,) 단위로 구분해주세요 -->
<!-- ex) close #10, resolves #123 -->


<!-- ex) -->
<!-- closes #1 --> 

