### PR TITLE
Feature/FE/#435: UserList 패널, RoomInfo 패널 스크롤 추가

### DIFF
--- a/frontend/src/pages/ChatRoom/components/RoomInfoPanel/RoomInfoPanel.tsx
+++ b/frontend/src/pages/ChatRoom/components/RoomInfoPanel/RoomInfoPanel.tsx
@@ -108,7 +108,21 @@ const Layout = styled.div([
     height: 100vh;
     padding: 2rem;
     gap: 1.6rem;
-    overflow: hidden;
+    overflow-x: hidden;
+    overflow-y: auto;
+
+    ::-webkit-scrollbar {
+      width: 0.5rem;
+    }
+    ::-webkit-scrollbar-thumb {
+      background-color: #f2f2f2;
+      border-radius: 0.5rem;
+    }
+    ::-webkit-scrollbar-track {
+      background-color: #222222;
+      border-radius: 0.5rem;
+      box-shadow: inset 0px 0px 5px white;
+    }
   `,
   tw`bg-gray-light rounded-[2rem] h-[calc(90vh - 6rem)]`,
 ]);

--- a/frontend/src/pages/ChatRoom/components/UserListPanel/UserListPanel.tsx
+++ b/frontend/src/pages/ChatRoom/components/UserListPanel/UserListPanel.tsx
@@ -74,9 +74,11 @@ const UserListPanel = memo(function UserListPanel({ roomId, settingMode, kickUse
           return null;
         })}
       </UserListWrapper>
-      <Button isIcon={false} onClick={handlerLeaveRoom}>
-        <>채팅방 나가기</>
-      </Button>
+      <ExitButtonWrapper>
+        <Button isIcon={false} onClick={handlerLeaveRoom}>
+          <>채팅방 나가기</>
+        </Button>
+      </ExitButtonWrapper>
     </Layout>
   );
 });
@@ -91,6 +93,21 @@ const Layout = styled.div([
     padding: 2rem;
     justify-content: space-between;
     align-items: center;
+
+    overflow-x: hidden;
+    overflow-y: auto;
+    ::-webkit-scrollbar {
+      width: 0.5rem;
+    }
+    ::-webkit-scrollbar-thumb {
+      background-color: #f2f2f2;
+      border-radius: 0.5rem;
+    }
+    ::-webkit-scrollbar-track {
+      background-color: #222222;
+      border-radius: 0.5rem;
+      box-shadow: inset 0px 0px 5px white;
+    }
   `,
   tw`bg-gray-light rounded-[2rem] h-[calc(90vh - 6rem)]`,
 ]);
@@ -124,6 +141,15 @@ const ButtonWrapper = styled.div(({ settingMode }: { settingMode: boolean }) => 
       width: 50%;
       margin-bottom: 1.2rem;
     `,
+]);
+
+const ExitButtonWrapper = styled.div([
+  tw`h-[3.2rem]`,
+  css`
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  `,
 ]);
 
 const Text = styled.div([tw`mx-auto`]);


### PR DESCRIPTION
## 🤷‍♂️ Description
UserList 패널, RoomInfo 패널 스크롤을 추가했어요.

<!-- 구현 한 기능에 대해 작성해 주세요. -->

## 📝 Primary Commits

<!-- 세부 구현 사항을 리스트로 작성해주세요. -->

- [X] UserList 패널, RoomInfo 패널 스크롤을 추가

## 📷 Screenshots

전

<img width="331" alt="Screenshot 2023-12-14 at 11 33 58 AM" src="https://github.com/boostcampwm2023/web03-LockFestival/assets/100738049/3f37a034-cd3a-4cca-a690-b11c740e3c15">

후

<img width="1051" alt="Screenshot 2023-12-14 at 11 37 20 AM" src="https://github.com/boostcampwm2023/web03-LockFestival/assets/100738049/f3725ae3-4863-4e04-91fd-282f87e5032e">




<!--스크린샷으로 보여줄 수 있는 이미지가 있다면 첨부해주세요!-->

<!--BE의 경우 API 테스트 결과를 첨부해주세요-->

<!--마지막으로 이슈 생성 시 우측의 옵션들을 체크했는지 확인해주세요!-->

<!-- 이슈번호를 작성해주세요. -->
<!-- 여러 이슈를 입력시 comma(,) 단위로 구분해주세요 -->
<!-- ex) close #10, resolves #123 -->

closes #435 
<!-- ex) -->
<!-- closes #1 --> 

