### PR TITLE
Feature/FE/#385: 실시간 시간표 수정 및 새로운 채팅 팝업 메세지 기능 구현

### DIFF
--- a/frontend/src/hooks/useTimeTableQuery.tsx
+++ b/frontend/src/hooks/useTimeTableQuery.tsx
@@ -7,6 +7,7 @@ const useTimeTableQuery = (themeId: number, date: Value) => {
   const { data, isSuccess, isLoading, isError } = useQuery<TimeTable[]>({
     queryKey: [QUERY_MANAGEMENT['themeTimeTable'].key, themeId, date],
     queryFn: () => QUERY_MANAGEMENT['themeTimeTable'].fn(themeId, date),
+    retryDelay: 5000,
   });
 
   return { data, isSuccess, isLoading, isError };

--- a/frontend/src/pages/ChatRoom/components/ChatPanel/MessageBox/BoxType/MyChatBox.tsx
+++ b/frontend/src/pages/ChatRoom/components/ChatPanel/MessageBox/BoxType/MyChatBox.tsx
@@ -49,7 +49,7 @@ const DateContent = styled.div([
 ]);
 
 const MessageContent = styled.div([
-  tw`border border-gray border-solid rounded-[1.2rem] px-2 py-1`,
+  tw`border border-border-default border-solid rounded-[1.2rem] px-2 py-1`,
   css`
     max-width: 25rem;
     width: fit-content;

--- a/frontend/src/pages/ChatRoom/components/ChatPanel/MessageBox/BoxType/OtherChatBox.tsx
+++ b/frontend/src/pages/ChatRoom/components/ChatPanel/MessageBox/BoxType/OtherChatBox.tsx
@@ -64,7 +64,7 @@ const ProfileContainer = styled.div([
 ]);
 
 const ProfileImg = styled.img([
-  tw`border border-gray border-solid`,
+  tw`border border-gray border-solid p-1`,
   css`
     width: 3rem;
     height: 3rem;
@@ -83,7 +83,7 @@ const TextContainer = styled.div([
 ]);
 
 const MessageContent = styled.div([
-  tw`border border-gray border-solid rounded-[1.2rem] px-2 py-1`,
+  tw`border border-border-default border-solid rounded-[1.2rem] px-2 py-1`,
   css`
     max-width: 25rem;
     width: fit-content;

--- a/frontend/src/pages/ChatRoom/components/ChatPanel/MessageBox/BoxType/SystemChatBox.tsx
+++ b/frontend/src/pages/ChatRoom/components/ChatPanel/MessageBox/BoxType/SystemChatBox.tsx
@@ -33,7 +33,7 @@ const TextContainer = styled.div([
 ]);
 
 const MessageContent = styled.div([
-  tw`w-full border border-gray border-solid rounded-[1.2rem] px-2 py-2 bg-gray-light text-white-60`,
+  tw`w-full border border-border-default border-solid rounded-[1.2rem] px-2 py-2 bg-gray-light text-white-60`,
   css`
     text-align: center;
     word-break: break-all;

--- a/frontend/src/pages/ChatRoom/components/ChatPanel/PopUpMessageBox/PopUpMessageBox.tsx
+++ b/frontend/src/pages/ChatRoom/components/ChatPanel/PopUpMessageBox/PopUpMessageBox.tsx
@@ -1,0 +1,45 @@
+import tw, { styled, css } from 'twin.macro';
+import { ChatLog } from 'types/chat';
+import { useRecoilValue } from 'recoil';
+import { userListInfoAtom } from '@store/chatRoom';
+import { FaCircleUser } from 'react-icons/fa6';
+
+const PopUpMessageBox = ({ message, userId }: Omit<ChatLog, 'time' | 'type'>) => {
+  const userListInfo = useRecoilValue(userListInfoAtom);
+  const curUser = userListInfo?.get(userId);
+
+  return (
+    <Layout>
+      {curUser?.profileImg ? <ProfileImg src={curUser?.profileImg} /> : <FaCircleUser size="28" />}
+      <div>{curUser?.nickname}</div>
+      <MessageText>{message}</MessageText>
+    </Layout>
+  );
+};
+
+export default PopUpMessageBox;
+
+const Layout = styled.div([
+  css`
+    display: flex;
+    align-items: center;
+    gap: 1.2rem;
+  `,
+  tw`w-full font-pretendard text-m`,
+]);
+
+const ProfileImg = styled.img([
+  tw`w-[3.2rem] h-[3.2rem] rounded-[50%] p-1`,
+  css`
+    border: 1px solid black;
+  `,
+]);
+
+const MessageText = styled.div([
+  css`
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    flex: 1;
+  `,
+]);

--- a/frontend/src/pages/ChatRoom/components/RoomInfoPanel/RoomInfoPanel.tsx
+++ b/frontend/src/pages/ChatRoom/components/RoomInfoPanel/RoomInfoPanel.tsx
@@ -108,6 +108,7 @@ const Layout = styled.div([
     height: 100vh;
     padding: 2rem;
     gap: 1.6rem;
+    overflow: hidden;
   `,
   tw`bg-gray-light rounded-[2rem] h-[calc(90vh - 6rem)]`,
 ]);

--- a/frontend/src/pages/ChatRoom/components/RoomInfoPanel/TimeTable/TimeTable.tsx
+++ b/frontend/src/pages/ChatRoom/components/RoomInfoPanel/TimeTable/TimeTable.tsx
@@ -6,12 +6,11 @@ import Calendar from 'react-calendar';
 import useTimeTableQuery from '@hooks/useTimeTableQuery';
 import { FaArrowsRotate } from 'react-icons/fa6';
 import { keyframes } from '@emotion/react';
+import { getStringByDate } from '@utils/dateUtil';
 
 const TimeTable = ({ themeId }: { themeId: number }) => {
   const today = new Date();
   const [date, setDate] = useState<Value>(today);
-  const oneWeekLater = new Date(today);
-  oneWeekLater.setDate(today.getDate() + 7);
   const { data, isLoading } = useTimeTableQuery(themeId, date);
 
   return (
@@ -25,10 +24,8 @@ const TimeTable = ({ themeId }: { themeId: number }) => {
           formatDay={(_, date) => date.toLocaleDateString('ko-KR', { day: '2-digit' }).slice(0, -1)}
           value={date}
           minDate={today}
-          maxDate={oneWeekLater}
           minDetail="month"
           maxDetail="month"
-          showNavigation={false}
         />
       </CalendarWrapper>
       <BottomWrapper>
@@ -38,16 +35,23 @@ const TimeTable = ({ themeId }: { themeId: number }) => {
           </Loading>
         ) : (
           <>
-            {data?.map((timeData) =>
-              timeData.possible ? (
-                <Label isBorder={false} width="6rem" backgroundColor="green-light">
-                  <LabelText>{timeData.time}</LabelText>
-                </Label>
-              ) : (
-                <Label isBorder={false} width="6rem" backgroundColor="green-dark">
-                  <LabelText>{timeData.time}</LabelText>
-                </Label>
+            {data && data.length > 0 ? (
+              data?.map((timeData) =>
+                timeData.possible ? (
+                  <Label isBorder={false} width="6rem" backgroundColor="green-light">
+                    <LabelText>{timeData.time}</LabelText>
+                  </Label>
+                ) : (
+                  <Label isBorder={false} width="6rem" backgroundColor="green-dark">
+                    <LabelText>{timeData.time}</LabelText>
+                  </Label>
+                )
               )
+            ) : (
+              <InfoText>
+                {getStringByDate(date as Date)}의<br />
+                시간표를 불러올 수 없습니다.
+              </InfoText>
             )}
           </>
         )}
@@ -75,7 +79,7 @@ const TopWrapper = styled.div([
   tw`text-white`,
 ]);
 
-const Text = styled.div([tw`font-pretendard text-m`]);
+const Text = styled.div([tw`font-pretendard text-l`]);
 
 const BottomWrapper = styled.div([tw`grid grid-cols-4 gap-4`]);
 const LabelText = styled.div(tw`mx-auto`);
@@ -98,5 +102,16 @@ const Loading = styled.div([
     justify-content: center;
     align-items: center;
     animation: ${rotate} 1s infinite linear;
+  `,
+]);
+
+const InfoText = styled.div([
+  tw`w-[30rem] h-[12.8rem] font-pretendard text-white text-m`,
+  css`
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    text-align: center;
+    line-height: 2.5rem;
   `,
 ]);

--- a/frontend/src/pages/ChatRoom/components/RoomInfoPanel/TimeTable/TimeTable.tsx
+++ b/frontend/src/pages/ChatRoom/components/RoomInfoPanel/TimeTable/TimeTable.tsx
@@ -38,11 +38,21 @@ const TimeTable = ({ themeId }: { themeId: number }) => {
             {data && data.length > 0 ? (
               data?.map((timeData) =>
                 timeData.possible ? (
-                  <Label isBorder={false} width="6rem" backgroundColor="green-light">
+                  <Label
+                    key={timeData.time}
+                    isBorder={false}
+                    width="6rem"
+                    backgroundColor="green-light"
+                  >
                     <LabelText>{timeData.time}</LabelText>
                   </Label>
                 ) : (
-                  <Label isBorder={false} width="6rem" backgroundColor="green-dark">
+                  <Label
+                    key={timeData.time}
+                    isBorder={false}
+                    width="6rem"
+                    backgroundColor="green-dark"
+                  >
                     <LabelText>{timeData.time}</LabelText>
                   </Label>
                 )

--- a/frontend/src/pages/ChatRoom/components/UserListPanel/UserItem/UserItem.tsx
+++ b/frontend/src/pages/ChatRoom/components/UserListPanel/UserItem/UserItem.tsx
@@ -49,4 +49,5 @@ const ProfileImg = styled.img([
     border-radius: 50%;
     background-color: white;
   `,
+  tw`p-1`,
 ]);

--- a/frontend/tailwind.config.ts
+++ b/frontend/tailwind.config.ts
@@ -110,6 +110,7 @@ export default {
         'red-dark': '#BE3144',
         'white': '#F2F2F2',
         'orange': '#e3651d',
+        'border-default': '#5F6E76',
       },
     },
   },


### PR DESCRIPTION
## 🤷‍♂️ Description
- 스크롤이 올라가있는 상태에서 다른 사람의 채팅이 왔을때, 입력창 위에 팝업 메세지를 띄워줘요.
- 사용자가 해당 메세지를 클릭하거나 스크롤이 하단으로 내려갔을때 읽음 처리를 해줘요.
- 실시간 시간표 날짜 제한을 없앴어요.
- 불러온 시간표의 길이가 0인 경우 안내 메세지를 띄워줘요.
- 실시간 시간표 API 요청 대기 시간을 5초로 변경했어요.

<!-- 구현 한 기능에 대해 작성해 주세요. -->

## 📝 Primary Commits

<!-- 세부 구현 사항을 리스트로 작성해주세요. -->

- [X] 실시간 시간표 날짜 제한 없애기, 불러온 시간표 없을때 안내 멘트 띄워주기
- [x] 팝업 메세지 UI 마크업
- [x] 팝업 메세지 보여주는 로직 작성하기

## 📷 Screenshots
1. 실시간 시간표

![녹화_2023_12_10_22_25_09_712](https://github.com/boostcampwm2023/web03-LockFestival/assets/82202370/082c97d1-3c0c-4566-aadd-85743f098e81)

2. 팝업 메세지

![녹화_2023_12_10_22_26_30_421](https://github.com/boostcampwm2023/web03-LockFestival/assets/82202370/b680cad0-5564-4ecd-b474-8b0a6699dec1)


<!--스크린샷으로 보여줄 수 있는 이미지가 있다면 첨부해주세요!-->

<!--BE의 경우 API 테스트 결과를 첨부해주세요-->

<!--마지막으로 이슈 생성 시 우측의 옵션들을 체크했는지 확인해주세요!-->

<!-- 이슈번호를 작성해주세요. -->
<!-- 여러 이슈를 입력시 comma(,) 단위로 구분해주세요 -->
<!-- ex) close #10, resolves #123 -->


<!-- ex) -->
<!-- closes #1 --> 

