### PR TITLE
Fix/FE/#411: 간헐적으로 프로필을 불러오지 못하는 문제 수정

### DIFF
--- a/frontend/src/apis/fetchFirstUserProfile.ts
+++ b/frontend/src/apis/fetchFirstUserProfile.ts
@@ -1,0 +1,16 @@
+import { SERVER_URL } from '@config/server';
+import axios from 'axios';
+
+const fetchFirstUserProfile = async (token: string) => {
+  const res = (
+    await axios({
+      method: 'get',
+      url: SERVER_URL + '/users/profile',
+      headers: { Authorization: `Bearer ${token}` },
+    })
+  ).data;
+
+  return res;
+};
+
+export default fetchFirstUserProfile;

--- a/frontend/src/apis/fetchFirstUserProfile.ts
+++ b/frontend/src/apis/fetchFirstUserProfile.ts
@@ -1,9 +1,10 @@
 import { SERVER_URL } from '@config/server';
 import axios from 'axios';
+import { Profile } from 'types/profile';
 
 const fetchFirstUserProfile = async (token: string) => {
   const res = (
-    await axios({
+    await axios<Profile>({
       method: 'get',
       url: SERVER_URL + '/users/profile',
       headers: { Authorization: `Bearer ${token}` },

--- a/frontend/src/pages/Auth/Auth.tsx
+++ b/frontend/src/pages/Auth/Auth.tsx
@@ -3,8 +3,8 @@ import { useNavigate, useSearchParams } from 'react-router-dom';
 import fetchLogin from '@apis/fetchLogin';
 import { useSetRecoilState } from 'recoil';
 import userAtom from 'store/userAtom';
-import fetchUserProfile from '@apis/fetchUserProfile';
 import { toast } from 'react-toastify';
+import fetchFirstUserProfile from '@apis/fetchFirstUserProfile';
 
 const Auth = () => {
   const navigate = useNavigate();
@@ -19,10 +19,8 @@ const Auth = () => {
 
       localStorage.setItem('accessToken', token);
 
-      await new Promise((resolve) => setTimeout(resolve, 100));
-
       // 프로필 api
-      const res = await fetchUserProfile();
+      const res = await fetchFirstUserProfile(token);
       setProfile(res);
 
       navigate(localStorage.getItem('lastVisited') || '/', {


### PR DESCRIPTION
## 🤷‍♂️ Description
로그인하면 간헐적으로 프로필을 불러오지 못하는 문제가 있었어요.
해당 원인은 로그인을 한 후, token을 받고 해당 토큰을 setItem한 후에 바로 getItem을 하는데 getItem에서 토큰을 가져올 수 없는 문제가 있었어요.

이를 해결하기 위해 setTimeout을 썼는데 여전히 간헐적으로 로그인이 불가능한 문제가 있어서 최초 로그인시에 프로필을 불러올 때, getItem을 하지 않고 파라미터로 토큰을 넘겨주도록 변경했어요

<!-- 구현 한 기능에 대해 작성해 주세요. -->

## 📝 Primary Commits

<!-- 세부 구현 사항을 리스트로 작성해주세요. -->

- [X] 파라미터로 토큰을 넘겨서 프로필을 불러오도록 수정

## 📷 Screenshots

<!--스크린샷으로 보여줄 수 있는 이미지가 있다면 첨부해주세요!-->

<!--BE의 경우 API 테스트 결과를 첨부해주세요-->

<!--마지막으로 이슈 생성 시 우측의 옵션들을 체크했는지 확인해주세요!-->

<!-- 이슈번호를 작성해주세요. -->
<!-- 여러 이슈를 입력시 comma(,) 단위로 구분해주세요 -->
<!-- ex) close #10, resolves #123 -->


<!-- ex) -->
<!-- closes #1 -->
closes #411  

