### PR TITLE
Refactor/FE/#452: 메인페이지 CSS 수정 및 상세정보모달 모바일 버전 CSS 코드 추가

### DIFF
--- a/frontend/src/components/Card/SimpleThemeCard/SimpleThemeCard.tsx
+++ b/frontend/src/components/Card/SimpleThemeCard/SimpleThemeCard.tsx
@@ -29,17 +29,16 @@ const SimpleThemeCard = ({ themeId, themeName, posterImageUrl }: SimpleThemeCard
 };
 
 const CardContainer = styled.div([
-  tw`font-pretendard text-white bg-gray`,
-  tw`desktop:(text-s h-[28.4rem] w-[18.2rem] rounded-[2rem] mx-3 p-3)`,
-  tw`tablet:(text-s h-[24rem] w-[15.2rem] rounded-[2rem] mx-3 p-3)`,
-  tw`mobile:(text-xs h-[21.3rem] w-[12.8rem] rounded-[1.4rem] mx-2 p-2)`,
+  tw`font-pretendard text-white bg-gray rounded-[2rem] mx-3 p-3 gap-[1rem]`,
+  tw`desktop:(text-s h-[28.4rem] w-[18.2rem])`,
+  tw`tablet:(text-s h-[24rem] w-[15.2rem])`,
+  tw`mobile:(text-xs h-[18.2rem] w-[11.2rem] rounded-[1.4rem] mx-1 p-2 gap-[0.5rem])`,
   css`
     display: flex;
     align-items: center;
     justify-content: flex-start;
     flex-direction: column;
     cursor: pointer;
-    gap: 1rem;
   `,
 ]);
 

