### PR TITLE
Refactor/FE/#130: 회원가입 모달 css 리팩토링 및 모바일 버전 추가

### DIFF
--- a/frontend/src/apis/fetchCheckNickName.ts
+++ b/frontend/src/apis/fetchCheckNickName.ts
@@ -1,0 +1,12 @@
+import userInstance from '@config/userInstance';
+
+const fetchCheckNickName = async (nickname: string) => {
+  const response = await userInstance({
+    method: 'get',
+    url: `/users/check-nickname/${nickname}`,
+  });
+
+  return response.data;
+};
+
+export default fetchCheckNickName;

--- a/frontend/src/components/JoinModal/JoinModalComponent/JoinModalComponent.tsx
+++ b/frontend/src/components/JoinModal/JoinModalComponent/JoinModalComponent.tsx
@@ -6,6 +6,7 @@ import StepTwoContent from './StepTwoContent/StepTwoContent';
 import useJoinMutation from '@hooks/mutation/useJoinMutation';
 import { JoinData } from 'types/profile';
 import useDebounceInput from '@hooks/useDebounceInput';
+import tw, { styled } from 'twin.macro';
 interface JoinModalProps {
   onClose: ModalProps['onClose'];
 }
@@ -53,7 +54,7 @@ function JoinModalComponent({ onClose }: JoinModalProps) {
   };
 
   return (
-    <>
+    <JoinModalContainer>
       {step === STEP1 && (
         <StepOneContent
           nameInput={realInputQuery}
@@ -69,8 +70,17 @@ function JoinModalComponent({ onClose }: JoinModalProps) {
           joinHandler={joinHandler}
         />
       )}
-    </>
+    </JoinModalContainer>
   );
 }
+
+const JoinModalContainer = styled.div([
+  tw`
+    w-auto p-5
+    desktop:(min-w-[54rem])
+    tablet:(min-w-[54rem])
+    mobile:(w-[85vw] max-w-[46rem])
+  `,
+]);
 
 export default JoinModalComponent;

--- a/frontend/src/components/JoinModal/JoinModalComponent/StepOneContent/StepOneContent.tsx
+++ b/frontend/src/components/JoinModal/JoinModalComponent/StepOneContent/StepOneContent.tsx
@@ -2,8 +2,7 @@ import Button from '@components/Button/Button';
 import { ChangeEventHandler, MouseEventHandler, useEffect } from 'react';
 import tw, { styled, css } from 'twin.macro';
 import useNameValidation from './useNameValidation';
