### PR TITLE
Refactor/FE/#455: 검색페이지 모바일 버전 css 코드 추가

### DIFF
--- a/frontend/src/pages/Search/Search.tsx
+++ b/frontend/src/pages/Search/Search.tsx
@@ -64,9 +64,9 @@ export default Search;
 
 const Layout = styled.div([
   tw`w-full mx-auto mt-[4rem] pb-[4rem]`,
-  tw`desktop:(max-w-[102.4rem])`,
-  tw`tablet:(max-w-[78rem])`,
-  tw`mobile:(max-w-[80%])`,
+  tw`desktop:(max-w-[97rem])`,
+  tw`tablet:(max-w-[47.5rem])`,
+  tw`mobile:(w-[90vw] max-w-[40rem])`,
   css`
     position: relative;
     display: flex;
@@ -82,24 +82,22 @@ const TopWrapper = styled.div([
     justify-content: space-between;
     align-items: center;
   `,
-  tw`w-full mb-2 px-2 desktop:(max-w-[97rem]) tablet:(max-w-[47.5rem]) mobile:(max-w-[34rem])`,
+  tw`w-full mb-4`,
 ]);
 
 const InfoText = styled.div([
-  tw`font-maplestory text-xl text-white`,
+  tw`font-maplestory text-xl text-white mobile:(text-l)`,
   css`
     flex: 1;
   `,
 ]);
 
 const CardList = styled.div([
-  tw`w-full desktop:(max-w-[97rem]) tablet:(flex-col) mobile:(flex-col min-w-[34rem])`,
+  tw`w-full mb-4 gap-4 tablet:(flex-col) mobile:(flex-col)`,
   css`
     display: flex;
     flex-wrap: wrap;
     justify-content: space-between;
-    gap: 1.5rem;
-    width: 100%;
   `,
 ]);
 

--- a/frontend/src/pages/Search/components/Card.tsx
+++ b/frontend/src/pages/Search/components/Card.tsx
@@ -61,10 +61,9 @@ const Card = ({ theme }: { theme: ThemeDetailsData }) => {
 export default Card;
 
 const Layout = styled.div<{ isHead: boolean }>(({ isHead }) => [
-  tw`text-white bg-gray-light rounded-default p-4 h-[26rem] desktop:(w-[47.5rem]) tablet:(mx-auto w-[47.5rem]) mobile:(mx-auto w-[90%] h-[20.4rem])`,
+  tw`w-[47.5rem] h-[26rem] text-white bg-gray-light rounded-default p-4 gap-4 tablet:(mx-auto) mobile:(w-full h-[20.4rem] mx-auto)`,
   css`
     display: flex;
-    gap: 1.6rem;
     position: relative;
     transition: transform 0.3s;
     transform: ${isHead ? 'perspective(50%) rotateY(0deg)' : 'perspective(50%) rotateY(180deg)'};

--- a/frontend/src/pages/Search/components/Card/CardInfoLabel/CardInfoLabel.tsx
+++ b/frontend/src/pages/Search/components/Card/CardInfoLabel/CardInfoLabel.tsx
@@ -7,9 +7,11 @@ interface Props {
 }
 
 const CardInfoLabel = ({ labelName, labelContent }: Props) => {
+  const labelWidth = labelName === '지점' || labelName === '테마명' ? '5.8rem' : '9rem';
+
   return (
     <LabelWrapper>
-      <Label isBorder={false} size="m" width="9rem">
+      <Label isBorder={false} size="m" width={labelWidth}>
         <Text>{labelName}</Text>
       </Label>
       <LabelContent>{labelContent}</LabelContent>
@@ -30,7 +32,7 @@ const LabelWrapper = styled.div([
 const Text = styled.div([tw`m-auto`]);
 
 const LabelContent = styled.div([
-  tw`font-pretendard text-m text-white mobile:(text-s)`,
+  tw`font-pretendard text-m text-white mobile:(text-s text-center)`,
   css`
     display: flex;
     flex: 1;

--- a/frontend/src/pages/Search/components/Card/HeadCard/HeadCard.tsx
+++ b/frontend/src/pages/Search/components/Card/HeadCard/HeadCard.tsx
@@ -83,9 +83,9 @@ const Layout = styled.div([
 ]);
 
 const LeftSection = styled.div([
-  tw`w-[26rem] h-[100%] bg-gray-dark rounded-default p-3 mobile:(w-[20rem] p-2.5)`,
+  tw`w-[26rem] bg-gray-dark rounded-default p-3 mobile:(w-[16rem] p-2 rounded-[2rem])`,
 ]);
-const ThemeImg = styled.img([tw`w-[100%] h-[100%] rounded-default`]);
+const ThemeImg = styled.img([tw`w-full aspect-[9/13] rounded-default mobile:(rounded-[1.8rem])`]);
 const RightSection = styled.div([
   css`
     display: flex;


### PR DESCRIPTION
## 🤷‍♂️ Description
- 이전에 중간에 카드 컴포넌트간 간격이 없는 버그를 수정했어요.
- 카드 앞면에 라벨 넓이를 조절했어요.
- 검색페이지 모바일 버전 css 코드를 추가했어요.

<!-- 구현 한 기능에 대해 작성해 주세요. -->

## 📝 Primary Commits

<!-- 세부 구현 사항을 리스트로 작성해주세요. -->

- [X] 검색페이지 모바일 버전 css 코드 추가
- [x] 카드 리스트 간격 없는 버그 수정

## 📷 Screenshots

https://github.com/boostcampwm2023/web03-LockFestival/assets/82202370/037af640-5747-4d5c-b9e8-30c77a594467


<!--스크린샷으로 보여줄 수 있는 이미지가 있다면 첨부해주세요!-->

<!--BE의 경우 API 테스트 결과를 첨부해주세요-->

<!--마지막으로 이슈 생성 시 우측의 옵션들을 체크했는지 확인해주세요!-->

<!-- 이슈번호를 작성해주세요. -->
<!-- 여러 이슈를 입력시 comma(,) 단위로 구분해주세요 -->
<!-- ex) close #10, resolves #123 -->


<!-- ex) -->
<!-- closes #1 --> 

close #455 