--- a/frontend/src/components/Carousel/Carousel.tsx
+++ b/frontend/src/components/Carousel/Carousel.tsx
@@ -36,7 +36,7 @@ const CarouselContainer = styled.div([
   tw`w-[90vw] bg-gray-light rounded-default py-3`,
   tw`desktop:(max-w-[102.4rem] h-[32.4rem])`,
   tw`tablet:(max-w-[70rem] h-[27.8rem])`,
-  tw`mobile:(max-w-[36rem] h-[20.6rem])`,
+  tw`mobile:(max-w-[36rem] h-[20.6rem] rounded-[2rem])`,
   css`
     overflow: hidden;
   `,

--- a/frontend/src/components/Carousel/Carousel.tsx
+++ b/frontend/src/components/Carousel/Carousel.tsx
@@ -33,10 +33,10 @@ const Carousel = ({ children }: CarouselProps) => {
 };
 
 const CarouselContainer = styled.div([
-  tw`w-full bg-gray-light rounded-default py-3`,
+  tw`w-[90vw] bg-gray-light rounded-default py-3`,
   tw`desktop:(max-w-[102.4rem] h-[32.4rem])`,
   tw`tablet:(max-w-[70rem] h-[27.8rem])`,
-  tw`mobile:(max-w-[43rem] h-[25rem])`,
+  tw`mobile:(max-w-[36rem] h-[20.6rem])`,
   css`
     overflow: hidden;
   `,

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -17,7 +17,7 @@ const Layout = () => {
   );
 };
 
-const Container = styled.div([tw`bg-gray-dark h-auto w-full min-h-screen mobile:(min-w-[34rem])`]);
+const Container = styled.div([tw`bg-gray-dark h-auto w-full min-h-screen`]);
 
 const Main = styled.main([]);
 

--- a/frontend/src/components/List/SimpleThemeCardList/SimpleThemeCardList.tsx
+++ b/frontend/src/components/List/SimpleThemeCardList/SimpleThemeCardList.tsx
@@ -35,8 +35,8 @@ const CardContainer = styled.div([css``]);
 const NoThemeContainer = styled.div([
   tw`w-full overflow-hidden bg-gray-light text-[4rem] text-white rounded-default`,
   tw`desktop:(max-w-[102.4rem] h-[32.4rem])`,
-  tw`tablet:(max-w-[80rem] h-[28.4rem])`,
-  tw`mobile:(max-w-[43rem] h-[21.6rem])`,
+  tw`tablet:(max-w-[80rem] h-[27.8rem])`,
+  tw`mobile:(max-w-[32.4rem] h-[20.6rem])`,
   css`
     display: flex;
     align-items: center;

--- a/frontend/src/components/ThemeDetailsModal/ThemeDetailsModal.tsx
+++ b/frontend/src/components/ThemeDetailsModal/ThemeDetailsModal.tsx
@@ -52,8 +52,7 @@ function ThemeDetailsModal({ themeId, onClose }: ThemeDetailsModalProps) {
               <ButtonWrapper>
                 <Button
                   isIcon={false}
-                  size="m"
-                  width="10rem"
+                  size="s"
                   onClick={() => {
                     window.open(data.website);
                   }}
@@ -62,8 +61,7 @@ function ThemeDetailsModal({ themeId, onClose }: ThemeDetailsModalProps) {
                 </Button>
                 <Button
                   isIcon={false}
-                  size="m"
-                  width="10rem"
+                  size="s"
                   onClick={() => {
                     onClose();
                     navigate(
@@ -118,7 +116,7 @@ const DetailModalContainer = styled.div([
     display: flex;
     flex-direction: column;
   `,
-  tw`p-6 bg-gray-light rounded-default w-[75rem] tablet:(w-[60rem] p-4) mobile:(w-[34rem] p-2)`,
+  tw`p-6 bg-gray-light rounded-default w-[75rem] tablet:(w-[60rem] p-4) mobile:(w-[32.4rem] p-2)`,
 ]);
 
 const HeadWrapper = styled.div([
@@ -128,7 +126,7 @@ const HeadWrapper = styled.div([
     align-items: center;
     height: 3.2rem;
   `,
-  tw`font-maplestory text-xl-bold mb-4 ml-2`,
+  tw`h-[3.2rem] font-maplestory text-xl-bold mb-4 ml-2 mobile:(h-[1.8rem] text-m-bold my-2)`,
 ]);
 
 const MainWrapper = styled.div([
@@ -137,15 +135,14 @@ const MainWrapper = styled.div([
     justify-content: space-between;
     margin-bottom: 1.6rem;
   `,
+  tw`mobile:(relative)`,
 ]);
 
 const MainThemePosterBox = styled.div([
-  tw`bg-gray-dark rounded-[2rem] mobile:(hidden)`,
-  css`
-    width: 18.5rem;
-    height: 27.2rem;
-    padding: 1.6rem;
+  tw`
+    w-[18.5rem] h-[27.2rem] p-4 bg-gray-dark rounded-[2.8rem] font-pretendard
   `,
+  tw`mobile:(w-[11.2rem] h-[18.2rem] p-2 rounded-[1.2rem])`,
 ]);
 
 const ThemePoster = styled.img([
@@ -153,7 +150,7 @@ const ThemePoster = styled.img([
     width: 100%;
     height: 100%;
   `,
-  tw`rounded-[2rem]`,
+  tw`rounded-[2rem] mobile:(rounded-[0.6rem])`,
 ]);
 
 const InfoWrapper = styled.div([
@@ -163,7 +160,7 @@ const InfoWrapper = styled.div([
     flex: 1;
     gap: 0.8rem;
   `,
-  tw`ml-4`,
+  tw`ml-4 mobile:(ml-2)`,
 ]);
 
 const ButtonWrapper = styled.div([
@@ -174,6 +171,7 @@ const ButtonWrapper = styled.div([
     gap: 0.8rem;
   `,
   tw`ml-4`,
+  tw`mobile:(absolute bottom-0 left-2)`,
 ]);
 
 const BottomWrapper = styled.div([
@@ -181,14 +179,13 @@ const BottomWrapper = styled.div([
     display: flex;
     flex-direction: column;
   `,
-  tw`mobile:(hidden)`,
 ]);
 
 const OtherThemeList = styled.div([
+  tw`gap-3 mobile:(gap-1)`,
   css`
     display: flex;
     justify-content: flex-start;
-    gap: 1.2rem;
   `,
 ]);
 

--- a/frontend/src/components/ThemeDetailsModal/components/ThemeCard.tsx
+++ b/frontend/src/components/ThemeDetailsModal/components/ThemeCard.tsx
@@ -27,8 +27,8 @@ const ThemeCard = ({ themeId, posterImageUrl, name, onClose }: ThemeCardProps) =
         }, 100);
       }}
     >
-      <img src={posterImageUrl} alt="추천_테마_포스터_이미지" />
-      <div>{name}</div>
+      <ThemeCardImg src={posterImageUrl} alt="추천_테마_포스터_이미지" />
+      <ThemeCardName>{name}</ThemeCardName>
     </ThemeCardBox>
   );
 };
@@ -36,25 +36,33 @@ const ThemeCard = ({ themeId, posterImageUrl, name, onClose }: ThemeCardProps) =
 export default ThemeCard;
 
 const ThemeCardBox = styled.div([
+  tw`
+    h-auto p-3 bg-gray-dark rounded-[2rem] font-pretendard text-s gap-3
+  `,
+  tw`desktop:(w-[13rem])`,
+  tw`tablet:(w-[10.4rem])`,
+  tw`mobile:(w-[5.8rem] p-2 rounded-[1.2rem] gap-2 text-xs)`,
   css`
     display: flex;
     flex-direction: column;
-    gap: 1.2rem;
-    justify-content: space-between;
     align-items: center;
-    width: 11rem;
-    height: 16rem;
-    padding: 1.2rem;
     text-align: center;
     cursor: pointer;
-
-    img {
-      width: 7.8rem;
-      height: 13.6rem;
-      border-radius: 1.5rem;
-    }
   `,
-  tw`
-    bg-gray-dark rounded-[2rem] font-pretendard text-s
+]);
+
+const ThemeCardImg = styled.img([
+  tw`rounded-[1.5rem] mobile:(rounded-[0.6rem])`,
+  css`
+    width: 100%;
+    aspect-ratio: 9/13;
+  `,
+]);
+
+const ThemeCardName = styled.div([
+  css`
+    width: 100%;
+    overflow: hidden;
+    white-space: nowrap;
   `,
 ]);

--- a/frontend/src/components/ThemeDetailsModal/components/ThemeInfoItem.tsx
+++ b/frontend/src/components/ThemeDetailsModal/components/ThemeInfoItem.tsx
@@ -5,11 +5,11 @@ export const ThemeInfoItem = (labelName: string, infoContent: string) => {
   return (
     <InfoItem>
       <LabelWrapper>
-        <Label isBorder={true} size="m-bold" width="10rem">
+        <Label isBorder={true} size="m-bold" width="100%">
           <FlexCenter>{labelName}</FlexCenter>
         </Label>
       </LabelWrapper>
-      <InfoContent>{infoContent}</InfoContent>
+      <InfoContent>{!infoContent || infoContent.trim() === '' ? '?' : infoContent}</InfoContent>
     </InfoItem>
   );
 };
@@ -26,6 +26,7 @@ const LabelWrapper = styled.div([
   css`
     min-width: 10rem;
   `,
+  tw`mobile:(min-w-[5rem])`,
 ]);
 
 const InfoItem = styled.div([
@@ -34,6 +35,7 @@ const InfoItem = styled.div([
     align-items: center;
     gap: 1.6rem;
   `,
+  tw`mobile:(gap-1)`,
 ]);
 
-const InfoContent = styled.div([tw`font-pretendard text-l`]);
+const InfoContent = styled.div([tw`font-pretendard text-l`, tw`mobile:(text-s)`]);

--- a/frontend/src/config/carouselConfig.ts
+++ b/frontend/src/config/carouselConfig.ts
@@ -20,5 +20,12 @@ export const carouselConfig = {
         slidesToScroll: 3,
       },
     },
+    {
+      breakpoint: 359,
+      settings: {
+        slidesToShow: 2,
+        slidesToScroll: 2,
+      },
+    },
   ],
 };

--- a/frontend/src/pages/Root/components/RandomThemeListContainer.tsx
+++ b/frontend/src/pages/Root/components/RandomThemeListContainer.tsx
@@ -35,6 +35,6 @@ const LabelWrapper = styled.div(css`
   margin-bottom: 0.8rem;
 `);
 
-const SimpleCardContainer = styled.div([tw`my-2 mt-[-0.5rem]`]);
+const SimpleCardContainer = styled.div([tw`my-2`]);
 
 export default RandomThemeListContainer;

--- a/frontend/src/pages/Root/components/RootLayout.tsx
+++ b/frontend/src/pages/Root/components/RootLayout.tsx
@@ -20,10 +20,10 @@ const RootLayout = () => {
 };
 
 const Container = styled.div([
-  tw`w-full mx-auto mt-[4rem]`,
-  tw`desktop:(max-w-[102.4rem] pb-[10rem])`,
+  tw`w-full mx-auto mt-[4rem] pb-[4rem]`,
+  tw`desktop:(max-w-[102.4rem])`,
   tw`tablet:(max-w-[78rem])`,
-  tw`mobile:(max-w-[80%])`,
+  tw`mobile:(max-w-[36rem])`,
   css`
     display: flex;
     flex-direction: column;

--- a/frontend/src/pages/Root/components/RootSkeletonComponent.tsx
+++ b/frontend/src/pages/Root/components/RootSkeletonComponent.tsx
@@ -28,23 +28,22 @@ const RootSkeletonComponent = () => {
 };
 
 const Container = styled.div([
-  tw`w-full mx-auto`,
+  tw`w-[90vw]`,
   tw`desktop:(max-w-[102.4rem])`,
   tw`tablet:(max-w-[70rem])`,
-  tw`mobile:(max-w-[90%])`,
+  tw`mobile:(max-w-[36rem])`,
   css`
     display: flex;
     flex-direction: column;
-    align-items: center;
-    gap: 1.5rem;
+    gap: 0.8rem;
   `,
 ]);
 
 const CardListContainer = styled.div([
-  tw`bg-gray-light rounded-default gap-[3.4rem]`,
-  tw`desktop:(h-[32.4rem] px-3 py-4)`,
-  tw`tablet:(max-w-[70rem] h-[27.8rem] px-3 py-4)`,
-  tw`mobile:(max-w-[43rem] h-[24.8rem] px-2 py-4)`,
+  tw`w-full bg-gray-light rounded-default mb-4 py-3`,
+  tw`desktop:(h-[32.4rem])`,
+  tw`tablet:(h-[27.8rem])`,
+  tw`mobile:(h-[20.6rem])`,
   css`
     display: flex;
     align-items: flex-start;
@@ -63,34 +62,34 @@ const loadingAnimation = keyframes`
 `;
 
 const SkeletonLabel = styled.div([
-  tw`rounded-default`,
+  tw`h-[3.6rem] rounded-default mt-2`,
+  tw`mobile:(h-[3.2rem])`,
+  tw`border-[0.3rem] border-solid border-gray-light`,
   css`
-    width: 8rem;
-    height: 2.8rem;
+    width: 6rem;
     background: #f2f2f2;
     position: relative;
     overflow: hidden;
     align-self: flex-start;
-    margin-left: 1rem;
     &::before {
       content: '';
       position: absolute;
       top: 0;
       left: 0;
-      width: 55px;
+      width: 50px;
       height: 100%;
-      background: linear-gradient(to right, #f2f2f2, #ddd, #f2f2f2);
-      animation: ${loadingAnimation} 1s infinite linear;
-      filter: blur(1px);
+      background: linear-gradient(to right, #999999, #8f8f8fa0, #999999);
+      animation: ${loadingAnimation} 2s infinite linear;
+      filter: blur(10px);
     }
   `,
 ]);
 
 const SkeletonCard = styled.div`
-  ${tw`mb-2 rounded-[1.5rem] bg-gray`}
-  ${tw`desktop:(w-[17.1rem] p-3)`}
-  ${tw`tablet:(w-[14rem]) p-3`}
-  ${tw`mobile:(w-[12.6rem]) p-2`}
+  ${tw`mx-auto mb-[1.5rem] rounded-[1.5rem] bg-gray`}
+  ${tw`desktop:(w-[17rem])`}
+  ${tw`tablet:(w-[15.2rem])`}
+  ${tw`mobile:(w-[10.8rem])`}
   background: #222222;
   position: relative;
   overflow: hidden;

--- a/frontend/src/pages/Root/components/RootSkeletonComponent.tsx
+++ b/frontend/src/pages/Root/components/RootSkeletonComponent.tsx
@@ -43,7 +43,7 @@ const CardListContainer = styled.div([
   tw`w-full bg-gray-light rounded-default mb-4 py-3`,
   tw`desktop:(h-[32.4rem])`,
   tw`tablet:(h-[27.8rem])`,
-  tw`mobile:(h-[20.6rem])`,
+  tw`mobile:(h-[20.6rem] rounded-[2rem])`,
   css`
     display: flex;
     align-items: flex-start;

--- a/frontend/tailwind.config.ts
+++ b/frontend/tailwind.config.ts
@@ -3,7 +3,7 @@ import type { Config } from 'tailwindcss';
 function generateSpacingValues() {
   const spacingValues: Record<number, string> = {};
   const RATIO = 0.4;
-  let key = 0.5;
+  let key = 0;
 
   while (key <= 10) {
     let value = Number((key * RATIO).toPrecision(2));


### PR DESCRIPTION
## 🤷‍♂️ Description
- 반응형으로 작성된 코드중 반복되는 코드가 있으면 중복을 제거해줬어요.
- 기존의 메인페이지 캐러셀 모바일 최대 넓이가 43rem였는데, 대부분의 모바일을 지원하려고 최대 넓이를 36rem으로 수정했어요.
[참고](https://velog.io/@sangpok/%EB%B0%98%EC%9D%91%ED%98%95-UI-%ED%95%B4%EC%83%81%EB%8F%84-%EA%B8%B0%EC%A4%80)
- 스켈레톤 컴포넌트도 수정된 css에 맞게 수정해줬어요.
- 테마 상세 모달은 기존에 모바일을 고려한 css코드가 거의 없었어서 글꼴 크기, 배치, 패딩이나 마진 등 모바일 기기에서 봤을때 이질감이 들지 않게 최대한 맞췄어요.
- 테마 상세 모달에서 장르가 없는 경우 ? 로 표시하게 예외처리 해줬어요.

<!-- 구현 한 기능에 대해 작성해 주세요. -->

## 📝 Primary Commits

<!-- 세부 구현 사항을 리스트로 작성해주세요. -->

- [X] 메인페이지 캐러셀 css 수정
- [X] 메인페이지 스켈레톤 컴포넌트 수정
- [X] 테마 상세 정보 모달 모바일 버전 css 코드 추가
- [X] 테마 상세 정보 모달 장르 예외처리

## 📷 Screenshots
1. 메인페이지

https://github.com/boostcampwm2023/web03-LockFestival/assets/82202370/f92a030f-64fd-4e35-8a66-a4d5c204ea34

2. 상세정보모달

https://github.com/boostcampwm2023/web03-LockFestival/assets/82202370/f5739c9d-9347-4bb3-9342-1bc09ebe9913

3. 상세정보모달 장르 예외처리
![캡처_2024_01_04_16_04_08_586](https://github.com/boostcampwm2023/web03-LockFestival/assets/82202370/bca96612-ad09-4fa0-b72b-3e3fec037ab4)



<!-- 이슈번호를 작성해주세요. -->
<!-- 여러 이슈를 입력시 comma(,) 단위로 구분해주세요 -->
<!-- ex) close #10, resolves #123 -->


<!-- ex) -->
<!-- closes #1 --> 

