### PR TITLE
Feature/FE/#381: 드롭다운 메뉴 추가 및 헤더 디자인 변경

### DIFF
--- a/frontend/src/components/Header/Header.tsx
+++ b/frontend/src/components/Header/Header.tsx
@@ -15,20 +15,22 @@ const Header = () => {
 };
 
 const HeaderContainer = styled.header([
-  tw`font-maplestory mx-auto text-white`,
-  tw`desktop:(max-w-[102.4rem] w-full h-[6rem] text-l-bold)`,
-  tw`mobile:(w-full text-m-bold)`,
-]);
-
-const HeaderInnerContainer = styled.div([
-  tw`desktop:(h-[6rem])`,
-  tw`tablet:(h-[6rem])`,
-  tw`mobile:(h-[5rem])`,
+  tw`w-full font-maplestory mx-auto text-white py-2`,
+  tw`desktop:(max-w-[102.4rem] h-[6rem] text-l-bold)`,
+  tw`tablet:(h-[5rem] text-l-bold)`,
+  tw`mobile:(h-[4rem] text-m-bold)`,
   css`
     display: flex;
     align-items: center;
-    justify-content: space-around;
-    width: 100%;
+  `,
+]);
+
+const HeaderInnerContainer = styled.div([
+  tw`w-[95%] mx-auto`,
+  css`
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
   `,
 ]);
 

