### PR TITLE
Feature/FE/#400: 나가기 버그 수정및 sweet-alert2 적용

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -30,7 +30,8 @@
     "react-toastify": "^9.1.3",
     "recoil": "^0.7.7",
     "slick-carousel": "^1.8.1",
-    "socket.io-client": "^4.7.2"
+    "socket.io-client": "^4.7.2",
+    "sweetalert2": "^11.10.1"
   },
   "devDependencies": {
     "@babel/preset-env": "^7.23.3",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,5 +1,6 @@
 import CustomRouter from '@components/Router/CustomRouter';
 import './styles/Calendar.css';
+import './styles/SweetAlert2.css';
 
 function App() {
   return <CustomRouter />;

--- a/frontend/src/hooks/mutation/useLeaveRoomMutation.tsx
+++ b/frontend/src/hooks/mutation/useLeaveRoomMutation.tsx
@@ -2,9 +2,11 @@ import MUTATION_MANAGEMENT from '@constants/mutationManagement';
 import QUERY_MANAGEMENT from '@constants/queryManagement';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { isAxiosError } from 'axios';
+import { useNavigate } from 'react-router-dom';
 import { toast } from 'react-toastify';
 
 const useLeaveRoomMutation = (groupId: number) => {
+  const navigate = useNavigate();
   const queryClient = useQueryClient();
 
   const { data, mutate, status } = useMutation({
@@ -13,6 +15,7 @@ const useLeaveRoomMutation = (groupId: number) => {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: [QUERY_MANAGEMENT['roomList'].key] });
       toast.success('방을 나왔습니다!');
+      navigate('/room-list');
     },
     onError: (error) => {
       if (isAxiosError(error)) {

--- a/frontend/src/pages/ChatRoom/components/UserListPanel/UserListPanel.tsx
+++ b/frontend/src/pages/ChatRoom/components/UserListPanel/UserListPanel.tsx
@@ -7,6 +7,7 @@ import { userListInfoAtom } from '@store/chatRoom';
 import { UserInfoObject } from 'types/chat';
 import useLeaveRoomMutation from '@hooks/mutation/useLeaveRoomMutation';
 import { memo } from 'react';
+import Swal from 'sweetalert2';
 
 interface Props {
   roomId: string;
@@ -16,15 +17,19 @@ interface Props {
 
 const UserListPanel = memo(function UserListPanel({ roomId, settingMode, kickUser }: Props) {
   const userListInfo = useRecoilValue(userListInfoAtom) as UserInfoObject;
-  const navigate = useNavigate();
   const { mutate } = useLeaveRoomMutation(Number(roomId));
 
-  const handlerLeaveRoom = () => {
-    if (!window.confirm('정말로 방을 나가시겠습니까?\n나간 이후 복구할 수 없습니다.')) {
-      return;
+  const handlerLeaveRoom = async () => {
+    const result = await Swal.fire({
+      icon: 'info',
+      title: '정말로 방을 나가시겠습니까?',
+      text: '나간 이후 복구할 수 없습니다.',
+      showCloseButton: true,
+      showCancelButton: true,
+    });
+    if (result.isConfirmed) {
+      mutate(Number(roomId));
     }
-    mutate(Number(roomId));
-    navigate('/room-list');
   };
 
   const handleUserKick = (e: React.MouseEvent) => {

--- a/frontend/src/pages/ChatRoom/components/UserListPanel/UserListPanel.tsx
+++ b/frontend/src/pages/ChatRoom/components/UserListPanel/UserListPanel.tsx
@@ -1,7 +1,6 @@
 import tw, { styled, css } from 'twin.macro';
 import UserItem from './UserItem/UserItem';
 import Button from '@components/Button/Button';
-import { useNavigate } from 'react-router-dom';
 import { useRecoilValue } from 'recoil';
 import { userListInfoAtom } from '@store/chatRoom';
 import { UserInfoObject } from 'types/chat';

--- a/frontend/src/pages/RoomList/components/Room/RoomFooter.tsx
+++ b/frontend/src/pages/RoomList/components/Room/RoomFooter.tsx
@@ -1,6 +1,7 @@
 import Button from '@components/Button/Button';
 import useLeaveRoomMutation from '@hooks/mutation/useLeaveRoomMutation';
 import { useNavigate } from 'react-router-dom';
+import Swal from 'sweetalert2';
 import tw, { styled, css } from 'twin.macro';
 import { GroupProps } from 'types/group';
 
@@ -9,11 +10,17 @@ const RoomFooter = ({ groupId }: Pick<GroupProps, 'groupId'>) => {
 
   const { mutate } = useLeaveRoomMutation(groupId);
 
-  const handleLeaveRoom = () => {
-    if (!window.confirm('정말로 방을 나가시겠습니까?\n나간 이후 복구할 수 없습니다.')) {
-      return;
+  const handleLeaveRoom = async () => {
+    const result = await Swal.fire({
+      icon: 'info',
+      title: '정말로 방을 나가시겠습니까?',
+      text: '나간 이후 복구할 수 없습니다.',
+      showCloseButton: true,
+      showCancelButton: true,
+    });
+    if (result.isConfirmed) {
+      mutate(groupId);
     }
-    mutate(groupId);
   };
 
   return (

--- a/frontend/src/styles/SweetAlert2.css
+++ b/frontend/src/styles/SweetAlert2.css
@@ -1,0 +1,15 @@
+.swal2-popup {
+  font-family: MaplestoryOTFLight;
+}
+
+div.swal2-html-container {
+  font-size: 1.6rem;
+}
+
+.swal2-actions > button {
+  font-family: MaplestoryOTFLight;
+}
+
+.swal2-icon {
+  margin: 10px auto;
+}

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -6476,6 +6476,11 @@ svg-parser@^2.0.4:
   resolved "https://registry.yarnpkg.com/svg-parser/-/svg-parser-2.0.4.tgz#fdc2e29e13951736140b76cb122c8ee6630eb6b5"
   integrity sha512-e4hG1hRwoOdRb37cIMSgzNsxyzKfayW6VOflrwvR+/bzrkyxY/31WkbgnQpgtrNp1SdpJvpUAGTa/ZoiPNDuRQ==
 
+sweetalert2@^11.10.1:
+  version "11.10.1"
+  resolved "https://registry.yarnpkg.com/sweetalert2/-/sweetalert2-11.10.1.tgz#783e18c90bcde72039e26e4b943573e83cf55afe"
+  integrity sha512-qu145oBuFfjYr5yZW9OSdG6YmRxDf8CnkgT/sXMfrXGe+asFy2imC2vlaLQ/L/naZ/JZna1MPAY56G4qYM0VUQ==
+
 symbol-tree@^3.2.4:
   version "3.2.4"
   resolved "https://registry.yarnpkg.com/symbol-tree/-/symbol-tree-3.2.4.tgz#430637d248ba77e078883951fb9aa0eed7c63fa2"


### PR DESCRIPTION
## 🤷‍♂️ Description
기본 alert 창이 밋밋해서 sweet-alert2를 설치해서 적용했어요. 근데 저희의 GlobalStyle과 겹쳐서 제대로 표시되지않는 문제가 있어서 적절히 css를 작성했어요.

또, 채팅방페이지에서 방 나가기를 하면 나가지 못하는 상황(방장이거나, 서버에러)에도 room-list로 이동하는 문제가 있었어요.

따라서 navigate로직을 onSuccess로 이동시켰어요.
<!-- 구현 한 기능에 대해 작성해 주세요. -->

## 📝 Primary Commits

<!-- 세부 구현 사항을 리스트로 작성해주세요. -->

- [X] sweet-alert 설치 및 적용
- [X] 에러처리

## 📷 Screenshots
- 이전
<img width="360" alt="이전" src="https://github.com/boostcampwm2023/web03-LockFestival/assets/100738049/5e7fc7da-688c-40f3-88b4-e11a79c43b05">


- 이후
<img width="284" alt="이후" src="https://github.com/boostcampwm2023/web03-LockFestival/assets/100738049/39bf2bc0-f19f-4c6d-8cf1-3f394492370b">

<!--스크린샷으로 보여줄 수 있는 이미지가 있다면 첨부해주세요!-->

<!--BE의 경우 API 테스트 결과를 첨부해주세요-->

<!--마지막으로 이슈 생성 시 우측의 옵션들을 체크했는지 확인해주세요!-->

<!-- 이슈번호를 작성해주세요. -->
<!-- 여러 이슈를 입력시 comma(,) 단위로 구분해주세요 -->
<!-- ex) close #10, resolves #123 -->


<!-- ex) -->
<!-- closes #1 --> 
closes #400 

