### PR TITLE
Chore/BE/#447: 넥스트에디션 크롤러 등록 해제

### DIFF
--- a/backend/src/modules/themeModules/crawlerUtils/crawler/nextedition.crawler.ts
+++ b/backend/src/modules/themeModules/crawlerUtils/crawler/nextedition.crawler.ts
@@ -2,6 +2,9 @@ import { AbstractCrawler } from '@crawlerUtils/abstractCrawler';
 import { TimeTableDto } from '@crawlerUtils/dtos/timetable.response.dto';
 import { TIMETABLE_TTL } from '@constants/ttl';
 
+/**
+ * @deprecated 넥스트 에디션 측 크롤러 미허가(https://www.notion.so/22d3b9ca2ae34fb1a452695d62f234e8?pvs=4)
+ */
 export class NextEditionCrawler extends AbstractCrawler {
   BASE_URL = 'https://www.nextedition.co.kr';
   zizumMap = {

--- a/backend/src/modules/themeModules/theme/theme.module.ts
+++ b/backend/src/modules/themeModules/theme/theme.module.ts
@@ -46,7 +46,6 @@ const DEFAULT_TTL = 3 * SEC_TO_MILLI;
         GoldenKeyCrawlerMetadata,
         KeyEscapeCrawlerMetadata,
         MasterKeyCrawlerMetadata,
-        NextEditionCrawlerMetadata,
         SecretGardenEscapeCrawlerMetadata,
         SeoulEscapeRoomCrawlerMetadata,
         XDungeonCrawlerMetadata,


### PR DESCRIPTION
## 🤷‍♂️ Description
넥스트에디션 측에서 크롤러 사용을 미허가 하셨어요.
최종발표일까지 허락해주셔서 이제 해당 기능을 제거합니다.

<!-- 구현 한 기능에 대해 작성해 주세요. -->

## 📝 Primary Commits

<!-- 세부 구현 사항을 리스트로 작성해주세요. -->

- [X] 넥스트 에디션 등록해제
- [X] 넥스트 에디션 크롤러 코드에 Docs를 추가
  - 그런데, 크롤러 코드를 아예 삭제할 지, 지금처럼 Docs에 deprecated 를 추가할 지 고민이에요.
  ```ts
  /**
   * @deprecated 넥스트 에디션 측 크롤러 미허가(https://www.notion.so/22d3b9ca2ae34fb1a452695d62f234e8?pvs=4)
   */
  export class NextEditionCrawler extends AbstractCrawler {
  ```

## 📷 Screenshots
<img width="921" alt="image" src="https://github.com/boostcampwm2023/web03-LockFestival/assets/44056518/a061cf45-fa12-4225-ac18-bd3c6ec3c7dd">

<!--스크린샷으로 보여줄 수 있는 이미지가 있다면 첨부해주세요!-->

<!--BE의 경우 API 테스트 결과를 첨부해주세요-->

<!--마지막으로 이슈 생성 시 우측의 옵션들을 체크했는지 확인해주세요!-->

<!-- 이슈번호를 작성해주세요. -->
<!-- 여러 이슈를 입력시 comma(,) 단위로 구분해주세요 -->
<!-- ex) close #10, resolves #123 -->


<!-- ex) -->
<!-- closes #1 --> 
closes #447
