### PR TITLE
Feature/FE/#457: 채팅방 모바일, 태블릿 버전 패널 오픈 메뉴 만들기

### DIFF
--- a/frontend/src/components/Header/Header.tsx
+++ b/frontend/src/components/Header/Header.tsx
@@ -26,13 +26,12 @@ const HeaderContainer = styled.header([
 ]);
 
 const HeaderInnerContainer = styled.div([
-  tw`desktop:(w-full)`,
-  tw`tablet:(w-[95%] mx-auto)`,
-  tw`mobile:(w-[95%] mx-auto)`,
+  tw`w-[95vw] mx-auto`,
   css`
     display: flex;
     align-items: center;
     justify-content: space-between;
+    gap: 1rem;
   `,
 ]);
 

--- a/frontend/src/components/Header/HeaderNav/HeaderNav.tsx
+++ b/frontend/src/components/Header/HeaderNav/HeaderNav.tsx
@@ -55,7 +55,7 @@ const HeaderLogo = styled.img([
 const NavContainer = styled.ul([
   tw`border border-white border-solid rounded-[4rem]`,
   tw`desktop:(w-[40rem] h-[3.6rem] mx-4)`,
-  tw`tablet:(w-[28rem] h-[3.2rem] mx-2)`,
+  tw`tablet:(w-[24rem] h-[3.2rem] mx-2)`,
   tw`mobile:(hidden)`,
   css`
     display: grid;

--- a/frontend/src/components/Header/HeaderRest/HeaderRest.tsx
+++ b/frontend/src/components/Header/HeaderRest/HeaderRest.tsx
@@ -98,7 +98,7 @@ const HeaderRest = () => {
                     <FaUser size={10} />
                   )}
                 </ProfileImgWrapper>
-                {profileData.nickname}님
+                <ProfileNameWrapper> {profileData.nickname}님</ProfileNameWrapper>
               </>
             </Button>
             {isHoverProfile && (
@@ -122,8 +122,9 @@ const HeaderRestContainer = styled.div([
     display: flex;
     align-items: flex-end;
     justify-content: flex-end;
-    gap: 2rem;
+    width: 100%;
   `,
+  tw`gap-5 tablet:(gap-2) mobile:(gap-2)`,
 ]);
 
 const widthAnimation = keyframes`
@@ -137,8 +138,8 @@ const widthAnimation = keyframes`
 
 const SearchContainer = styled.div([
   tw`desktop:(w-[16rem] h-[3.6rem] rounded-[4rem])`,
-  tw`tablet:(w-[12rem] h-[3.6rem] rounded-[4rem])`,
-  tw`mobile:(w-[8rem] h-[3.6rem] rounded-[3rem])`,
+  tw`tablet:(flex-1 max-w-[16rem] h-[3.6rem] rounded-[4rem])`,
+  tw`mobile:(flex-1 max-w-[16rem] h-[3.2rem] rounded-[3rem])`,
   css`
     display: flex;
     align-items: center;
@@ -147,7 +148,7 @@ const SearchContainer = styled.div([
 ]);
 
 const SearchInputForm = styled.div([
-  tw`bg-gray-light w-[10rem]`,
+  tw`bg-gray-light w-full`,
   tw`desktop:(rounded-[4rem])`,
   tw`tablet:(rounded-[4rem])`,
   tw`mobile:(rounded-[3rem])`,
@@ -159,10 +160,10 @@ const SearchInputForm = styled.div([
 ]);
 
 const SearchInput = styled.input([
-  tw`font-pretendard h-full pl-2 bg-gray-light text-white rounded-[4rem]`,
-  tw`desktop:(text-m w-[10rem])`,
-  tw`tablet:(text-m w-[8rem])`,
-  tw`mobile:(text-s w-[6rem])`,
+  tw`font-pretendard h-full px-2 bg-gray-light text-white rounded-[4rem]`,
+  tw`desktop:(w-[calc(100%-3.6rem)] text-m)`,
+  tw`tablet:(w-[calc(100%-3.2rem)] text-m)`,
+  tw`mobile:(w-[calc(100%-3.2rem)] text-s)`,
   css`
     border: none;
     outline: none;
@@ -211,10 +212,12 @@ const ProfileImgWrapper = styled.div([
 ]);
 
 const ProfileImg = styled.img([
-  tw`w-[2rem] h-[2rem] mr-1`,
+  tw`w-full h-full mr-1`,
   css`
     border-radius: 50%;
   `,
 ]);
+
+const ProfileNameWrapper = styled.div([tw`text-m`]);
 
 export default HeaderRest;

--- a/frontend/src/constants/StyleMap/ButtonsStyleMap.ts
+++ b/frontend/src/constants/StyleMap/ButtonsStyleMap.ts
@@ -6,9 +6,7 @@ const iconButtonBaseStyle: CSSInterpolation = css`
   display: flex;
   justify-content: center;
   align-items: center;
-  text-align: center;
   border: 1px solid white;
-  vertical-align: middle;
   cursor: pointer;
 `;
 
@@ -31,19 +29,19 @@ const iconStyleMap: Record<string, TwStyle[]> = {
   m: [
     tw`mobile:(w-[2.8rem] h-[2.8rem]) tablet:(w-[3.2rem] h-[3.2rem]) desktop:(w-[3.2rem] h-[3.2rem])`,
     {
-      svg: tw`mobile:(w-[1.5rem] h-[1.5rem]) tablet:(w-[1.8rem] h-[1.8rem]) desktop:(w-[1.8rem] h-[1.8rem])`,
+      svg: tw`mobile:(w-[1.6rem] h-[1.6rem]) tablet:(w-[1.8rem] h-[1.8rem]) desktop:(w-[1.8rem] h-[1.8rem])`,
     },
   ],
   s: [
     tw`mobile:(w-[2.4rem] h-[2.4rem]) tablet:(w-[2.8rem] h-[2.8rem]) desktop:(w-[2.8rem] h-[2.8rem])`,
     {
-      svg: tw`mobile:(w-[1.2rem] h-[1.2rem]) tablet:(w-[1.5rem] h-[1.5rem]) desktop:(w-[1.5rem] h-[1.5rem])`,
+      svg: tw`mobile:(w-[1.2rem] h-[1.2rem]) tablet:(w-[1.6rem] h-[1.6rem]) desktop:(w-[1.6rem] h-[1.6rem])`,
     },
   ],
   default: [
     tw`mobile:(w-[2.8rem] h-[2.8rem]) tablet:(w-[3.2rem] h-[3.2rem]) desktop:(w-[3.2rem] h-[3.2rem])`,
     {
-      svg: tw`mobile:(w-[1.5rem] h-[1.5rem]) tablet:(w-[1.8rem] h-[1.8rem]) desktop:(w-[1.8rem] h-[1.8rem])`,
+      svg: tw`mobile:(w-[1.6rem] h-[1.6rem]) tablet:(w-[1.8rem] h-[1.8rem]) desktop:(w-[1.8rem] h-[1.8rem])`,
     },
   ],
 };

--- a/frontend/src/hooks/useTouchSlidePanel.tsx
+++ b/frontend/src/hooks/useTouchSlidePanel.tsx
@@ -49,6 +49,10 @@ const useTouchSlidePanel = (
   };
 
   useEffect(() => {
+    return setMenuState(false);
+  }, []);
+
+  useEffect(() => {
     if (isClosing) {
       setTimeout(() => {
         setMenuState(false);
@@ -57,7 +61,7 @@ const useTouchSlidePanel = (
           ref.current.style.left = '0px';
         }
         setIsClosing(false);
-      }, 500);
+      }, 300);
     }
   }, [isClosing]);
 

--- a/frontend/src/hooks/useTouchSlidePanel.tsx
+++ b/frontend/src/hooks/useTouchSlidePanel.tsx
@@ -1,0 +1,78 @@
+import { mobileMenuSelector } from '@store/chatRoom';
+import { throttle } from '@utils/throttle';
+import { useEffect, useState } from 'react';
+import { useRecoilState } from 'recoil';
+
+const useTouchSlidePanel = (
+  ref: React.RefObject<HTMLDivElement>,
+  menuName: 'userListMenuSelected' | 'roomInfoMenuSelected'
+) => {
+  const [isClosing, setIsClosing] = useState(false);
+  const [isDragging, setIsDragging] = useState(false);
+  const [xPos, setXPos] = useState(0);
+  const [menuState, setMenuState] = useRecoilState(mobileMenuSelector(menuName));
+
+  const handleTouchStart = (e: React.TouchEvent) => {
+    setIsDragging(true);
+    setXPos(e.touches[0].clientX);
+  };
+
+  const handleTouchMove = throttle((e: React.TouchEvent) => {
+    if (!isDragging) {
+      return;
+    }
+
+    const deltaX = e.touches[0].clientX - xPos;
+    setXPos(e.touches[0].clientX);
+
+    if (ref.current instanceof HTMLElement) {
+      const newLeft = ref.current.offsetLeft + deltaX;
+
+      if (deltaX > 0 && newLeft > 0) {
+        return;
+      }
+
+      ref.current.style.transition = 'left 0.2s linear';
+      ref.current.style.left = `${newLeft}px`;
+      ref.current.ontransitionend = () => {
+        if (deltaX < 0 && ref.current instanceof HTMLElement) {
+          ref.current.style.transition = 'left 0.3s ease-in';
+          ref.current.style.left = `${-ref.current.offsetWidth}px`;
+        }
+        setIsClosing(true);
+      };
+    }
+  }, 100);
+
+  const handleTouchEnd = () => {
+    setIsDragging(false);
+  };
+
+  useEffect(() => {
+    if (isClosing) {
+      setTimeout(() => {
+        setMenuState(false);
+        if (ref.current) {
+          ref.current.ontransitionend = null;
+          ref.current.style.left = '0px';
+        }
+        setIsClosing(false);
+      }, 500);
+    }
+  }, [isClosing]);
+
+  useEffect(() => {
+    if (!ref.current) {
+      return;
+    }
+    if (menuState === true) {
+      ref.current.style.zIndex = '2';
+    } else {
+      ref.current.style.zIndex = '0';
+    }
+  }, [menuState]);
+
+  return { menuState, handleTouchStart, handleTouchMove, handleTouchEnd };
+};
+
+export default useTouchSlidePanel;

--- a/frontend/src/pages/ChatRoom/components/ChatPanel/ChatPanel.tsx
+++ b/frontend/src/pages/ChatRoom/components/ChatPanel/ChatPanel.tsx
@@ -197,6 +197,7 @@ const ChatPanel = memo(function ChatPanel({ roomId, sendChat, getPastChat }: Cha
           isIcon={true}
           onClick={() => {
             navigate('/room-list');
+            setMobileMenuClicked(false);
           }}
         >
           <FaRightFromBracket />

--- a/frontend/src/pages/ChatRoom/components/ChatPanel/ChatPanel.tsx
+++ b/frontend/src/pages/ChatRoom/components/ChatPanel/ChatPanel.tsx
@@ -1,9 +1,9 @@
 import tw, { styled, css } from 'twin.macro';
 import Button from '@components/Button/Button';
-import { FaRightFromBracket } from 'react-icons/fa6';
+import { FaRightFromBracket, FaBars, FaXmark } from 'react-icons/fa6';
 import { useNavigate } from 'react-router-dom';
-import { useRecoilValue } from 'recoil';
-import { chatLogAtom, chatUnreadAtom, userListInfoAtom } from 'store/chatRoom';
+import { useRecoilState, useRecoilValue, useSetRecoilState } from 'recoil';
+import { chatLogAtom, chatUnreadAtom, mobileMenuSelector, userListInfoAtom } from 'store/chatRoom';
 import { ChatLog } from 'types/chat';
 import MessageBox from './MessageBox/MessageBox';
 import { useEffect, useMemo, useRef, useState, useCallback, memo } from 'react';
@@ -19,6 +19,8 @@ import { useVirtualizer } from '@tanstack/react-virtual';
 import { throttle } from '@utils/throttle';
 import PopUpMessageBox from './PopUpMessageBox/PopUpMessageBox';
 import InputBox from './InputBox/InputBox';
+import { keyframes } from '@emotion/react';
+
 interface ChatPanelProps {
   roomId: string;
   sendChat: (message: string) => void;
@@ -41,6 +43,13 @@ const ChatPanel = memo(function ChatPanel({ roomId, sendChat, getPastChat }: Cha
   const [isScrollToTop, setIsScrollToTop] = useState<boolean>(false);
   const [lastUnreadChat, setLastUnreadChat] = useState<UnreadState>();
   const [prevChatLogDataSize, setPrevChatLogDataSize] = useState<number>(0);
+
+  const [mobileMenuClicked, setMobileMenuClicked] = useRecoilState(
+    mobileMenuSelector('mobileMenuClicked')
+  );
+  const setUserListMenuState = useSetRecoilState(mobileMenuSelector('userListMenuSelected'));
+  const setRoomInfoMenuState = useSetRecoilState(mobileMenuSelector('roomInfoMenuSelected'));
+
   const PAGING_SIZE = 50;
   const MIN_SCROLL_TOP = 50;
   const LAST_INDEX = -1;
@@ -163,7 +172,27 @@ const ChatPanel = memo(function ChatPanel({ roomId, sendChat, getPastChat }: Cha
 
   return (
     <Layout>
-      <ButtonWrapper>
+      <ButtonContainer>
+        <MobileLeftButtonWrapper>
+          {mobileMenuClicked ? (
+            <MenuBar>
+              <Button isIcon={false} onClick={() => setUserListMenuState(true)}>
+                <>대화상대</>
+              </Button>
+              <Button isIcon={false} onClick={() => setRoomInfoMenuState(true)}>
+                <>방 정보</>
+              </Button>
+              <Button isIcon={true} onClick={() => setMobileMenuClicked(false)}>
+                <FaXmark />
+              </Button>
+            </MenuBar>
+          ) : (
+            <Button isIcon={true} onClick={() => setMobileMenuClicked(true)}>
+              <FaBars />
+            </Button>
+          )}
+        </MobileLeftButtonWrapper>
+
         <Button
           isIcon={true}
           onClick={() => {
@@ -172,7 +201,7 @@ const ChatPanel = memo(function ChatPanel({ roomId, sendChat, getPastChat }: Cha
         >
           <FaRightFromBracket />
         </Button>
-      </ButtonWrapper>
+      </ButtonContainer>
       <ChatLayout>
         <ChatDisplayContainer ref={parentRef} onScroll={() => handleScroll()}>
           <div ref={targetRef} />
@@ -250,16 +279,45 @@ const Layout = styled.div([
     width: 49rem;
     height: 100vh;
     padding: 2rem;
+    z-index: 1;
   `,
   tw`bg-gray-light rounded-[2rem] h-[calc(90vh - 6rem)]`,
+  tw`tablet:(w-full rounded-[0])`,
+  tw`mobile:(w-full rounded-[0])`,
 ]);
 
-const ButtonWrapper = styled.div([
+const ButtonContainer = styled.div([
   css`
     display: flex;
     justify-content: flex-end;
     width: 100%;
   `,
+  tw`tablet:(justify-between)`,
+  tw`mobile:(justify-between)`,
+]);
+
+const MobileLeftButtonWrapper = styled.div([
+  tw`desktop:(hidden) tablet:(overflow-hidden) mobile:(overflow-hidden)`,
+]);
+
+const slideInFromLeft = keyframes`
+  0% {
+    transform: translateX(-100%);
+  }
+  100% {
+    transform: translateX(0);
+  }
+`;
+
+const MenuBar = styled.div([
+  css`
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    gap: 0.6rem;
+    animation: ${slideInFromLeft} 0.2s linear;
+  `,
+  tw`w-full h-full bg-white-60 rounded-default`,
 ]);
 
 const ChatLayout = styled.div([

--- a/frontend/src/pages/ChatRoom/components/ChatRoomContainer.tsx
+++ b/frontend/src/pages/ChatRoom/components/ChatRoomContainer.tsx
@@ -31,8 +31,10 @@ const ChatRoomContainer = ({
 };
 
 const Container = styled.div([
-  tw`w-full mx-auto mt-[4rem] h-[calc(100vh -10rem)]`,
+  tw`relative w-full mx-auto mt-[4rem] h-[calc(100vh-10rem)]`,
   tw`desktop:(max-w-[102.4rem] pb-[10rem])`,
+  tw`tablet:(overflow-x-hidden)`,
+  tw`mobile:(overflow-x-hidden)`,
   css`
     display: flex;
     gap: 3.2rem;

--- a/frontend/src/pages/ChatRoom/components/RoomInfoPanel/RoomInfoPanel.tsx
+++ b/frontend/src/pages/ChatRoom/components/RoomInfoPanel/RoomInfoPanel.tsx
@@ -145,8 +145,8 @@ const Layout = styled.div(({ menuState }: { menuState: boolean | DefaultValue })
     }
   `,
   tw`bg-gray-light rounded-[2rem] h-[calc(90vh - 6rem)] p-4`,
-  tw`tablet:(absolute w-[26rem] left-[0] rounded-l-[0] border border-solid border-white-60 z-[-1] p-3)`,
-  tw`mobile:(absolute w-[26rem] left-[0] rounded-l-[0] border border-solid border-white-60 z-[-1] p-3)`,
+  tw`tablet:(absolute w-[26rem] left-[0] rounded-l-[0] border border-solid border-l-0 border-white-60 z-[-1] p-3)`,
+  tw`mobile:(absolute w-[26rem] left-[0] rounded-l-[0] border border-solid border-l-0 border-white-60 z-[-1] p-3)`,
   menuState &&
     css`
       animation: ${slideInAnimation} 0.3s ease-in forwards;

--- a/frontend/src/pages/ChatRoom/components/RoomInfoPanel/RoomInfoPanel.tsx
+++ b/frontend/src/pages/ChatRoom/components/RoomInfoPanel/RoomInfoPanel.tsx
@@ -7,11 +7,13 @@ import { FaGear } from 'react-icons/fa6';
 import useModal from '@hooks/useModal';
 import Modal from '@components/Modal/Modal';
 import RoomSettingModal from './RoomSettingModal/RoomSettingModal';
-import { useRecoilValue } from 'recoil';
+import { DefaultValue, useRecoilValue } from 'recoil';
 import { roomInfoAtom } from '@store/chatRoom';
 import { getStringByDate } from '@utils/dateUtil';
 import TimeTable from './TimeTable/TimeTable';
-import { memo } from 'react';
+import { memo, useRef } from 'react';
+import useTouchSlidePanel from '@hooks/useTouchSlidePanel';
+import { keyframes } from '@emotion/react';
 
 interface Props {
   settingMode: boolean;
@@ -36,6 +38,11 @@ const RoomInfoPanel = memo(function RoomInfoPanel({ settingMode, changeRoom }: P
     themeId,
     website,
   } = roomInfo as RoomInfo;
+  const ref = useRef<HTMLDivElement>(null);
+  const { menuState, handleTouchStart, handleTouchMove, handleTouchEnd } = useTouchSlidePanel(
+    ref,
+    'roomInfoMenuSelected'
+  );
 
   const handleSettingButton = () => {
     openModal(Modal, {
@@ -46,7 +53,13 @@ const RoomInfoPanel = memo(function RoomInfoPanel({ settingMode, changeRoom }: P
   };
 
   return (
-    <Layout>
+    <Layout
+      ref={ref}
+      menuState={menuState}
+      onTouchStart={handleTouchStart}
+      onTouchMove={handleTouchMove}
+      onTouchEnd={handleTouchEnd}
+    >
       <RoomInfoTopContainer>
         {settingMode && (
           <SettingButton>
@@ -65,19 +78,19 @@ const RoomInfoPanel = memo(function RoomInfoPanel({ settingMode, changeRoom }: P
           </ThemeInfoWrapper>
         </HeadContainer>
         <RoomInfoWrapper>
-          <Label isBorder={true} width="10rem">
+          <Label isBorder={true} size="s" width="6.4rem">
             <LabelText>모집내용</LabelText>
           </Label>
           <RoomInfoContent>{recruitmentContent}</RoomInfoContent>
         </RoomInfoWrapper>
         <RoomInfoWrapper>
-          <Label isBorder={true} width="10rem">
+          <Label isBorder={true} size="s" width="6.4rem">
             <LabelText>날짜</LabelText>
           </Label>
           <RoomInfoContent>{getStringByDate(new Date(appointmentDate))}</RoomInfoContent>
         </RoomInfoWrapper>
         <RoomInfoWrapper>
-          <Label isBorder={true} width="10rem">
+          <Label isBorder={true} size="s" width="6.4rem">
             <LabelText>인원</LabelText>
           </Label>
           <RoomInfoContent>
@@ -85,7 +98,7 @@ const RoomInfoPanel = memo(function RoomInfoPanel({ settingMode, changeRoom }: P
           </RoomInfoContent>
         </RoomInfoWrapper>
         <RoomInfoWrapper>
-          <Label isBorder={true} width="10rem">
+          <Label isBorder={true} size="s" width="6.4rem">
             <LabelText>상태</LabelText>
           </Label>
           <RoomInfoContent>
@@ -99,14 +112,21 @@ const RoomInfoPanel = memo(function RoomInfoPanel({ settingMode, changeRoom }: P
   );
 });
 
-const Layout = styled.div([
+const slideInAnimation = keyframes`
+  from {
+    transform: translateX(-100%);
+  }
+  to {
+    transform: translateX(0);
+  }
+`;
+
+const Layout = styled.div(({ menuState }: { menuState: boolean | DefaultValue }) => [
   css`
     display: flex;
     flex-direction: column;
     justify-content: space-between;
     width: 34rem;
-    height: 100vh;
-    padding: 2rem;
     gap: 1.6rem;
     overflow-x: hidden;
     overflow-y: auto;
@@ -124,14 +144,19 @@ const Layout = styled.div([
       box-shadow: inset 0px 0px 5px white;
     }
   `,
-  tw`bg-gray-light rounded-[2rem] h-[calc(90vh - 6rem)]`,
+  tw`bg-gray-light rounded-[2rem] h-[calc(90vh - 6rem)] p-4`,
+  tw`tablet:(absolute w-[26rem] left-[0] rounded-l-[0] border border-solid border-white-60 z-[-1] p-3)`,
+  tw`mobile:(absolute w-[26rem] left-[0] rounded-l-[0] border border-solid border-white-60 z-[-1] p-3)`,
+  menuState &&
+    css`
+      animation: ${slideInAnimation} 0.3s ease-in forwards;
+    `,
 ]);
 
 const RoomInfoTopContainer = styled.div([
   css`
     display: flex;
     flex-direction: column;
-    gap: 1.2rem;
   `,
 ]);
 
@@ -144,17 +169,17 @@ const SettingButton = styled.div([
 ]);
 
 const HeadContainer = styled.div([
-  tw`w-[full] h-[14.2rem] bg-gray rounded-[2rem]`,
+  tw`w-[full] h-full bg-gray rounded-[2rem] gap-3 p-3 my-4`,
+  tw`tablet:(gap-2 p-2 my-2)`,
+  tw`mobile:(gap-2 p-2 my-2)`,
   css`
     display: flex;
     justify-content: space-between;
     align-items: center;
-    padding: 2rem;
-    gap: 1.2rem;
   `,
 ]);
 
-const ThemePoster = styled.img([tw`w-[10rem] h-[10.7rem] rounded-[2rem]`]);
+const ThemePoster = styled.img([tw`w-[8.4rem] aspect-[1/1.2] rounded-[1.8rem]`]);
 
 const ThemeInfoWrapper = styled.div([
   css`
@@ -168,7 +193,7 @@ const ThemeInfoWrapper = styled.div([
 ]);
 
 const ThemeInfo = styled.div([
-  tw`font-pretendard text-m text-white`,
+  tw`font-pretendard text-s text-white mobile:(text-xs)`,
   css`
     text-align: center;
   `,
@@ -190,11 +215,10 @@ const LabelText = styled.div([
 ]);
 
 const RoomInfoContent = styled.div([
-  tw`font-pretendard text-white text-m`,
+  tw`font-pretendard text-white text-s mobile:(text-xs)`,
   css`
     display: flex;
     align-items: center;
-    width: 16.4rem;
   `,
 ]);
 

--- a/frontend/src/pages/ChatRoom/components/RoomInfoPanel/StateLabel/StateLabel.tsx
+++ b/frontend/src/pages/ChatRoom/components/RoomInfoPanel/StateLabel/StateLabel.tsx
@@ -7,7 +7,7 @@ interface StateLabelProps {
 
 const StateLabel = ({ text, state }: StateLabelProps) => {
   return (
-    <Label isBorder={true} backgroundColor={state ? 'green-dark' : 'green-light'} width="10rem">
+    <Label isBorder={true} backgroundColor={state ? 'green-dark' : 'green-light'} size="s">
       <LabelText>
         {text}
         {state ? '완료' : '중'}

--- a/frontend/src/pages/ChatRoom/components/RoomInfoPanel/TimeTable/TimeTable.tsx
+++ b/frontend/src/pages/ChatRoom/components/RoomInfoPanel/TimeTable/TimeTable.tsx
@@ -93,7 +93,7 @@ const TopWrapper = styled.div([
   tw`text-white`,
 ]);
 
-const Text = styled.div([tw`font-pretendard text-m`]);
+const Text = styled.div([tw`font-pretendard text-m mobile:(text-s)`]);
 
 const TimeTableWrapper = styled.div([
   tw`grid grid-cols-4 gap-3`,

--- a/frontend/src/pages/ChatRoom/components/RoomInfoPanel/TimeTable/TimeTable.tsx
+++ b/frontend/src/pages/ChatRoom/components/RoomInfoPanel/TimeTable/TimeTable.tsx
@@ -7,6 +7,7 @@ import useTimeTableQuery from '@hooks/useTimeTableQuery';
 import { FaArrowsRotate } from 'react-icons/fa6';
 import { keyframes } from '@emotion/react';
 import { getStringByDate } from '@utils/dateUtil';
+import Button from '@components/Button/Button';
 
 interface Props {
   themeId: number;
@@ -39,26 +40,16 @@ const TimeTable = ({ themeId, website }: Props) => {
           <FaArrowsRotate size="30" />
         </Loading>
       ) : (
-        <>
+        <BottomWrapper>
           {data && data.length > 0 ? (
             <TimeTableWrapper>
               {data?.map((timeData) =>
                 timeData.possible ? (
-                  <Label
-                    key={timeData.time}
-                    isBorder={false}
-                    width="6rem"
-                    backgroundColor="green-light"
-                  >
+                  <Label key={timeData.time} isBorder={false} backgroundColor="green-light">
                     <LabelText>{timeData.time}</LabelText>
                   </Label>
                 ) : (
-                  <Label
-                    key={timeData.time}
-                    isBorder={false}
-                    width="6rem"
-                    backgroundColor="green-dark"
-                  >
+                  <Label key={timeData.time} isBorder={false} backgroundColor="green-dark">
                     <LabelText>{timeData.time}</LabelText>
                   </Label>
                 )
@@ -70,10 +61,12 @@ const TimeTable = ({ themeId, website }: Props) => {
               시간표를 불러올 수 없습니다.
             </InfoText>
           )}
-          <WebsiteLink href={website} target="_blank">
-            예약 사이트 바로가기
-          </WebsiteLink>
-        </>
+          <ReservationButtonWrapper>
+            <Button isIcon={false} onClick={() => window.open(website, '_blank')}>
+              <>예약 사이트 바로가기</>
+            </Button>
+          </ReservationButtonWrapper>
+        </BottomWrapper>
       )}
     </Container>
   );
@@ -87,8 +80,10 @@ const Container = styled.div([
     flex-direction: column;
     align-items: center;
     gap: 1.2rem;
+    height: 100%;
   `,
 ]);
+
 const TopWrapper = styled.div([
   css`
     display: flex;
@@ -98,9 +93,13 @@ const TopWrapper = styled.div([
   tw`text-white`,
 ]);
 
-const Text = styled.div([tw`font-pretendard text-l`]);
+const Text = styled.div([tw`font-pretendard text-m`]);
 
-const TimeTableWrapper = styled.div([tw`grid grid-cols-4 gap-4`]);
+const TimeTableWrapper = styled.div([
+  tw`grid grid-cols-4 gap-3`,
+  tw`tablet:(gap-2) mobile:(gap-2)`,
+]);
+
 const LabelText = styled.div(tw`mx-auto`);
 
 const CalendarWrapper = styled.div([tw`font-pretendard text-s w-full`]);
@@ -114,6 +113,16 @@ const rotate = keyframes`
     }
 `;
 
+const BottomWrapper = styled.div([
+  css`
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+    align-items: center;
+  `,
+]);
+
 const Loading = styled.div([
   tw`w-full h-[12.8rem] text-white`,
   css`
@@ -125,7 +134,7 @@ const Loading = styled.div([
 ]);
 
 const InfoText = styled.div([
-  tw`w-full h-[12.8rem] font-pretendard text-white text-m`,
+  tw`w-full font-pretendard text-white text-s`,
   css`
     display: flex;
     justify-content: center;
@@ -135,10 +144,8 @@ const InfoText = styled.div([
   `,
 ]);
 
-const WebsiteLink = styled.a([
-  tw`font-pretendard text-white text-l border border-white border-solid py-3 px-4 rounded-[1rem]`,
+const ReservationButtonWrapper = styled.div([
   css`
-    text-decoration: none;
-    cursor: pointer;
+    justify-self: flex-end;
   `,
 ]);

--- a/frontend/src/pages/ChatRoom/components/UserListPanel/UserItem/UserItem.tsx
+++ b/frontend/src/pages/ChatRoom/components/UserListPanel/UserItem/UserItem.tsx
@@ -4,17 +4,11 @@ import { UserInfo } from 'types/chat';
 import Label from '@components/Label/Label';
 import LeaderIcon from '../../icon/LeaderIcon.svg?react';
 
-const UserItem = ({
-  nickname,
-  profileImg,
-  isLeader,
-  isMe,
-  lastChatLogId,
-}: Omit<UserInfo, 'isLeave' | 'userId'>) => {
+const UserItem = ({ nickname, profileImg, isLeader }: Omit<UserInfo, 'isLeave' | 'userId'>) => {
   return (
     <UserItemWrapper>
       {profileImg ? <ProfileImg src={profileImg} /> : <FaCircleUser size="20" color="white" />}
-      <Label isBorder={false} backgroundColor="transparent" size="l" width="11rem">
+      <Label isBorder={false} backgroundColor="transparent" size="m">
         <NameTag>{nickname}</NameTag>
       </Label>
       {isLeader ? <LeaderIcon width={20} height={20} /> : ''}
@@ -27,20 +21,13 @@ export default UserItem;
 const UserItemWrapper = styled.div([
   css`
     display: flex;
+    flex: 1;
     align-items: center;
-    width: 100%;
     height: 3.6rem;
   `,
 ]);
 
-const NameTag = styled.div([
-  tw`text-white`,
-  css`
-    display: flex;
-    justify-content: center;
-    align-items: center;
-  `,
-]);
+const NameTag = styled.div([tw`text-white`]);
 
 const ProfileImg = styled.img([
   css`

--- a/frontend/src/pages/ChatRoom/components/UserListPanel/UserListPanel.tsx
+++ b/frontend/src/pages/ChatRoom/components/UserListPanel/UserListPanel.tsx
@@ -1,8 +1,8 @@
 import tw, { styled, css } from 'twin.macro';
 import UserItem from './UserItem/UserItem';
 import Button from '@components/Button/Button';
-import { DefaultValue, useRecoilValue } from 'recoil';
-import { userListInfoAtom } from '@store/chatRoom';
+import { DefaultValue, useRecoilValue, useSetRecoilState } from 'recoil';
+import { mobileMenuSelector, userListInfoAtom } from '@store/chatRoom';
 import { UserInfoObject } from 'types/chat';
 import useLeaveRoomMutation from '@hooks/mutation/useLeaveRoomMutation';
 import { memo, useRef } from 'react';
@@ -24,6 +24,7 @@ const UserListPanel = memo(function UserListPanel({ roomId, settingMode, kickUse
     ref,
     'userListMenuSelected'
   );
+  const setMobileMenuClicked = useSetRecoilState(mobileMenuSelector('mobileMenuClicked'));
 
   const handlerLeaveRoom = async () => {
     const result = await Swal.fire({
@@ -35,6 +36,7 @@ const UserListPanel = memo(function UserListPanel({ roomId, settingMode, kickUse
     });
     if (result.isConfirmed) {
       mutate(Number(roomId));
+      setMobileMenuClicked(false);
     }
   };
 

--- a/frontend/src/pages/ChatRoom/components/UserListPanel/UserListPanel.tsx
+++ b/frontend/src/pages/ChatRoom/components/UserListPanel/UserListPanel.tsx
@@ -129,10 +129,10 @@ const Layout = styled.div(({ menuState }: { menuState: boolean | DefaultValue })
   `,
   tw`bg-gray-light rounded-[2rem] h-[calc(90vh - 6rem)]`,
   tw`
-    tablet:(absolute left-[0] rounded-l-[0] border border-solid border-white-60)
+    tablet:(absolute left-[0] rounded-l-[0] border border-solid border-l-0 border-white-60)
   `,
   tw`
-    mobile:(absolute left-[0] rounded-l-[0] border border-solid border-white-60)
+    mobile:(absolute left-[0] rounded-l-[0] border border-solid border-l-0 border-white-60)
   `,
   menuState &&
     css`

--- a/frontend/src/pages/ChatRoom/components/UserListPanel/UserListPanel.tsx
+++ b/frontend/src/pages/ChatRoom/components/UserListPanel/UserListPanel.tsx
@@ -1,12 +1,14 @@
 import tw, { styled, css } from 'twin.macro';
 import UserItem from './UserItem/UserItem';
 import Button from '@components/Button/Button';
-import { useRecoilValue } from 'recoil';
+import { DefaultValue, useRecoilValue } from 'recoil';
 import { userListInfoAtom } from '@store/chatRoom';
 import { UserInfoObject } from 'types/chat';
 import useLeaveRoomMutation from '@hooks/mutation/useLeaveRoomMutation';
-import { memo } from 'react';
+import { memo, useRef } from 'react';
 import Swal from 'sweetalert2';
+import { keyframes } from '@emotion/react';
+import useTouchSlidePanel from '@hooks/useTouchSlidePanel';
 
 interface Props {
   roomId: string;
@@ -17,6 +19,11 @@ interface Props {
 const UserListPanel = memo(function UserListPanel({ roomId, settingMode, kickUser }: Props) {
   const userListInfo = useRecoilValue(userListInfoAtom) as UserInfoObject;
   const { mutate } = useLeaveRoomMutation(Number(roomId));
+  const ref = useRef<HTMLDivElement>(null);
+  const { menuState, handleTouchStart, handleTouchMove, handleTouchEnd } = useTouchSlidePanel(
+    ref,
+    'userListMenuSelected'
+  );
 
   const handlerLeaveRoom = async () => {
     const result = await Swal.fire({
@@ -41,7 +48,13 @@ const UserListPanel = memo(function UserListPanel({ roomId, settingMode, kickUse
   };
 
   return (
-    <Layout>
+    <Layout
+      ref={ref}
+      menuState={menuState}
+      onTouchStart={handleTouchStart}
+      onTouchMove={handleTouchMove}
+      onTouchEnd={handleTouchEnd}
+    >
       <UserListWrapper>
         {Array.from(userListInfo).map(([userId, userData]) => {
           const { nickname, profileImg, isLeader, isLeave, isMe, lastChatLogId } = userData;
@@ -57,17 +70,11 @@ const UserListPanel = memo(function UserListPanel({ roomId, settingMode, kickUse
                 />
                 {!isMe && (
                   <ButtonWrapper settingMode={settingMode}>
-                    <Button
-                      isIcon={false}
-                      width="100%"
-                      data-user-id={userId}
-                      onClick={handleUserKick}
-                    >
+                    <Button isIcon={false} data-user-id={userId} size="s" onClick={handleUserKick}>
                       <Text>추방</Text>
                     </Button>
                   </ButtonWrapper>
                 )}
-                <Division />
               </UserItemWrapper>
             );
           }
@@ -85,11 +92,20 @@ const UserListPanel = memo(function UserListPanel({ roomId, settingMode, kickUse
 
 export default UserListPanel;
 
-const Layout = styled.div([
+const slideInAnimation = keyframes`
+  from {
+    transform: translateX(-100%);
+  }
+  to {
+    transform: translateX(0);
+  }
+`;
+
+const Layout = styled.div(({ menuState }: { menuState: boolean | DefaultValue }) => [
   css`
     display: flex;
     flex-direction: column;
-    width: 20.8rem;
+    width: 26rem;
     padding: 2rem;
     justify-content: space-between;
     align-items: center;
@@ -110,21 +126,24 @@ const Layout = styled.div([
     }
   `,
   tw`bg-gray-light rounded-[2rem] h-[calc(90vh - 6rem)]`,
+  tw`
+    tablet:(absolute left-[0] rounded-l-[0] border border-solid border-white-60)
+  `,
+  tw`
+    mobile:(absolute left-[0] rounded-l-[0] border border-solid border-white-60)
+  `,
+  menuState &&
+    css`
+      animation: ${slideInAnimation} 0.3s ease-in forwards;
+    `,
 ]);
 
-const UserListWrapper = styled.div([
-  css`
-    display: flex;
-    flex-direction: column;
-  `,
-]);
+const UserListWrapper = styled.div([tw`w-full`]);
 
 const UserItemWrapper = styled.div([
   css`
     display: flex;
-    flex-direction: column;
     align-items: center;
-    gap: 1.6rem;
   `,
 ]);
 
@@ -133,14 +152,7 @@ const ButtonWrapper = styled.div(({ settingMode }: { settingMode: boolean }) => 
     css`
       display: none;
     `,
-  settingMode &&
-    css`
-      display: flex;
-      justify-content: center;
-      align-items: flex-end;
-      width: 50%;
-      margin-bottom: 1.2rem;
-    `,
+  settingMode && css``,
 ]);
 
 const ExitButtonWrapper = styled.div([
@@ -153,5 +165,3 @@ const ExitButtonWrapper = styled.div([
 ]);
 
 const Text = styled.div([tw`mx-auto`]);
-
-const Division = styled.div([tw`w-[100%] h-[0.1rem] bg-white-60 mb-4`]);

--- a/frontend/src/store/chatRoom.tsx
+++ b/frontend/src/store/chatRoom.tsx
@@ -1,4 +1,4 @@
-import { atom, atomFamily } from 'recoil';
+import { DefaultValue, atom, atomFamily, selectorFamily } from 'recoil';
 import { ChatLog, RoomInfo, UserInfoObject } from 'types/chat';
 
 export const chatLogAtom = atomFamily<Map<string, ChatLog>, string>({
@@ -19,4 +19,24 @@ export const userListInfoAtom = atom<UserInfoObject | undefined>({
 export const chatUnreadAtom = atom<Map<string, string>>({
   key: 'chatUnreadAtom',
   default: new Map(),
+});
+
+const mobileMenuState = atom<Record<string, boolean | DefaultValue>>({
+  key: 'mobileMenuState',
+  default: { mobileMenuClicked: false, userListMenuSelected: false, roomInfoMenuSelected: false },
+});
+
+export const mobileMenuSelector = selectorFamily({
+  key: 'mobileMenuSelector',
+  get:
+    (menuName: 'mobileMenuClicked' | 'userListMenuSelected' | 'roomInfoMenuSelected') =>
+    ({ get }) =>
+      get(mobileMenuState)[menuName],
+  set:
+    (menuName: 'mobileMenuClicked' | 'userListMenuSelected' | 'roomInfoMenuSelected') =>
+    ({ set }, val) =>
+      set(mobileMenuState, (prevState) => ({
+        ...prevState,
+        [menuName]: val,
+      })),
 });

--- a/frontend/src/styles/Calendar.css
+++ b/frontend/src/styles/Calendar.css
@@ -11,6 +11,24 @@
   height: 2rem;
   margin: 0;
 }
+
+.react-calendar__navigation {
+  display: flex;
+  align-items: center;
+  height: 100%;
+
+  button {
+    width: 3rem;
+    min-width: none;
+    padding: 0.2rem 0;
+  }
+}
+
+.react-calendar__navigation__label__labelText {
+  font-family: Pretendard-Regular;
+  font-size: 1.2rem;
+}
+
 .react-calendar__month-view__weekdays__weekday {
   display: flex;
   justify-content: center;

--- a/frontend/src/styles/Calendar.css
+++ b/frontend/src/styles/Calendar.css
@@ -18,8 +18,7 @@
   height: 100%;
 
   button {
-    width: 3rem;
-    min-width: none;
+    min-width: 3rem;
     padding: 0.2rem 0;
   }
 }

--- a/frontend/src/styles/Calendar.css
+++ b/frontend/src/styles/Calendar.css
@@ -23,6 +23,14 @@
   }
 }
 
+.react-calendar__navigation__prev2-button {
+  border-top-left-radius: 0.6rem;
+}
+
+.react-calendar__navigation__next2-button {
+  border-top-right-radius: 0.6rem;
+}
+
 .react-calendar__navigation__label__labelText {
   font-family: Pretendard-Regular;
   font-size: 1.2rem;


### PR DESCRIPTION
## 🤷‍♂️ Description
- 모바일, 태블릿에서 채팅방 페이지의 UI를 변경했어요.
- 모바일, 태블릿에서는 유저리스트, 방정보 패널을 햄버거 버튼으로 열 수 있게 하고 터치 이벤트로 닫을 수 있게 했어요.
- 오른쪽으로 터치무브시 패널이 닫히지 않고, 왼쪽으로 터치무브시 닫힐 수 있게 하는 로직을 커스텀 훅으로 만들었어요.
- 헤더 css도 반응형에서 조금 어색한 부분이 있어서 고쳤어요.

<!-- 구현 한 기능에 대해 작성해 주세요. -->

## 📝 Primary Commits

<!-- 세부 구현 사항을 리스트로 작성해주세요. -->

- [X] 헤더 태블릿 네브바 메뉴 넓이 및 검색바 반응형 넓이 수정 
- [x] 채팅방 모바일 메뉴 상태 관리 추가 및 터치 무브로 패널 닫는 로직 담은 커스텀 훅 생성
- [x] 각 패널 마다 컴포넌트 크기 수정 및 터치 슬라이드 패널 커스텀 훅 적용

## 📷 Screenshots

https://github.com/boostcampwm2023/web03-LockFestival/assets/82202370/1c904e79-d898-4351-99a0-11e55ef5df54



<!--BE의 경우 API 테스트 결과를 첨부해주세요-->

<!--마지막으로 이슈 생성 시 우측의 옵션들을 체크했는지 확인해주세요!-->

<!-- 이슈번호를 작성해주세요. -->
<!-- 여러 이슈를 입력시 comma(,) 단위로 구분해주세요 -->
<!-- ex) close #10, resolves #123 -->


<!-- ex) -->
<!-- closes #1 --> 

close #457 