--- a/frontend/src/components/Header/HeaderNav/HeaderNav.tsx
+++ b/frontend/src/components/Header/HeaderNav/HeaderNav.tsx
@@ -54,7 +54,7 @@ const HeaderLogo = styled.img([
 const NavContainer = styled.ul([
   tw`border border-white border-solid rounded-[4rem]`,
   tw`desktop:(w-[40rem] h-[3.6rem] mx-4)`,
-  tw`tablet:(w-[32rem] h-[3.2rem] mx-2)`,
+  tw`tablet:(w-[28rem] h-[3.2rem] mx-2)`,
   tw`mobile:(hidden)`,
   css`
     display: grid;

--- a/frontend/src/components/Header/HeaderRest/HeaderRest.tsx
+++ b/frontend/src/components/Header/HeaderRest/HeaderRest.tsx
@@ -91,7 +91,13 @@ const HeaderRest = () => {
           <>
             <Button size="l" isIcon={false}>
               <>
-                <FaUser size={20} />
+                <ProfileImgWrapper>
+                  {profileData.profileImageUrl ? (
+                    <ProfileImg src={profileData.profileImageUrl} />
+                  ) : (
+                    <FaUser size={10} />
+                  )}
+                </ProfileImgWrapper>
                 {profileData.nickname}님
               </>
             </Button>
@@ -191,6 +197,23 @@ const DropDownList = styled.li([
     display: flex;
     align-items: center;
     cursor: pointer;
+  `,
+]);
+
+const ProfileImgWrapper = styled.div([
+  tw` w-[2rem] h-[2rem] mr-1`,
+  css`
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  `,
+]);
+
+const ProfileImg = styled.img([
+  tw`w-[2rem] h-[2rem] mr-1`,
+  css`
+    border-radius: 50%;
   `,
 ]);
 

--- a/frontend/src/components/Header/HeaderRest/HeaderRest.tsx
+++ b/frontend/src/components/Header/HeaderRest/HeaderRest.tsx
@@ -3,7 +3,7 @@ import Button from '@components/Button/Button';
 import { FaUser } from 'react-icons/fa6';
 import { FaSistrix } from 'react-icons/fa6';
 import { keyframes } from '@emotion/react';
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import useProfileQuery from '@hooks/useProfileQuery';
 import useModal from '@hooks/useModal';
 import Modal from '@components/Modal/Modal';
@@ -20,6 +20,8 @@ const HeaderRest = () => {
   const { data } = useProfileQuery();
 
   const [profileData, setProfileData] = useRecoilState<Profile>(userAtom);
+
+  const [isHoverProfile, setIsHoverProfile] = useState<boolean>(false);
 
   const {
     realInputQuery,
@@ -81,14 +83,24 @@ const HeaderRest = () => {
           </Button>
         )}
       </SearchContainer>
-      <ProfileContainer>
+      <ProfileContainer
+        onMouseOver={() => setIsHoverProfile(true)}
+        onMouseOut={() => setIsHoverProfile(false)}
+      >
         {profileData.nickname ? (
-          <Button size="l" onClick={handleLogout} isIcon={false}>
-            <>
-              <FaUser size={20} />
-              {profileData.nickname}님
-            </>
-          </Button>
+          <>
+            <Button size="l" isIcon={false}>
+              <>
+                <FaUser size={20} />
+                {profileData.nickname}님
+              </>
+            </Button>
+            {isHoverProfile && (
+              <DropDown>
+                <DropDownList onClick={handleLogout}>로그아웃</DropDownList>
+              </DropDown>
+            )}
+          </>
         ) : (
           <Button size="l" font="maplestory" isIcon={false} onClick={handleLogin}>
             <>로그인</>
@@ -100,8 +112,6 @@ const HeaderRest = () => {
 };
 
 const HeaderRestContainer = styled.div([
-  tw`desktop:(w-[40rem])`,
-  tw`mobile:(w-[20rem])`,
   css`
     display: flex;
     align-items: flex-end;
@@ -120,6 +130,9 @@ const widthAnimation = keyframes`
 `;
 
 const SearchContainer = styled.div([
+  tw`desktop:(w-[16rem] h-[3.6rem] rounded-[4rem])`,
+  tw`tablet:(w-[12rem] h-[3.6rem] rounded-[4rem])`,
+  tw`mobile:(w-[8rem] h-[3.6rem] rounded-[3rem])`,
   css`
     display: flex;
     align-items: center;
@@ -128,22 +141,23 @@ const SearchContainer = styled.div([
 ]);
 
 const SearchInputForm = styled.div([
-  tw`bg-gray-light`,
-  tw`desktop:(max-w-[16.4rem] w-[16.4rem] h-[3.6rem] rounded-[4rem])`,
-  tw`mobile:(w-[12.4rem] h-[3.2rem] rounded-[3rem])`,
+  tw`bg-gray-light w-[10rem]`,
+  tw`desktop:(rounded-[4rem])`,
+  tw`tablet:(rounded-[4rem])`,
+  tw`mobile:(rounded-[3rem])`,
   css`
-    animation: 0.6s ${widthAnimation} forwards;
+    animation: 0.5s ${widthAnimation} forwards;
     display: flex;
     align-items: center;
   `,
 ]);
 
 const SearchInput = styled.input([
-  tw`(font-pretendard h-full pl-2 pr-3 bg-gray-light text-white rounded-[4rem])`,
-  tw`desktop:(max-w-[12.8rem] text-m)`,
-  tw`mobile:(max-w-[9.2rem] text-s)`,
+  tw`font-pretendard h-full pl-2 bg-gray-light text-white rounded-[4rem]`,
+  tw`desktop:(text-m w-[10rem])`,
+  tw`tablet:(text-m w-[8rem])`,
+  tw`mobile:(text-s w-[6rem])`,
   css`
-    animation: 1s ${widthAnimation} forwards;
     border: none;
     outline: none;
   `,
@@ -154,6 +168,29 @@ const ProfileContainer = styled.div([
     display: flex;
     align-items: center;
     justify-content: flex-end;
+    position: relative;
+  `,
+]);
+
+const DropDown = styled.ul([
+  tw`w-full font-pretendard text-l`,
+  css`
+    position: absolute;
+    top: 3.6rem;
+    right: 0;
+    display: flex;
+    flex-direction: column;
+    z-index: 5;
+  `,
+]);
+
+const DropDownList = styled.li([
+  tw`rounded-[1rem] border border-white border-solid pl-4 h-[4rem] bg-gray-light`,
+
+  css`
+    display: flex;
+    align-items: center;
+    cursor: pointer;
   `,
 ]);
 


### PR DESCRIPTION
## 🤷‍♂️ Description
기존에는 프로필을 클릭하면 로그아웃이 되었는데 불편하다는 의견이 많아서 hover를 하면 드롭다운 메뉴가 나오도록 변경했어요!

그리고 검색 버튼이 찌그러져 보였는데 해당 부분을 수정했어요.
반응형에서 input이 짤리던 문제가 있어서 약간의 수정을 했어요.

<!-- 구현 한 기능에 대해 작성해 주세요. -->

## 📝 Primary Commits

<!-- 세부 구현 사항을 리스트로 작성해주세요. -->

- [X] 드롭다운 메뉴 추가
- [X] 검색 버튼 수정

## 📷 Screenshots

- 드롭다운

![녹화_2023_12_10_17_40_33_861](https://github.com/boostcampwm2023/web03-LockFestival/assets/100738049/b033bef8-f77a-4312-a785-39e943b4ce04)

- 검색 버튼 안 찌그러지도록 수정

![캡처_2023_12_10_17_40_57_158](https://github.com/boostcampwm2023/web03-LockFestival/assets/100738049/94571dd0-9c01-4fa8-b2e8-2c12dd1560a6)

<!--스크린샷으로 보여줄 수 있는 이미지가 있다면 첨부해주세요!-->

<!--BE의 경우 API 테스트 결과를 첨부해주세요-->

<!--마지막으로 이슈 생성 시 우측의 옵션들을 체크했는지 확인해주세요!-->

<!-- 이슈번호를 작성해주세요. -->
<!-- 여러 이슈를 입력시 comma(,) 단위로 구분해주세요 -->
<!-- ex) close #10, resolves #123 -->


<!-- ex) -->
<!-- closes #1 --> 
closes #381 