### PR TITLE
Fix/BE/#397: 캐시 적용 위치를 크롤러 API에만 적용하도록 수정

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -3,8 +3,6 @@ import { MiddlewareConsumer, Module, NestModule } from '@nestjs/common';
 import { ConfigModule, ConfigService } from '@nestjs/config';
 import { MongooseModule } from '@nestjs/mongoose';
 import { TypeOrmModule } from '@nestjs/typeorm';
-import { CacheInterceptor, CacheModule } from '@nestjs/cache-manager';
-import { APP_INTERCEPTOR } from '@nestjs/core';
 import { AppController } from '@src/app.controller';
 import { AppService } from '@src/app.service';
 import { LoggerMiddleware } from '@src/utils/logger.middleware';
@@ -19,7 +17,6 @@ import { BrandModule } from '@brand/brand.module';
 import { ChatModule } from '@chat/chat.module';
 import { GroupModule } from '@group/group.module';
 import { EventsModule } from '@src/gateway/events.module';
-import { SEC_TO_MILLI } from '@constants/time.converter';
 
 @Module({
   imports: [
@@ -53,19 +50,9 @@ import { SEC_TO_MILLI } from '@constants/time.converter';
       },
       inject: [ConfigService],
     }),
-    CacheModule.register({
-      ttl: 5 * SEC_TO_MILLI,
-      isGlobal: true,
-    }),
   ],
   controllers: [AppController],
-  providers: [
-    AppService,
-    {
-      provide: APP_INTERCEPTOR,
-      useClass: CacheInterceptor,
-    },
-  ],
+  providers: [AppService],
 })
 export class AppModule implements NestModule {
   configure(consumer: MiddlewareConsumer) {

--- a/backend/src/modules/themeModules/theme/theme.controller.ts
+++ b/backend/src/modules/themeModules/theme/theme.controller.ts
@@ -24,8 +24,8 @@ import { CacheInterceptor, CacheTTL } from '@nestjs/cache-manager';
 import { TimeTableDto } from '@crawlerUtils/dtos/timetable.response.dto';
 import { MIN_TO_MILLI } from '@constants/time.converter';
 import {
-  GetGenreThemesSwagger,
   GetGenresSwagger,
+  GetGenreThemesSwagger,
   GetLocationThemesSwagger,
   GetRandomGenresThemesSwagger,
   GetSimpleThemesSwagger,

--- a/backend/src/modules/themeModules/theme/theme.module.ts
+++ b/backend/src/modules/themeModules/theme/theme.module.ts
@@ -18,9 +18,10 @@ import { NextEditionCrawlerMetadata } from '@crawlerUtils/crawler/nextedition.cr
 import { SecretGardenEscapeCrawlerMetadata } from '@crawlerUtils/crawler/secretgardenescape.crawler';
 import { SeoulEscapeRoomCrawlerMetadata } from '@crawlerUtils/crawler/seoulescaperoom.crawler';
 import { XDungeonCrawlerMetadata } from '@crawlerUtils/crawler/xdungeon.crawler';
+import { CacheModule } from '@nestjs/cache-manager';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Theme]), BrandModule],
+  imports: [TypeOrmModule.forFeature([Theme]), BrandModule, CacheModule.register()],
   controllers: [ThemeController],
   providers: [
     ThemeService,


### PR DESCRIPTION
## 🤷‍♂️ Description
isGlobal로 설정했더니 모든 API에 캐시가 적용되었어요.
이를 필요한 API에만 사용할 수 있도록 수정해요.
(추후 적용되어도 문제없는 API에는 캐싱을 적용해요)

<!-- 구현 한 기능에 대해 작성해 주세요. -->

## 📝 Primary Commits

<!-- 세부 구현 사항을 리스트로 작성해주세요. -->

- [X] CacheModule을 AppModule -> ThemeModule에서 등록하도록 수정해요.

## 📷 Screenshots

<!--스크린샷으로 보여줄 수 있는 이미지가 있다면 첨부해주세요!-->

<!--BE의 경우 API 테스트 결과를 첨부해주세요-->

<!--마지막으로 이슈 생성 시 우측의 옵션들을 체크했는지 확인해주세요!-->

<!-- 이슈번호를 작성해주세요. -->
<!-- 여러 이슈를 입력시 comma(,) 단위로 구분해주세요 -->
<!-- ex) close #10, resolves #123 -->


<!-- ex) -->
<!-- closes #1 --> 
related to #397
