### PR TITLE
Refactor/BE/#419: ThemeController에 캐싱 적용 & 크롤러 캐싱 성능 최적화

### DIFF
--- a/backend/src/constants/ttl.ts
+++ b/backend/src/constants/ttl.ts
@@ -1,0 +1,5 @@
+import { MIN_TO_MILLI } from '@constants/time.converter';
+
+export const TIMETABLE_TTL: number = MIN_TO_MILLI * 5;
+export const DETAILS_TTL: number = MIN_TO_MILLI;
+export const LOCATION_TTL: number = MIN_TO_MILLI;

--- a/backend/src/modules/themeModules/crawlerUtils/crawler.factory.ts
+++ b/backend/src/modules/themeModules/crawlerUtils/crawler.factory.ts
@@ -2,12 +2,16 @@ import { Inject, Injectable } from '@nestjs/common';
 import { AbstractCrawler } from '@crawlerUtils/abstractCrawler';
 import { CRAWLERS } from '@crawlerUtils/crawler.tokens';
 import { CrawlerMetadata } from '@crawlerUtils/crawler.metadata.interface';
+import { CACHE_MANAGER } from '@nestjs/cache-manager';
 
 @Injectable()
 export class CrawlerFactory {
   private readonly crawlerMap: Map<string, AbstractCrawler> = new Map();
 
-  constructor(@Inject(CRAWLERS) private readonly crawlerMetadataList: CrawlerMetadata[]) {
+  constructor(
+    @Inject(CRAWLERS) private readonly crawlerMetadataList: CrawlerMetadata[],
+    @Inject(CACHE_MANAGER) private cacheManager
+  ) {
     this.registerCrawlers();
   }
 
@@ -23,7 +27,7 @@ export class CrawlerFactory {
 
   private registerCrawlers() {
     this.crawlerMetadataList.forEach(({ brandName, crawlerClass }: CrawlerMetadata) => {
-      this.crawlerMap.set(brandName, new crawlerClass());
+      this.crawlerMap.set(brandName, new crawlerClass(this.cacheManager));
     });
   }
 }

--- a/backend/src/modules/themeModules/crawlerUtils/crawler/nextedition.crawler.ts
+++ b/backend/src/modules/themeModules/crawlerUtils/crawler/nextedition.crawler.ts
@@ -1,5 +1,6 @@
 import { AbstractCrawler } from '@crawlerUtils/abstractCrawler';
 import { TimeTableDto } from '@crawlerUtils/dtos/timetable.response.dto';
+import { TIMETABLE_TTL } from '@constants/ttl';
 
 export class NextEditionCrawler extends AbstractCrawler {
   BASE_URL = 'https://www.nextedition.co.kr';
@@ -28,6 +29,13 @@ export class NextEditionCrawler extends AbstractCrawler {
   }): Promise<TimeTableDto[]> {
     const shopId = this.zizumMap[shop];
     const timeTableMap = await this.getInfoByData({ shop: shopId, date });
+
+    await Promise.all(
+      Object.entries(timeTableMap).map(([themeName, timetable]) => {
+        const key = JSON.stringify({ shop, theme: themeName, date });
+        this.cacheManager.set(key, timetable, TIMETABLE_TTL);
+      })
+    );
 
     return timeTableMap[theme];
   }

--- a/backend/src/modules/themeModules/theme/theme.controller.ts
+++ b/backend/src/modules/themeModules/theme/theme.controller.ts
@@ -36,6 +36,8 @@ import {
 
 const DEFAULT_THEME_COUNT = 10;
 const TIMETABLE_TTL = MIN_TO_MILLI * 5;
+const DETAILS_TTL = MIN_TO_MILLI;
+const LOCATION_TTL = MIN_TO_MILLI;
 
 @ApiTags('themes')
 @UseInterceptors(CacheInterceptor)
@@ -48,6 +50,7 @@ export class ThemeController {
 
   @Get(':themeId/details')
   @GetThemeDetailsSwagger()
+  @CacheTTL(DETAILS_TTL)
   async getThemeDetails(
     @Param('themeId', ParseIntPipe) themeId: number
   ): Promise<ThemeBranchThemesDetailsResponseDto> {
@@ -65,6 +68,7 @@ export class ThemeController {
 
   @Get('/location')
   @GetLocationThemesSwagger()
+  @CacheTTL(LOCATION_TTL)
   async getLocationThemes(
     @Query() themeLocationDto: ThemeLocationDto
   ): Promise<ThemeLocationResponseDto> {

--- a/backend/src/modules/themeModules/theme/theme.controller.ts
+++ b/backend/src/modules/themeModules/theme/theme.controller.ts
@@ -38,6 +38,7 @@ const DEFAULT_THEME_COUNT = 10;
 const TIMETABLE_TTL = MIN_TO_MILLI * 5;
 
 @ApiTags('themes')
+@UseInterceptors(CacheInterceptor)
 @Controller('themes')
 export class ThemeController {
   constructor(
@@ -101,7 +102,6 @@ export class ThemeController {
 
   @Get('/:themeId/timetable')
   @GetTimeTableSwagger()
-  @UseInterceptors(CacheInterceptor)
   @CacheTTL(TIMETABLE_TTL)
   async getTimeTable(
     @Param('themeId', ParseIntPipe) themeId: number,

--- a/backend/src/modules/themeModules/theme/theme.controller.ts
+++ b/backend/src/modules/themeModules/theme/theme.controller.ts
@@ -33,11 +33,9 @@ import {
   GetThemesSwagger,
   GetTimeTableSwagger,
 } from '@utils/swagger/theme.swagger.decorator';
+import { DETAILS_TTL, LOCATION_TTL } from '@constants/ttl';
 
 const DEFAULT_THEME_COUNT = 10;
-const TIMETABLE_TTL = MIN_TO_MILLI * 5;
-const DETAILS_TTL = MIN_TO_MILLI;
-const LOCATION_TTL = MIN_TO_MILLI;
 
 @ApiTags('themes')
 @UseInterceptors(CacheInterceptor)
@@ -106,7 +104,6 @@ export class ThemeController {
 
   @Get('/:themeId/timetable')
   @GetTimeTableSwagger()
-  @CacheTTL(TIMETABLE_TTL)
   async getTimeTable(
     @Param('themeId', ParseIntPipe) themeId: number,
     @Query() { date }: DateRequestDto

--- a/backend/src/modules/themeModules/theme/theme.module.ts
+++ b/backend/src/modules/themeModules/theme/theme.module.ts
@@ -19,9 +19,18 @@ import { SecretGardenEscapeCrawlerMetadata } from '@crawlerUtils/crawler/secretg
 import { SeoulEscapeRoomCrawlerMetadata } from '@crawlerUtils/crawler/seoulescaperoom.crawler';
 import { XDungeonCrawlerMetadata } from '@crawlerUtils/crawler/xdungeon.crawler';
 import { CacheModule } from '@nestjs/cache-manager';
+import { SEC_TO_MILLI } from '@constants/time.converter';
+
+const DEFAULT_TTL = 10 * SEC_TO_MILLI;
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Theme]), BrandModule, CacheModule.register()],
+  imports: [
+    TypeOrmModule.forFeature([Theme]),
+    BrandModule,
+    CacheModule.register({
+      ttl: DEFAULT_TTL,
+    }),
+  ],
   controllers: [ThemeController],
   providers: [
     ThemeService,

--- a/backend/src/modules/themeModules/theme/theme.module.ts
+++ b/backend/src/modules/themeModules/theme/theme.module.ts
@@ -21,7 +21,7 @@ import { XDungeonCrawlerMetadata } from '@crawlerUtils/crawler/xdungeon.crawler'
 import { CacheModule } from '@nestjs/cache-manager';
 import { SEC_TO_MILLI } from '@constants/time.converter';
 
-const DEFAULT_TTL = 10 * SEC_TO_MILLI;
+const DEFAULT_TTL = 3 * SEC_TO_MILLI;
 
 @Module({
   imports: [


### PR DESCRIPTION
## 🤷‍♂️ Description
테마 관련 API들에는 캐싱을 적용해도 문제 없을 것으로 판단되서 수정해요.
크롤러에 캐싱을 최적화해서 성능을 최적화해요.

<!-- 구현 한 기능에 대해 작성해 주세요. -->

## 📝 Primary Commits

<!-- 세부 구현 사항을 리스트로 작성해주세요. -->

- [X] 테마 관련 API들에 캐싱을 적용해요.
  - 테마 관련 API들에는 캐싱된 결과를 반환해도 문제가 없어요.
  - 현재 캐싱은 요청에 대해 캐싱하고 있어요.(url이 동일하면 캐싱된 결과 반환)
  - 서버의 부하를 줄이고(DB 접근 최소화) UX면에서 불편함을 겪지 않도록 프론트엔드와 협의 끝에 3초간 캐싱처리하기로 결정했어요.
  - 테마 상세정보, 위치기반 테마 리스트 API에는 변환이 필요없을 것으로 생각되어 1분간 캐싱합니다.
- [X] 시간표 크롤링 API에 대한 캐싱 처리를 최적화 하도록 변경했어요.
  - 기존은 요청 기반으로 캐싱을 처리해요
  - 하지만 프론트엔드에서 당일의 경우 현재시간을 기준으로 요청을 보내요
  - 이로 인해서 동일한 날짜지만 서로 다른 날로 인식되어 캐싱이 적용되지 않아요
  - 이를 해소하고자 날짜가 yyyy-mm-dd 로 변환된 값을 기준으로 키를 사용해요
  - key: { date: 'yyyy-mm-dd', shop: '홍대점', theme: '나를잊어요' }

 - [X] 크롤러 중 지점 내 모든 테마를 조회하는 경우 함께 캐싱해요.
   - 현재 넥스트에디션의 경우 지점 내 모든 테마들에 대한 시간표를 생성한 후 반환해요
   - 이 정보들이 아까워 함께 캐싱하도록 처리했어요.
   - 덕분에 같은 지점에 대한 요청이 있으면 응답 속도가 빨라져요.

## 📷 Screenshots
넥스트에디션 신림점의 Tester에 대한 요청을 보낸 후 같은 지점의 LOVER에 요청을 보내면 캐싱된 데이터가 반환되는 모습을 볼 수 있음
![image](https://github.com/boostcampwm2023/web03-LockFestival/assets/44056518/f06944d7-399d-4798-addf-95892888ae1c)

<!--스크린샷으로 보여줄 수 있는 이미지가 있다면 첨부해주세요!-->

<!--BE의 경우 API 테스트 결과를 첨부해주세요-->

<!--마지막으로 이슈 생성 시 우측의 옵션들을 체크했는지 확인해주세요!-->

<!-- 이슈번호를 작성해주세요. -->
<!-- 여러 이슈를 입력시 comma(,) 단위로 구분해주세요 -->
<!-- ex) close #10, resolves #123 -->


<!-- ex) -->
<!-- closes #1 --> 
closes #419
