### PR TITLE
Refactor/FE/#424: chatMessageUtils 함수 리팩토링 및 회원가입 모달 닉네임 입력창 디바운스 적용

### DIFF
--- a/frontend/src/components/JoinModal/JoinModalComponent/JoinModalComponent.tsx
+++ b/frontend/src/components/JoinModal/JoinModalComponent/JoinModalComponent.tsx
@@ -1,11 +1,11 @@
 import { useEffect, useState } from 'react';
 import { ModalProps } from 'types/modal';
 
-import useInput from '@hooks/useInput';
 import StepOneContent from './StepOneContent/StepOneContent';
 import StepTwoContent from './StepTwoContent/StepTwoContent';
 import useJoinMutation from '@hooks/mutation/useJoinMutation';
 import { JoinData } from 'types/profile';
+import useDebounceInput from '@hooks/useDebounceInput';
 interface JoinModalProps {
   onClose: ModalProps['onClose'];
 }
@@ -14,7 +14,7 @@ function JoinModalComponent({ onClose }: JoinModalProps) {
   const STEP1 = 0;
   const STEP2 = 1;
   const [step, setStep] = useState<number>(STEP1);
-  const [nameInput, setNameInput] = useInput('');
+  const { realInputQuery, debounceQuery, setRealInputQuery } = useDebounceInput(300);
   const [selectGenre, setSelectGenre] = useState<Set<string>>(new Set());
   const [userData, setUserData] = useState<JoinData>();
   const { mutate } = useJoinMutation(userData);
@@ -40,7 +40,7 @@ function JoinModalComponent({ onClose }: JoinModalProps) {
 
   const joinHandler = () => {
     const totalUserData = {
-      nickname: nameInput,
+      nickname: debounceQuery,
       profileImageUrl: null,
       favoriteGenres: Array.from(selectGenre),
       favoriteThemes: [],
@@ -55,7 +55,12 @@ function JoinModalComponent({ onClose }: JoinModalProps) {
   return (
     <>
       {step === STEP1 && (
-        <StepOneContent nameInput={nameInput} setNameInput={setNameInput} nextStep={nextStep} />
+        <StepOneContent
+          nameInput={realInputQuery}
+          debounceInput={debounceQuery}
+          setNameInput={setRealInputQuery}
+          nextStep={nextStep}
+        />
       )}
       {step === STEP2 && (
         <StepTwoContent

--- a/frontend/src/components/JoinModal/JoinModalComponent/StepOneContent/StepOneContent.tsx
+++ b/frontend/src/components/JoinModal/JoinModalComponent/StepOneContent/StepOneContent.tsx
@@ -8,6 +8,7 @@ import { useQuery } from '@tanstack/react-query';
 interface StepOneContentProps {
   nameInput: string;
   setNameInput: ChangeEventHandler;
+  debounceInput: string;
   nextStep: MouseEventHandler;
 }
 
@@ -22,11 +23,11 @@ const fetchCheckNickName = async (nickname: string) => {
   return response.data;
 };
 
-function StepOneContent({ nameInput, setNameInput, nextStep }: StepOneContentProps) {
-  const [isValidName, isDuplicated, checkValidation, warning] = useNameValidation(nameInput);
+function StepOneContent({ nameInput, debounceInput, setNameInput, nextStep }: StepOneContentProps) {
+  const [isValidName, isDuplicated, checkValidation, warning] = useNameValidation(debounceInput);
   const { data, isSuccess, isError, refetch } = useQuery<boolean>({
-    queryKey: ['checkNickName', nameInput],
-    queryFn: () => fetchCheckNickName(nameInput),
+    queryKey: ['checkNickName', debounceInput],
+    queryFn: () => fetchCheckNickName(debounceInput),
     staleTime: 0,
     enabled: false,
   });

--- a/frontend/src/pages/ChatRoom/components/ChatPanel/ChatPanel.tsx
+++ b/frontend/src/pages/ChatRoom/components/ChatPanel/ChatPanel.tsx
@@ -206,7 +206,7 @@ const ChatPanel = memo(function ChatPanel({ roomId, sendChat, getPastChat }: Cha
 
                   return (
                     <div key={index} ref={virtualizer.measureElement} data-index={index}>
-                      {!checkIsFirstChatToday(index, chatArrayFromChatLogData) && (
+                      {checkIsFirstChatToday(index, chatArrayFromChatLogData) && (
                         <DateDisplayWrapper>
                           <HorizontalLine />
                           <DateDisplay>{getStringByDate(new Date(time))}</DateDisplay>

--- a/frontend/src/utils/chatMessageUtil.ts
+++ b/frontend/src/utils/chatMessageUtil.ts
@@ -18,7 +18,7 @@ const checkIsFirstChatToday = (
 // 프로필 표시 여부
 const checkIsFirstChatFromUser = (
   targetIndex: number,
-  chatLogData: [string, ChatLog][]
+  chatLogData: Array<[string, ChatLog]>
 ): boolean => {
   if (targetIndex === 0) {
     return true;
@@ -27,20 +27,10 @@ const checkIsFirstChatFromUser = (
   const prevData = chatLogData[targetIndex - 1][1];
   const targetData = chatLogData[targetIndex][1];
 
-  const prevUser = prevData.userId;
   const prevTime = getTimeByDate(new Date(prevData.time));
-  const targetUser = targetData.userId;
   const targetTime = getTimeByDate(new Date(targetData.time));
 
-  if (prevTime !== targetTime) {
-    return true;
-  }
-
-  if (prevUser !== targetUser) {
-    return true;
-  }
-
-  return false;
+  return prevTime !== targetTime || prevData.userId !== targetData.userId;
 };
 
 // 시각 표시 여부

--- a/frontend/src/utils/chatMessageUtil.ts
+++ b/frontend/src/utils/chatMessageUtil.ts
@@ -36,7 +36,7 @@ const checkIsFirstChatFromUser = (
 // 시각 표시 여부
 const checkIsLastChatFromUser = (
   targetIndex: number,
-  chatLogData: [string, ChatLog][]
+  chatLogData: Array<[string, ChatLog]>
 ): boolean => {
   if (targetIndex === chatLogData.length - 1) {
     return true;
@@ -48,18 +48,7 @@ const checkIsLastChatFromUser = (
   const targetTime = getTimeByDate(new Date(targetData.time));
   const nextTime = getTimeByDate(new Date(nextData.time));
 
-  const targetUser = targetData.userId;
-  const nextUser = nextData.userId;
-
-  if (targetTime !== nextTime) {
-    return true;
-  }
-
-  if (targetUser !== nextUser) {
-    return true;
-  }
-
-  return false;
+  return targetTime !== nextTime || targetData.userId !== nextData.userId;
 };
 
 export { checkIsFirstChatToday, checkIsFirstChatFromUser, checkIsLastChatFromUser };

--- a/frontend/src/utils/chatMessageUtil.ts
+++ b/frontend/src/utils/chatMessageUtil.ts
@@ -2,13 +2,17 @@ import { ChatLog } from 'types/chat';
 import { checkDateIsSameDate, getTimeByDate } from './dateUtil';
 
 // 특정 날짜의 첫 번째 채팅인지 확인한다.
-const checkIsFirstChatToday = (targetIndex: number, chatLogData: [string, ChatLog][]): boolean => {
+const checkIsFirstChatToday = (
+  targetIndex: number,
+  chatLogData: Array<[string, ChatLog]>
+): boolean => {
   if (targetIndex === 0) {
-    return false;
+    return true;
   }
+
   const prevTime = chatLogData[targetIndex - 1][1].time;
   const targetTime = chatLogData[targetIndex][1].time;
-  return checkDateIsSameDate(new Date(prevTime), new Date(targetTime));
+  return !checkDateIsSameDate(new Date(prevTime), new Date(targetTime));
 };
 
 // 프로필 표시 여부


### PR DESCRIPTION
## 🤷‍♂️ Description
- 날짜 구분선, 프로필, 시각 중복 제거하는 로직을 리팩토링 했어요.
- 회원가입 모달창에 디바운스가 적용되어있지 않아서, 디바운스 적용했어요.

<!-- 구현 한 기능에 대해 작성해 주세요. -->

## 📝 Primary Commits

<!-- 세부 구현 사항을 리스트로 작성해주세요. -->

- [X] 채팅방 계산 로직 리팩토링
- [X] 회원가입 모달 디바운스 적용

## 📷 Screenshots

<!--스크린샷으로 보여줄 수 있는 이미지가 있다면 첨부해주세요!-->

<!--BE의 경우 API 테스트 결과를 첨부해주세요-->

<!--마지막으로 이슈 생성 시 우측의 옵션들을 체크했는지 확인해주세요!-->

<!-- 이슈번호를 작성해주세요. -->
<!-- 여러 이슈를 입력시 comma(,) 단위로 구분해주세요 -->
<!-- ex) close #10, resolves #123 -->


<!-- ex) -->
<!-- closes #1 --> 

close #424 