### PR TITLE
Fix/BE/#426: 중복 세션에 unread값이 안가는 이슈 수정

### DIFF
--- a/backend/src/gateway/events.gateway.ts
+++ b/backend/src/gateway/events.gateway.ts
@@ -77,6 +77,8 @@ export class EventsGateway implements OnGatewayInit, OnGatewayConnection, OnGate
 
     if (!this.hasAnotherSession(roomId, meUser.userId)) {
       this.server.to(roomId).emit('unread', unreadCountMap);
+    } else {
+      client.emit('unread', unreadCountMap);
     }
 
     this.socketsInRooms[roomId][client.id] = meUser.userId;


### PR DESCRIPTION
## 🤷‍♂️ Description
중복 세션의 경우 최초의 unread가 전송되지 않는 이슈가 있어요.
중복 세션의 경우 본인에게만 unreadCountMap을 전송하도록 수정했어요.

<!-- 구현 한 기능에 대해 작성해 주세요. -->

## 📝 Primary Commits

<!-- 세부 구현 사항을 리스트로 작성해주세요. -->

- [X] 중복 세션의 경우 본인에게만 unreadCountMap을 전송하도록 수정

## 📷 Screenshots

<!--스크린샷으로 보여줄 수 있는 이미지가 있다면 첨부해주세요!-->

<!--BE의 경우 API 테스트 결과를 첨부해주세요-->

<!--마지막으로 이슈 생성 시 우측의 옵션들을 체크했는지 확인해주세요!-->

<!-- 이슈번호를 작성해주세요. -->
<!-- 여러 이슈를 입력시 comma(,) 단위로 구분해주세요 -->
<!-- ex) close #10, resolves #123 -->


<!-- ex) -->
<!-- closes #1 --> 
closes #426
