### PR TITLE
Feature/FE/#449: bottom navigation bar 추가

### DIFF
--- a/frontend/src/components/FooterNavigationBar/FooterNavigationBar.tsx
+++ b/frontend/src/components/FooterNavigationBar/FooterNavigationBar.tsx
@@ -17,28 +17,31 @@ const FooterNavigationBar = () => {
     <FooterBar>
       <Container>
         <Content>
-          <IconWrapper isSelected={location.pathname === '/recruitment'}>
+          <IconWrapper
+            isSelected={location.pathname === '/recruitment'}
+            onClick={() => handleSelectedItem('/recruitment')}
+          >
             <FaChildren
               size={28}
-              onClick={() => handleSelectedItem('/recruitment')}
               color={location.pathname === '/recruitment' ? '#F2F2F2' : '#1A1A1A'}
             />
           </IconWrapper>
         </Content>
         <Content>
-          <IconWrapper isSelected={location.pathname === '/'}>
-            <FaHouse
-              size={28}
-              onClick={() => handleSelectedItem('/')}
-              color={location.pathname === '/' ? '#F2F2F2' : '#1A1A1A'}
-            />
+          <IconWrapper
+            isSelected={location.pathname === '/'}
+            onClick={() => handleSelectedItem('/')}
+          >
+            <FaHouse size={28} color={location.pathname === '/' ? '#F2F2F2' : '#1A1A1A'} />
           </IconWrapper>
         </Content>
         <Content>
-          <IconWrapper isSelected={location.pathname === '/room-list'}>
+          <IconWrapper
+            isSelected={location.pathname === '/room-list'}
+            onClick={() => handleSelectedItem('/room-list')}
+          >
             <FaComment
               size={28}
-              onClick={() => handleSelectedItem('/room-list')}
               color={location.pathname === '/room-list' ? '#F2F2F2' : '#1A1A1A'}
             />
           </IconWrapper>

--- a/frontend/src/components/FooterNavigationBar/FooterNavigationBar.tsx
+++ b/frontend/src/components/FooterNavigationBar/FooterNavigationBar.tsx
@@ -1,0 +1,90 @@
+import tw, { styled, css } from 'twin.macro';
+import { FaChildren } from 'react-icons/fa6';
+import { useNavigate, useLocation } from 'react-router-dom';
+import { FaComment } from 'react-icons/fa6';
+import { FaHouse } from 'react-icons/fa6';
+import { NavMenu } from 'types/navMenu';
+
+const FooterNavigationBar = () => {
+  const navigate = useNavigate();
+  const location = useLocation();
+
+  const handleSelectedItem = (item: NavMenu) => {
+    navigate(`${item}`);
+  };
+
+  return (
+    <FooterBar>
+      <Container>
+        <Content>
+          <IconWrapper isSelected={location.pathname === '/recruitment'}>
+            <FaChildren
+              size={28}
+              onClick={() => handleSelectedItem('/recruitment')}
+              color={location.pathname === '/recruitment' ? '#F2F2F2' : '#1A1A1A'}
+            />
+          </IconWrapper>
+        </Content>
+        <Content>
+          <IconWrapper isSelected={location.pathname === '/'}>
+            <FaHouse
+              size={28}
+              onClick={() => handleSelectedItem('/')}
+              color={location.pathname === '/' ? '#F2F2F2' : '#1A1A1A'}
+            />
+          </IconWrapper>
+        </Content>
+        <Content>
+          <IconWrapper isSelected={location.pathname === '/room-list'}>
+            <FaComment
+              size={28}
+              onClick={() => handleSelectedItem('/room-list')}
+              color={location.pathname === '/room-list' ? '#F2F2F2' : '#1A1A1A'}
+            />
+          </IconWrapper>
+        </Content>
+      </Container>
+    </FooterBar>
+  );
+};
+
+const FooterBar = styled.div(
+  [tw`hidden w-full bg-white mx-auto`, tw`mobile:(block)`],
+  css`
+    position: sticky;
+    bottom: 0;
+  `
+);
+
+const Container = styled.div([
+  css`
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  `,
+]);
+
+const Content = styled.div([
+  tw`w-[8rem] h-[4.8rem]`,
+  css`
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+  `,
+]);
+
+const IconWrapper = styled.div<{ isSelected: boolean }>(({ isSelected }) => [
+  tw`h-[4rem] w-[4rem]`,
+  css`
+    border: 1px solid #1a1a1a;
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+
+    background-color: ${isSelected ? '#1A1A1A' : '#F2F2F2'};
+  `,
+]);
+
+export default FooterNavigationBar;

--- a/frontend/src/components/FooterNavigationBar/FooterNavigationBar.tsx
+++ b/frontend/src/components/FooterNavigationBar/FooterNavigationBar.tsx
@@ -73,7 +73,6 @@ const Content = styled.div([
     display: flex;
     align-items: center;
     justify-content: center;
-    cursor: pointer;
   `,
 ]);
 
@@ -85,7 +84,7 @@ const IconWrapper = styled.div<{ isSelected: boolean }>(({ isSelected }) => [
     display: flex;
     align-items: center;
     justify-content: center;
-
+    cursor: pointer;
     background-color: ${isSelected ? '#1A1A1A' : '#F2F2F2'};
   `,
 ]);

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -4,16 +4,20 @@ import { Outlet } from 'react-router-dom';
 import Modals from './Modals/Modals';
 import { ToastContainer } from 'react-toastify';
 import 'react-toastify/dist/ReactToastify.css';
+import FooterNavigationBar from './FooterNavigationBar/FooterNavigationBar';
 const Layout = () => {
   return (
-    <Container>
-      <Header />
-      <Main>
-        <Modals />
-        <Outlet />
-        <CustomToastContainer theme="dark" position="bottom-center" autoClose={3000} />
-      </Main>
-    </Container>
+    <>
+      <Container>
+        <Header />
+        <Main>
+          <Modals />
+          <Outlet />
+          <CustomToastContainer theme="dark" position="bottom-center" autoClose={3000} />
+        </Main>
+      </Container>
+      <FooterNavigationBar />
+    </>
   );
 };
 

--- a/frontend/src/pages/Recruitment/components/RecruitmentLayout.tsx
+++ b/frontend/src/pages/Recruitment/components/RecruitmentLayout.tsx
@@ -102,6 +102,7 @@ const TextContainer = styled.div([
 const ButtonPosition = styled.div([
   tw`mx-auto w-4/5 py-[2rem] px-4`,
   tw`desktop:(w-[102.4rem])`,
+  tw`mobile:(w-full)`,
   css`
     display: flex;
     align-items: center;
@@ -110,9 +111,10 @@ const ButtonPosition = styled.div([
 ]);
 
 const AddButton = styled(Button)([
+  tw`bottom-[1rem]`,
+  tw`mobile:(bottom-[5.6rem])`,
   css`
     position: fixed;
-    bottom: 1rem;
     z-index: 3;
   `,
 ]);


### PR DESCRIPTION
## 🤷‍♂️ Description
모바일 화면에서도 페이지 이동을 할 수 있도록 bottom navigation bar를 추가했어요.

현재 디자인이 완전 공대생 감성인데  많은 피드백 부탁드려요!

클릭한 요소의 경우 아이콘 색상과 배경색을 반전시켜서 클릭이 되었다는 것을 확인 시켜주고 있어요.

메뉴가 더 있으면 좋긴한데 현재 3개밖에 없어서 조금 비어보여요.

또, 현재 각 메뉴가 하드코딩 되어있는데 메뉴가 추가될 수도 있으니 추후에 리팩토링 해볼게요.

그리고 모집 리스트 페이지에서 모집글 작성하기 버튼과 Footer가 겹쳐서 모바일인 경우에는 모집글 작성하기 위치를 상단으로 옮겼어요

<!-- 구현 한 기능에 대해 작성해 주세요. -->

## 📝 Primary Commits

<!-- 세부 구현 사항을 리스트로 작성해주세요. -->

- [X] bottom navigation bar 컴포넌트 추가


## 📷 Screenshots

![녹화_2024_01_06_16_06_58_609](https://github.com/boostcampwm2023/web03-LockFestival/assets/100738049/1043376a-057b-4fab-a866-ac0d95b1aedc)

<!--스크린샷으로 보여줄 수 있는 이미지가 있다면 첨부해주세요!-->

<!--BE의 경우 API 테스트 결과를 첨부해주세요-->

<!--마지막으로 이슈 생성 시 우측의 옵션들을 체크했는지 확인해주세요!-->

<!-- 이슈번호를 작성해주세요. -->
<!-- 여러 이슈를 입력시 comma(,) 단위로 구분해주세요 -->
<!-- ex) close #10, resolves #123 -->


<!-- ex) -->
<!-- closes #1 --> 
closes #449 
