### PR TITLE
Feature/BE/#388: 채팅방 정보에 홈페이지도 함께 반환

### DIFF
--- a/backend/src/modules/userModules/group/dtos/group.info.response.dto.ts
+++ b/backend/src/modules/userModules/group/dtos/group.info.response.dto.ts
@@ -12,6 +12,13 @@ export class GroupInfoResponseDto extends GroupInfoDto {
   @ApiProperty({ description: '지역', type: String, example: '서울 홍대' })
   regionName: string;
 
+  @ApiProperty({
+    description: '웹사이트',
+    type: String,
+    example: 'http://www.secretgardenescape.com/reservation.html?k_shopno=2',
+  })
+  website: string;
+
   constructor({
     brandName,
     branchName,
@@ -25,6 +32,7 @@ export class GroupInfoResponseDto extends GroupInfoDto {
     currentMembers,
     recruitmentCompleted,
     appointmentCompleted,
+    website,
   }) {
     super({
       recruitmentContent,
@@ -37,6 +45,7 @@ export class GroupInfoResponseDto extends GroupInfoDto {
     this.brandName = brandName;
     this.branchName = branchName;
     this.regionName = regionName;
+    this.website = website;
     Object.assign(this, new ThemeResponseDto({ name: themeName, id: themeId, posterImageUrl }));
   }
 }

--- a/backend/src/modules/userModules/group/group.repository.ts
+++ b/backend/src/modules/userModules/group/group.repository.ts
@@ -167,6 +167,7 @@ export class GroupRepository extends Repository<Group> {
         .select([
           'brand.brandName as brandName',
           'branch.branchName as branchName',
+          'branch.website as website',
           "CONCAT(branch.big_region, ' ', branch.small_region) AS regionName",
           'theme.name as themeName',
           'theme.id as themeId',

--- a/backend/src/modules/userModules/group/group.repository.ts
+++ b/backend/src/modules/userModules/group/group.repository.ts
@@ -162,7 +162,7 @@ export class GroupRepository extends Repository<Group> {
 
   async getGroupInfo(groupId: number): Promise<GroupInfoResponseDto> {
     try {
-      const qb = await this.dataSource
+      const rawData = await this.dataSource
         .createQueryBuilder(Group, 'group')
         .select([
           'brand.brandName as brandName',
@@ -184,7 +184,7 @@ export class GroupRepository extends Repository<Group> {
         .innerJoin(Branch, 'branch', 'theme.branch_id = branch.id')
         .innerJoin(Brand, 'brand', 'branch.brand_id = brand.id')
         .getRawOne();
-      return new GroupInfoResponseDto(qb);
+      return new GroupInfoResponseDto(rawData);
     } catch (err) {
       throw new HttpException('Error getting group information', HttpStatus.INTERNAL_SERVER_ERROR);
     }


### PR DESCRIPTION
## 🤷‍♂️ Description
채팅방의 정보를 반환할 때 예약 홈페이지 정보도 함께 반환해요.

<!-- 구현 한 기능에 대해 작성해 주세요. -->

## 📝 Primary Commits

<!-- 세부 구현 사항을 리스트로 작성해주세요. -->

- [X] website 타입 추가
  - 테마 시간표를 보여줄 때 예약 링크도 함께 표기하기 위함이에요
- [X] qb -> rawData 변수명 변경
  - qb는 QueryBuilder의 약칭으로 이미 결과를 가져온 해당 내용과 맞지 않다고 판단하여 수정했어요

## 📷 Screenshots

<!--스크린샷으로 보여줄 수 있는 이미지가 있다면 첨부해주세요!-->

<!--BE의 경우 API 테스트 결과를 첨부해주세요-->

<!--마지막으로 이슈 생성 시 우측의 옵션들을 체크했는지 확인해주세요!-->

<!-- 이슈번호를 작성해주세요. -->
<!-- 여러 이슈를 입력시 comma(,) 단위로 구분해주세요 -->
<!-- ex) close #10, resolves #123 -->


<!-- ex) -->
<!-- closes #1 --> 
closes #388
