### PR TITLE
Fix/FE/#383: 스크롤 & 처음 렌더링시 팝업메세지 버그 수정

### DIFF
--- a/frontend/src/pages/ChatRoom/components/ChatPanel/ChatPanel.tsx
+++ b/frontend/src/pages/ChatRoom/components/ChatPanel/ChatPanel.tsx
@@ -1,6 +1,6 @@
 import tw, { styled, css } from 'twin.macro';
 import Button from '@components/Button/Button';
-import { FaCropSimple, FaRightFromBracket } from 'react-icons/fa6';
+import { FaRightFromBracket } from 'react-icons/fa6';
 import useInput from '@hooks/useInput';
 import { useNavigate } from 'react-router-dom';
 import { useRecoilValue } from 'recoil';

--- a/frontend/src/pages/ChatRoom/components/ChatPanel/ChatPanel.tsx
+++ b/frontend/src/pages/ChatRoom/components/ChatPanel/ChatPanel.tsx
@@ -122,7 +122,7 @@ const ChatPanel = ({ roomId, sendChat, getPastChat }: ChatPanelProps) => {
       return;
     }
 
-    if (pastChatSize === PAGING_SIZE) {
+    if (pastChatSize >= PAGING_SIZE) {
       virtualizer.scrollToIndex(PAGING_SIZE, { align: 'start' });
     }
   }, [chatLogData]);

--- a/frontend/src/pages/ChatRoom/components/RoomInfoPanel/TimeTable/TimeTable.tsx
+++ b/frontend/src/pages/ChatRoom/components/RoomInfoPanel/TimeTable/TimeTable.tsx
@@ -28,15 +28,16 @@ const TimeTable = ({ themeId }: { themeId: number }) => {
           maxDetail="month"
         />
       </CalendarWrapper>
-      <BottomWrapper>
-        {isLoading ? (
-          <Loading>
-            <FaArrowsRotate size="30" />
-          </Loading>
-        ) : (
-          <>
-            {data && data.length > 0 ? (
-              data?.map((timeData) =>
+
+      {isLoading ? (
+        <Loading>
+          <FaArrowsRotate size="30" />
+        </Loading>
+      ) : (
+        <>
+          {data && data.length > 0 ? (
+            <TimeTableWrapper>
+              {data?.map((timeData) =>
                 timeData.possible ? (
                   <Label
                     key={timeData.time}
@@ -56,16 +57,16 @@ const TimeTable = ({ themeId }: { themeId: number }) => {
                     <LabelText>{timeData.time}</LabelText>
                   </Label>
                 )
-              )
-            ) : (
-              <InfoText>
-                {getStringByDate(date as Date)}의<br />
-                시간표를 불러올 수 없습니다.
-              </InfoText>
-            )}
-          </>
-        )}
-      </BottomWrapper>
+              )}
+            </TimeTableWrapper>
+          ) : (
+            <InfoText>
+              {getStringByDate(date as Date)}의<br />
+              시간표를 불러올 수 없습니다.
+            </InfoText>
+          )}
+        </>
+      )}
     </Container>
   );
 };
@@ -91,7 +92,7 @@ const TopWrapper = styled.div([
 
 const Text = styled.div([tw`font-pretendard text-l`]);
 
-const BottomWrapper = styled.div([tw`grid grid-cols-4 gap-4`]);
+const TimeTableWrapper = styled.div([tw`grid grid-cols-4 gap-4`]);
 const LabelText = styled.div(tw`mx-auto`);
 
 const CalendarWrapper = styled.div([tw`font-pretendard text-s w-full`]);
@@ -106,7 +107,7 @@ const rotate = keyframes`
 `;
 
 const Loading = styled.div([
-  tw`w-[30rem] h-[12.8rem] text-white`,
+  tw`w-full h-[12.8rem] text-white`,
   css`
     display: flex;
     justify-content: center;
@@ -116,7 +117,7 @@ const Loading = styled.div([
 ]);
 
 const InfoText = styled.div([
-  tw`w-[30rem] h-[12.8rem] font-pretendard text-white text-m`,
+  tw`w-full h-[12.8rem] font-pretendard text-white text-m`,
   css`
     display: flex;
     justify-content: center;


### PR DESCRIPTION
## 🤷‍♂️ Description
- 처음 렌더링시 이전 채팅을 불러왔을때 마지막 채팅이 팝업 메세지로 뜨는 버그를 수정했어요.
- 가상 스크롤을 적용했을때 이전에 보던 채팅이 유지되지 않는 버그를 수정했어요.
    - 동적으로 scrollHeight이 변하기 때문에 react-virtual의 scrollToIndex메소드를 사용해서 처리했어요.

<!-- 구현 한 기능에 대해 작성해 주세요. -->

## 📝 Primary Commits

<!-- 세부 구현 사항을 리스트로 작성해주세요. -->

- [X] 팝업 메세지 버그 수정
- [x] 스크롤 버그 수정

## 📷 Screenshots

<!--스크린샷으로 보여줄 수 있는 이미지가 있다면 첨부해주세요!-->

<!--BE의 경우 API 테스트 결과를 첨부해주세요-->

<!--마지막으로 이슈 생성 시 우측의 옵션들을 체크했는지 확인해주세요!-->

<!-- 이슈번호를 작성해주세요. -->
<!-- 여러 이슈를 입력시 comma(,) 단위로 구분해주세요 -->
<!-- ex) close #10, resolves #123 -->


<!-- ex) -->
<!-- closes #1 --> 

close #383 