### PR TITLE
Fix/BE/#439: 채팅방 내부에서 방을 삭제할때 중복세션일 경우 오류 수정

### DIFF
--- a/backend/src/gateway/events.gateway.ts
+++ b/backend/src/gateway/events.gateway.ts
@@ -114,9 +114,11 @@ export class EventsGateway implements OnGatewayInit, OnGatewayConnection, OnGate
   async leave(roomId: string, nickname: string, isLeader: boolean) {
     if (isLeader) {
       await this.chatService.deleteRoomByLeader(roomId);
-      const socketId = Object.keys(this.socketsInRooms[roomId])[0];
+      const socketIdList = Object.keys(this.socketsInRooms[roomId]);
       delete this.socketsInRooms[roomId];
-      delete this.socketToRoomId[socketId];
+      socketIdList.forEach((socketId) => {
+        delete this.socketToRoomId[socketId];
+      });
       return;
     }
     const chatUserId = await this.chatService.getChatUserIdByNicknameAndRoomId(roomId, nickname);


### PR DESCRIPTION
## 🤷‍♂️ Description
중복 세션일 경우 채팅방 내부에서 방장이 방을 삭제하면 오류가 발생해요.
세션 정보에는 해당 방이 아직 남아있어서 조회를 시도하다가 에러가 발생하고 있어요.


<!-- 구현 한 기능에 대해 작성해 주세요. -->

## 📝 Primary Commits

<!-- 세부 구현 사항을 리스트로 작성해주세요. -->

- [X] room 내부 세션값 하나가 아닌 전체를 삭제하도록 변경

## 📷 Screenshots

<!--스크린샷으로 보여줄 수 있는 이미지가 있다면 첨부해주세요!-->

<!--BE의 경우 API 테스트 결과를 첨부해주세요-->

<!--마지막으로 이슈 생성 시 우측의 옵션들을 체크했는지 확인해주세요!-->

<!-- 이슈번호를 작성해주세요. -->
<!-- 여러 이슈를 입력시 comma(,) 단위로 구분해주세요 -->
<!-- ex) close #10, resolves #123 -->


<!-- ex) -->
<!-- closes #1 --> 

cloese #439