### PR TITLE
Fix/FE/#405: timeout 설정 및 사이트 바로가기

### DIFF
--- a/frontend/src/apis/fetchThemeTimeTable.ts
+++ b/frontend/src/apis/fetchThemeTimeTable.ts
@@ -2,8 +2,13 @@ import userInstance from '@config/userInstance';
 import { Value } from 'react-calendar/dist/cjs/shared/types';
 
 const fetchThemeTimeTable = async (themeId: number, date: Value) => {
-  return (await userInstance({ method: 'get', url: `/themes/${themeId}/timetable?date=${date}` }))
-    .data;
+  return (
+    await userInstance({
+      method: 'get',
+      url: `/themes/${themeId}/timetable?date=${date}`,
+      timeout: 5000,
+    })
+  ).data;
 };
 
 export default fetchThemeTimeTable;

--- a/frontend/src/hooks/useTimeTableQuery.tsx
+++ b/frontend/src/hooks/useTimeTableQuery.tsx
@@ -7,7 +7,6 @@ const useTimeTableQuery = (themeId: number, date: Value) => {
   const { data, isSuccess, isLoading, isError } = useQuery<TimeTable[]>({
     queryKey: [QUERY_MANAGEMENT['themeTimeTable'].key, themeId, date],
     queryFn: () => QUERY_MANAGEMENT['themeTimeTable'].fn(themeId, date),
-    retryDelay: 5000,
   });
 
   return { data, isSuccess, isLoading, isError };

--- a/frontend/src/pages/ChatRoom/components/RoomInfoPanel/RoomInfoPanel.tsx
+++ b/frontend/src/pages/ChatRoom/components/RoomInfoPanel/RoomInfoPanel.tsx
@@ -34,6 +34,7 @@ const RoomInfoPanel = memo(function RoomInfoPanel({ settingMode, changeRoom }: P
     recruitmentCompleted,
     appointmentCompleted,
     themeId,
+    website,
   } = roomInfo as RoomInfo;
 
   const handleSettingButton = () => {
@@ -93,7 +94,7 @@ const RoomInfoPanel = memo(function RoomInfoPanel({ settingMode, changeRoom }: P
           </RoomInfoContent>
         </RoomInfoWrapper>
       </RoomInfoTopContainer>
-      <TimeTable themeId={themeId} />
+      <TimeTable themeId={themeId} website={website} />
     </Layout>
   );
 });

--- a/frontend/src/pages/ChatRoom/components/RoomInfoPanel/TimeTable/TimeTable.tsx
+++ b/frontend/src/pages/ChatRoom/components/RoomInfoPanel/TimeTable/TimeTable.tsx
@@ -8,7 +8,12 @@ import { FaArrowsRotate } from 'react-icons/fa6';
 import { keyframes } from '@emotion/react';
 import { getStringByDate } from '@utils/dateUtil';
 
-const TimeTable = ({ themeId }: { themeId: number }) => {
+interface Props {
+  themeId: number;
+  website: string;
+}
+
+const TimeTable = ({ themeId, website }: Props) => {
   const today = new Date();
   const [date, setDate] = useState<Value>(today);
   const { data, isLoading } = useTimeTableQuery(themeId, date);
@@ -65,6 +70,9 @@ const TimeTable = ({ themeId }: { themeId: number }) => {
               시간표를 불러올 수 없습니다.
             </InfoText>
           )}
+          <WebsiteLink href={website} target="_blank">
+            예약 사이트 바로가기
+          </WebsiteLink>
         </>
       )}
     </Container>
@@ -124,5 +132,13 @@ const InfoText = styled.div([
     align-items: center;
     text-align: center;
     line-height: 2.5rem;
+  `,
+]);
+
+const WebsiteLink = styled.a([
+  tw`font-pretendard text-white text-l border border-white border-solid py-3 px-4 rounded-[1rem]`,
+  css`
+    text-decoration: none;
+    cursor: pointer;
   `,
 ]);

--- a/frontend/src/pages/ChatRoom/mock/mockRoomInfoData.ts
+++ b/frontend/src/pages/ChatRoom/mock/mockRoomInfoData.ts
@@ -13,4 +13,5 @@ export const mockRoomInfo: RoomInfo = {
   currentMembers: 5,
   recruitmentCompleted: false,
   appointmentCompleted: true,
+  website: 'https://www.naver.com',
 };

--- a/frontend/src/types/chat.ts
+++ b/frontend/src/types/chat.ts
@@ -41,6 +41,7 @@ export interface RoomInfo {
   currentMembers: number;
   recruitmentCompleted: boolean;
   appointmentCompleted: boolean;
+  website: string;
 }
 
 export type ChangeRoomData = {

--- a/frontend/src/utils/pickRandomNumber.ts
+++ b/frontend/src/utils/pickRandomNumber.ts
@@ -7,7 +7,7 @@ const START_INDEX = 0;
  */
 const pickRandomNumber = (n: number, k: number): Array<number> => {
   if (k > n) {
-    throw new Error('asd');
+    throw new Error('k는 n보다 클 수 없습니다.');
   }
 
   const numbersArray = Array.from({ length: n }, (_, index) => index + 1).sort(


### PR DESCRIPTION
## 🤷‍♂️ Description
실시간 시간표를 크롤링을 통해 가져오고있는데 특정 웹사이트가 느렸어요.
근데 axios의 기본 타임아웃이 1000ms라서 항상 불러오는데 실패했어요.
따라서 해당 api에 대해서만 타임아웃을 5000ms로 늘렸어요.

또, 예약 사이트 바로가기 버튼을 추가해서 바로 사이트로 이동할 수 있게했어요!

<!-- 구현 한 기능에 대해 작성해 주세요. -->

## 📝 Primary Commits

<!-- 세부 구현 사항을 리스트로 작성해주세요. -->

- [X] timeout 설정
- [X] 예약 사이트 바로가기 추가

## 📷 Screenshots

![녹화_2023_12_12_17_20_48_146](https://github.com/boostcampwm2023/web03-LockFestival/assets/100738049/fe933d5e-90ca-46b1-9f78-57b4d7dc92d1)

<!--스크린샷으로 보여줄 수 있는 이미지가 있다면 첨부해주세요!-->

<!--BE의 경우 API 테스트 결과를 첨부해주세요-->

<!--마지막으로 이슈 생성 시 우측의 옵션들을 체크했는지 확인해주세요!-->

<!-- 이슈번호를 작성해주세요. -->
<!-- 여러 이슈를 입력시 comma(,) 단위로 구분해주세요 -->
<!-- ex) close #10, resolves #123 -->


<!-- ex) -->
<!-- closes #1 --> 

closes #405 