### PR TITLE
Fix/BE/#384: 넥스트에디션의 반환값 수정 및 크롤러 모듈의 에러처리

### DIFF
--- a/backend/src/modules/themeModules/crawlerUtils/crawler/nextedition.crawler.ts
+++ b/backend/src/modules/themeModules/crawlerUtils/crawler/nextedition.crawler.ts
@@ -44,7 +44,7 @@ export class NextEditionCrawler extends AbstractCrawler {
 
       const roundMap = data.themes.reduce((prev, { title, rounds }) => {
         rounds.forEach(({ id, target_time }) => {
-          prev[id] = { target_time, title, possible: true };
+          prev[id] = { time: target_time, title, possible: true };
         });
         return prev;
       }, {});
@@ -53,15 +53,15 @@ export class NextEditionCrawler extends AbstractCrawler {
         roundMap[round_id].possible = false;
       });
 
-      const result = Object.values(roundMap).reduce((prev, { title, target_time, possible }) => {
+      const result = Object.values(roundMap).reduce((prev, { title, time, possible }) => {
         prev[title] = prev[title] || [];
-        prev[title].push({ target_time, possible });
+        prev[title].push({ time, possible });
         return prev;
       }, {});
 
       return result;
     } catch (error) {
-      return null;
+      return [];
     }
   }
 }

--- a/backend/src/modules/themeModules/theme/theme.service.ts
+++ b/backend/src/modules/themeModules/theme/theme.service.ts
@@ -98,8 +98,6 @@ export class ThemeService {
     const { themeName, branchName, brandName } =
       await this.themeRepository.getThemeNameBranchNameBrandNameByThemeId(themeId);
 
-    this.logger.log(`crawler start brand: ${brandName} branch: ${branchName} theme: ${themeName}`);
-
     //format : yyyy-mm-dd
     const dateString =
       date.getFullYear() +
@@ -108,8 +106,17 @@ export class ThemeService {
       `-` +
       (date.getDate() < 10 ? `0` + date.getDate() : date.getDate());
 
-    return await this.crawlerFactory
-      .getCrawler(brandName)
-      .getTimeTableByTheme({ shop: branchName, theme: themeName, date: dateString });
+    this.logger.log(
+      `crawler start date: ${dateString} brand: ${brandName} branch: ${branchName} theme: ${themeName}`
+    );
+
+    try {
+      return await this.crawlerFactory
+        .getCrawler(brandName)
+        .getTimeTableByTheme({ shop: branchName, theme: themeName, date: dateString });
+    } catch (err) {
+      this.logger.error(err);
+      return [];
+    }
   }
 }


### PR DESCRIPTION
## 🤷‍♂️ Description
넥스트에디션 크롤러의 반환값이 { target_time, possible }로 들어가고 있었어요. 이를 수정했어요.
크롤러를 수행하는 도중 에러가 발생하면 빈배열을 반환하도록 에러처리해요.

<!-- 구현 한 기능에 대해 작성해 주세요. -->


## 📝 Primary Commits

<!-- 세부 구현 사항을 리스트로 작성해주세요. -->

- [X] NextEditionCrawler의 응답값 target_time -> time 변경
- [x] 크롤러 요청에 try/catch를 붙여 에러가 발생하면 빈배열을 반환해요

## 📷 Screenshots

<!--스크린샷으로 보여줄 수 있는 이미지가 있다면 첨부해주세요!-->

<!--BE의 경우 API 테스트 결과를 첨부해주세요-->

<!--마지막으로 이슈 생성 시 우측의 옵션들을 체크했는지 확인해주세요!-->

<!-- 이슈번호를 작성해주세요. -->
<!-- 여러 이슈를 입력시 comma(,) 단위로 구분해주세요 -->
<!-- ex) close #10, resolves #123 -->


<!-- ex) -->
<!-- closes #1 --> 
closes #384
