### PR TITLE
Feature/FE/#393: 채팅 렌더링 최적화 - 2

### DIFF
--- a/frontend/src/hooks/socket/useSocket.ts
+++ b/frontend/src/hooks/socket/useSocket.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import { ChangeRoomData, ServerChatLog, ServerChatLogList } from 'types/chat';
 import useSocketConnection from './useSocketConnection';
 import useChatLog from './useChatLog';
@@ -20,27 +20,39 @@ const useSocket = (roomId: string) => {
 
   const navigate = useNavigate();
 
-  const sendChat = (message: string) => {
-    socket?.emit('chat', { message });
-  };
+  const sendChat = useCallback(
+    (message: string) => {
+      socket?.emit('chat', { message });
+    },
+    [socket]
+  );
 
-  const getPastChat = (cursorId: string) => {
-    socket?.emit('chatLog', {
-      cursorLogId: cursorId,
-      count: 50,
-      directrion: -1,
-    });
-  };
+  const getPastChat = useCallback(
+    (cursorId: string) => {
+      socket?.emit('chatLog', {
+        cursorLogId: cursorId,
+        count: 50,
+        directrion: -1,
+      });
+    },
+    [socket]
+  );
 
-  const kickUser = (userId: string) => {
-    socket?.emit('kick', {
-      userId,
-    });
-  };
+  const kickUser = useCallback(
+    (userId: string) => {
+      socket?.emit('kick', {
+        userId,
+      });
+    },
+    [socket]
+  );
 
-  const changeRoom = (afterRoomInfo: Record<string, ChangeRoomData>) => {
-    socket?.emit('roomInfo', afterRoomInfo);
-  };
+  const changeRoom = useCallback(
+    (afterRoomInfo: Record<string, ChangeRoomData>) => {
+      socket?.emit('roomInfo', afterRoomInfo);
+    },
+    [socket]
+  );
 
   useEffect(() => {
     if (socket) {

--- a/frontend/src/pages/ChatRoom/components/ChatPanel/InputBox/InputBox.tsx
+++ b/frontend/src/pages/ChatRoom/components/ChatPanel/InputBox/InputBox.tsx
@@ -1,0 +1,71 @@
+import Button from '@components/Button/Button';
+import useInput from '@hooks/useInput';
+import tw, { styled, css } from 'twin.macro';
+
+interface Props {
+  setIsScrollToTop: React.Dispatch<React.SetStateAction<boolean>>;
+  sendChat: (message: string) => void;
+}
+
+const InputBox = ({ setIsScrollToTop, sendChat }: Props) => {
+  const [inputValue, handleValue, resetValue] = useInput('');
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Enter' && !e.shiftKey && !e.nativeEvent.isComposing) {
+      e.preventDefault();
+      handleSubmit();
+    }
+  };
+
+  const preventDefault = (e: React.FocusEvent<HTMLTextAreaElement>) => {
+    e.preventDefault();
+  };
+
+  const handleSubmit = () => {
+    if (inputValue === '') {
+      return;
+    }
+    setIsScrollToTop(false);
+    sendChat(inputValue);
+    resetValue();
+  };
+
+  return (
+    <>
+      <InputChatPanel
+        value={inputValue}
+        onChange={handleValue}
+        rows={4}
+        onKeyDown={handleKeyDown}
+        onFocus={preventDefault}
+        onBlur={preventDefault}
+      />
+      <SendButtonWrapper>
+        <Button type="button" isIcon={false} onClick={handleSubmit}>
+          <>보내기</>
+        </Button>
+      </SendButtonWrapper>
+    </>
+  );
+};
+
+const InputChatPanel = styled.textarea([
+  tw`font-pretendard text-white text-m w-[100%] h-[10rem] bg-gray rounded-[2rem] p-4 pr-[6.4rem]`,
+  css`
+    resize: none;
+
+    &:focus {
+      outline: none;
+    }
+  `,
+]);
+
+const SendButtonWrapper = styled.div([
+  css`
+    position: absolute;
+    bottom: 3rem;
+    right: 3rem;
+  `,
+]);
+
+export default InputBox;

--- a/frontend/src/pages/ChatRoom/components/RoomInfoPanel/RoomInfoPanel.tsx
+++ b/frontend/src/pages/ChatRoom/components/RoomInfoPanel/RoomInfoPanel.tsx
@@ -11,13 +11,14 @@ import { useRecoilValue } from 'recoil';
 import { roomInfoAtom } from '@store/chatRoom';
 import { getStringByDate } from '@utils/dateUtil';
 import TimeTable from './TimeTable/TimeTable';
+import { memo } from 'react';
 
 interface Props {
   settingMode: boolean;
   changeRoom: (afterRoomInfo: Record<string, ChangeRoomData>) => void;
 }
 
-const RoomInfoPanel = ({ settingMode, changeRoom }: Props) => {
+const RoomInfoPanel = memo(function RoomInfoPanel({ settingMode, changeRoom }: Props) {
   const { openModal, closeModal } = useModal();
   const roomInfo = useRecoilValue(roomInfoAtom);
   const {
@@ -95,9 +96,7 @@ const RoomInfoPanel = ({ settingMode, changeRoom }: Props) => {
       <TimeTable themeId={themeId} />
     </Layout>
   );
-};
-
-export default RoomInfoPanel;
+});
 
 const Layout = styled.div([
   css`
@@ -183,3 +182,5 @@ const RoomInfoContent = styled.div([
     width: 16.4rem;
   `,
 ]);
+
+export default RoomInfoPanel;

--- a/frontend/src/pages/ChatRoom/components/UserListPanel/UserListPanel.tsx
+++ b/frontend/src/pages/ChatRoom/components/UserListPanel/UserListPanel.tsx
@@ -6,6 +6,7 @@ import { useRecoilValue } from 'recoil';
 import { userListInfoAtom } from '@store/chatRoom';
 import { UserInfoObject } from 'types/chat';
 import useLeaveRoomMutation from '@hooks/mutation/useLeaveRoomMutation';
+import { memo } from 'react';
 
 interface Props {
   roomId: string;
@@ -13,7 +14,7 @@ interface Props {
   kickUser: (userId: string) => void;
 }
 
-const UserListPanel = ({ roomId, settingMode, kickUser }: Props) => {
+const UserListPanel = memo(function UserListPanel({ roomId, settingMode, kickUser }: Props) {
   const userListInfo = useRecoilValue(userListInfoAtom) as UserInfoObject;
   const navigate = useNavigate();
   const { mutate } = useLeaveRoomMutation(Number(roomId));
@@ -74,7 +75,7 @@ const UserListPanel = ({ roomId, settingMode, kickUser }: Props) => {
       </Button>
     </Layout>
   );
-};
+});
 
 export default UserListPanel;
 


### PR DESCRIPTION
## 🤷‍♂️ Description
useSocket 훅을 상위에서 선언한 후 하위 props로 넘겨주는 구조인데. 채팅을 보낼때 마다 sendChat, getPastChat 등이 재 참조 되어서 하위 컴포넌트가 리렌더링되는 문제가 있었어요.

따라서 해당 함수들에 useCallback을 적용하고 하위 컴포넌트에는 memo 함수를 사용해 불필요한 렌더링을 막았어요.





<!-- 구현 한 기능에 대해 작성해 주세요. -->

## 📝 Primary Commits

<!-- 세부 구현 사항을 리스트로 작성해주세요. -->

- [X] useSocket의 함수에 useCallback 적용
- [X] 하위 컴포넌트에 memo 함수 사용

## 📷 Screenshots

- 이전

![이전](https://github.com/boostcampwm2023/web03-LockFestival/assets/100738049/19c09fd6-83f3-4241-8cdc-4dda739a12e8)


- 이후

![이후](https://github.com/boostcampwm2023/web03-LockFestival/assets/100738049/fa8f4524-30e7-4b95-94fd-f24a9eb2bac7)


- 이전

![최적화 이전](https://github.com/boostcampwm2023/web03-LockFestival/assets/100738049/35e5b2ce-ffe3-4c9e-b6c5-36cec279b71f)

- 이후

![최적화 이후](https://github.com/boostcampwm2023/web03-LockFestival/assets/100738049/d0f59b9c-01cc-4fb7-8ca8-08a637b3aba2)


<!--스크린샷으로 보여줄 수 있는 이미지가 있다면 첨부해주세요!-->

<!--BE의 경우 API 테스트 결과를 첨부해주세요-->

<!--마지막으로 이슈 생성 시 우측의 옵션들을 체크했는지 확인해주세요!-->

<!-- 이슈번호를 작성해주세요. -->
<!-- 여러 이슈를 입력시 comma(,) 단위로 구분해주세요 -->
<!-- ex) close #10, resolves #123 -->


<!-- ex) -->
<!-- closes #1 --> 