-import userInstance from '@config/userInstance';
-import { useQuery } from '@tanstack/react-query';
+import useCheckNickNameQuery from '@hooks/query/useCheckNickNameQuery';
 
 interface StepOneContentProps {
   nameInput: string;
@@ -14,32 +13,18 @@ interface StepOneContentProps {
 
 const NOT_CHECK = 0;
 
-const fetchCheckNickName = async (nickname: string) => {
-  const response = await userInstance({
-    method: 'get',
-    url: `/users/check-nickname/${nickname}`,
-  });
-
-  return response.data;
-};
-
 function StepOneContent({ nameInput, debounceInput, setNameInput, nextStep }: StepOneContentProps) {
   const [isValidName, isDuplicated, checkValidation, warning] = useNameValidation(debounceInput);
-  const { data, isSuccess, isError, refetch } = useQuery<boolean>({
-    queryKey: ['checkNickName', debounceInput],
-    queryFn: () => fetchCheckNickName(debounceInput),
-    staleTime: 0,
-    enabled: false,
-  });
+  const { data, isSuccess, isError, refetch } = useCheckNickNameQuery(debounceInput);
 
   useEffect(() => {
     checkValidation(data, isSuccess, isError);
   }, [isError, isSuccess, data]);
 
   return (
-    <>
-      <TopWrapper>
-        <JoinModalInfo>Lock Festival에서 사용하실 닉네임을 입력하세요.</JoinModalInfo>
+    <StepOneContainer>
+      <JoinModalInfo>Lock Festival에서 사용하실 닉네임을 입력하세요.</JoinModalInfo>
+      <NameInputLabel>
         <NameInput value={nameInput} onChange={setNameInput} type="text" autoFocus />
         <InputButtonWrapper>
           <Button
@@ -52,11 +37,10 @@ function StepOneContent({ nameInput, debounceInput, setNameInput, nextStep }: St
             <>중복확인</>
           </Button>
         </InputButtonWrapper>
-      </TopWrapper>
+      </NameInputLabel>
       <WarningTextWrapper>
         <WarningText isValid={warning.status}>{warning.message}</WarningText>
       </WarningTextWrapper>
-
       <ButtonWrapper>
         <Button
           isIcon={false}
@@ -66,51 +50,51 @@ function StepOneContent({ nameInput, debounceInput, setNameInput, nextStep }: St
           <>NEXT</>
         </Button>
       </ButtonWrapper>
-    </>
+    </StepOneContainer>
   );
 }
 
 export default StepOneContent;
 
-const TopWrapper = styled.div([
+const StepOneContainer = styled.div([
+  tw`mt-[6rem] gap-[6rem]`,
+  tw`mobile:(mt-8 gap-10)`,
   css`
-    position: relative;
     display: flex;
-    gap: 4rem;
-    margin-top: 13.4rem;
-    height: 14.2rem;
     flex-direction: column;
     align-items: center;
-    justify-content: flex-start;
+    text-align: center;
   `,
 ]);
 
 const WarningTextWrapper = styled.div([
+  tw`w-full h-[4rem] mobile:(h-4)`,
   css`
     display: flex;
     flex-direction: column;
-    justify-content: flex-start;
     align-items: center;
-    height: 6rem;
+    text-align: center;
   `,
 ]);
 
-const JoinModalInfo = styled.div([tw`font-maplestory text-l text-white`]);
+const JoinModalInfo = styled.div([tw`font-maplestory text-l text-white`, tw`mobile:(text-m)`]);
+
+const NameInputLabel = styled.label([
+  css`
+    position: relative;
+  `,
+]);
 
 const NameInput = styled.input([
-  tw`font-pretendard text-m bg-white rounded-default pl-5 pr-[8.8rem]`,
-  css`
-    width: 32rem;
-    height: 3.6rem;
-    border: 0;
-  `,
+  tw`w-[32rem] h-[3.6rem] font-pretendard text-m bg-white rounded-default pl-5 pr-[8.8rem] border-0`,
+  tw`mobile:(w-[100%] h-[3.2rem] pl-3 pr-[7.2rem])`,
 ]);
 
 const InputButtonWrapper = styled.div([
   css`
     position: absolute;
-    top: 5.6rem;
-    left: 32.9rem;
+    top: 0;
+    right: 0;
   `,
 ]);
 
@@ -120,9 +104,6 @@ const ButtonWrapper = styled.div([
     width: 100%;
     justify-content: flex-end;
   `,
-  tw`
-    p-4
-  `,
 ]);
 
 interface WarningTextProps {
@@ -130,12 +111,7 @@ interface WarningTextProps {
 }
 
 const WarningText = styled.div<WarningTextProps>(({ isValid }) => {
-  const warningTextStyle = [
-    tw`font-pretendard text-m `,
-    css`
-      margin-top: -2rem;
-    `,
-  ];
+  const warningTextStyle = [tw`font-pretendard text-m mobile:(text-s)`];
 
   if (isValid) {
     warningTextStyle.push(tw`text-green-light`);

--- a/frontend/src/components/JoinModal/JoinModalComponent/StepTwoContent/StepTwoContent.tsx
+++ b/frontend/src/components/JoinModal/JoinModalComponent/StepTwoContent/StepTwoContent.tsx
@@ -13,54 +13,47 @@ function StepTwoContent({ selectGenre, setSelectGenre, joinHandler }: StepTwoCon
   const NOT_SELECT = 0;
 
   return (
-    <>
-      <TopWrapper>
-        <JoinModalInfo>선호하시는 장르를 전부 선택해주세요.</JoinModalInfo>
-        <ThemeButtonsContainer>
-          {genreList.map((item, idx) => (
-            <ThemeButton
-              item={item}
-              idx={idx}
-              buttonHandler={setSelectGenre}
-              isSelected={selectGenre.has(item.genre)}
-            />
-          ))}
-        </ThemeButtonsContainer>
-      </TopWrapper>
+    <StepTwoContainer>
+      <JoinModalInfo>선호하는 장르를 모두 선택해주세요.</JoinModalInfo>
+      <ThemeButtonsContainer>
+        {genreList.map((item, idx) => (
+          <ThemeButton
+            item={item}
+            idx={idx}
+            buttonHandler={setSelectGenre}
+            isSelected={selectGenre.has(item.genre)}
+          />
+        ))}
+      </ThemeButtonsContainer>
       <ButtonWrapper>
         <Button isIcon={false} onClick={joinHandler} disabled={selectGenre.size === NOT_SELECT}>
           <>완료</>
         </Button>
       </ButtonWrapper>
-    </>
+    </StepTwoContainer>
   );
 }
 
 export default StepTwoContent;
 
-const TopWrapper = styled.div([
+const StepTwoContainer = styled.div([
+  tw`w-[54.2rem] h-auto p-4 gap-10`,
+  tw`mobile:(w-auto h-auto gap-6)`,
   css`
     display: flex;
-    gap: 4rem;
-    margin-top: 6.4rem;
-    width: 54.2rem;
-    height: 40rem;
     flex-direction: column;
     align-items: center;
     justify-content: flex-start;
   `,
 ]);
 
-const JoinModalInfo = styled.div([tw`font-maplestory text-l text-white`]);
+const JoinModalInfo = styled.div([tw`font-maplestory text-l text-white mobile:(text-m)`]);
 
 const ButtonWrapper = styled.div([
   css`
     display: flex;
     width: 100%;
     justify-content: flex-end;
-  `,
-  tw`
-    p-4
   `,
 ]);
 

--- a/frontend/src/components/JoinModal/JoinModalComponent/StepTwoContent/ThemeButton/ThemeButton.tsx
+++ b/frontend/src/components/JoinModal/JoinModalComponent/StepTwoContent/ThemeButton/ThemeButton.tsx
@@ -23,27 +23,24 @@ const ThemeButtonWrapper = styled.div<Pick<ThemeButtonProps, 'isSelected'>>(({ i
   const backgroundColor = isSelected ? tw`bg-gray-dark` : tw`bg-white`;
   return [
     backgroundColor,
-    tw`rounded-[2rem]`,
+    tw`w-[100%] p-2 rounded-[1.5rem] gap-2`,
+    tw`mobile:(p-1.5 rounded-[0.8rem])`,
     css`
       position: relative;
       display: flex;
       flex-direction: column;
       justify-content: center;
       align-items: center;
-      gap: 1rem;
-      width: 11.8rem;
-      height: 16rem;
       cursor: pointer;
     `,
   ];
 });
 
 const ThemeImg = styled.img([
-  tw`rounded-[2rem]`,
+  tw`rounded-[1rem] mobile:(rounded-[0.4rem])`,
   css`
-    width: 9rem;
-    height: 10rem;
-    margin-top: 1rem;
+    width: 100%;
+    aspect-ratio: 9/13;
   `,
 ]);
 
@@ -52,19 +49,12 @@ const SelectedState = styled.div<Pick<ThemeButtonProps, 'isSelected'>>(({ isSele
 
   return [
     backgroundColor,
-    tw`rounded-[50%]`,
-    css`
-      position: absolute;
-      width: 1.2rem;
-
-      height: 1.2rem;
-      top: 1rem;
-      right: 1rem;
-    `,
+    tw`absolute rounded-[50%] w-[0.8rem] h-[0.8rem] top-3.5 right-3.5`,
+    tw`mobile:(w-[0.6rem] h-[0.6rem] top-2.5 right-2.5)`,
   ];
 });
 
 const ThemeGenre = styled.div<Pick<ThemeButtonProps, 'isSelected'>>(({ isSelected }) => {
   const fontColor = isSelected ? tw`text-white` : tw`text-gray-dark`;
-  return [fontColor, tw`font-pretendard text-s-bold`];
+  return [fontColor, tw`font-pretendard text-s-bold mobile:(text-xs-bold)`];
 });

--- a/frontend/src/constants/queryManagement.ts
+++ b/frontend/src/constants/queryManagement.ts
@@ -7,6 +7,7 @@ import fetchUserProfile from '@apis/fetchUserProfile';
 import fetchThemesByPage from './../apis/fetchThemesByPage';
 import fetchThemeTimeTable from '@apis/fetchThemeTimeTable';
 import { Value } from 'react-calendar/dist/cjs/shared/types';
+import fetchCheckNickName from '@apis/fetchCheckNickName';
 
 const QUERY_MANAGEMENT = {
   geolocation: {
@@ -40,6 +41,10 @@ const QUERY_MANAGEMENT = {
   themeTimeTable: {
     key: 'themeTimeTable',
     fn: (themeId: number, date: Value) => fetchThemeTimeTable(themeId, date),
+  },
+  isValidNickName: {
+    key: 'isValidNickName',
+    fn: (input: string) => fetchCheckNickName(input),
   },
 };
 

--- a/frontend/src/hooks/query/useCheckNickNameQuery.tsx
+++ b/frontend/src/hooks/query/useCheckNickNameQuery.tsx
@@ -1,0 +1,14 @@
+import { useQuery } from '@tanstack/react-query';
+import QUERY_MANAGEMENT from '@constants/queryManagement';
+
+const useCheckNickNameQuery = (input: string) => {
+  const { data, isSuccess, isError, refetch } = useQuery<boolean>({
+    queryKey: [QUERY_MANAGEMENT['isValidNickName'].key, input],
+    queryFn: () => QUERY_MANAGEMENT['isValidNickName'].fn(input),
+    enabled: false,
+  });
+
+  return { data, isSuccess, isError, refetch };
+};
+
+export default useCheckNickNameQuery;


### PR DESCRIPTION
## 🤷‍♂️ Description
- 회원가입 모달 컴포넌트에 닉네임 중복 체크 API 호출하는 로직을 커스텀 훅으로 분리했어요.
- 모바일에서도 정상적인 레이아웃으로 렌더링되게 반응형 코드를 추가했어요.

<!-- 구현 한 기능에 대해 작성해 주세요. -->

## 📝 Primary Commits

<!-- 세부 구현 사항을 리스트로 작성해주세요. -->

- [X] 닉네임 체크 쿼리 생성
- [x] 회원 가입 모달 모바일 버전 css 코드 추가

## 📷 Screenshots
- 회원가입 모달

https://github.com/boostcampwm2023/web03-LockFestival/assets/82202370/f693bfcf-da9e-48e7-92aa-676a6dc5ff1a


<!--스크린샷으로 보여줄 수 있는 이미지가 있다면 첨부해주세요!-->

<!--BE의 경우 API 테스트 결과를 첨부해주세요-->

<!--마지막으로 이슈 생성 시 우측의 옵션들을 체크했는지 확인해주세요!-->

<!-- 이슈번호를 작성해주세요. -->
<!-- 여러 이슈를 입력시 comma(,) 단위로 구분해주세요 -->
<!-- ex) close #10, resolves #123 -->


<!-- ex) -->
<!-- closes #1 --> 

close #130 