### PR TITLE
Feature/FE/#461: 카드 UI 변경

### DIFF
--- a/frontend/src/components/Card/GroupInfoCard/GroupInfoCard.tsx
+++ b/frontend/src/components/Card/GroupInfoCard/GroupInfoCard.tsx
@@ -25,9 +25,8 @@ const GroupInfoCard = (props: GroupInfoCardProps) => {
 };
 
 const Container = styled.div<{ isHead: boolean }>(({ isHead }) => [
-  tw`w-4/5 mx-auto px-4 py-2 text-white bg-gray-light font-pretendard`,
+  tw`w-4/5 mx-auto px-4 py-2 text-white bg-gray-light font-pretendard rounded-[2rem]`,
   tw`desktop:(w-[48rem]) h-[34.4rem]`,
-  tw`mobile:(h-[55rem])`,
   css`
     position: relative;
     transition: transform 0.3s;

--- a/frontend/src/components/Card/GroupInfoCard/HeadCard/HeadCardContent.tsx
+++ b/frontend/src/components/Card/GroupInfoCard/HeadCard/HeadCardContent.tsx
@@ -128,7 +128,6 @@ const HeadCardContent = ({
 
 const Content = styled.div([
   tw`text-m mt-2 gap-x-2`,
-  tw`tablet:(gap-x-[8rem])`,
   css`
     display: flex;
   `,

--- a/frontend/src/components/Card/GroupInfoCard/HeadCard/HeadCardContent.tsx
+++ b/frontend/src/components/Card/GroupInfoCard/HeadCard/HeadCardContent.tsx
@@ -128,42 +128,29 @@ const HeadCardContent = ({
 
 const Content = styled.div([
   tw`text-m mt-2 gap-x-2`,
-  tw`tablet:(gap-x-4 justify-evenly)`,
-  tw`mobile:(flex-col)`,
+  tw`tablet:(gap-x-[8rem])`,
   css`
     display: flex;
   `,
 ]);
 
 const ThemeCard = styled.div([
-  tw`w-[17.6rem] h-[28rem] bg-gray rounded-[2rem]`,
-  tw`mobile:(w-[14rem] h-[22.4rem] mx-auto)`,
+  tw`p-1 w-1/5 aspect-[1/1.6] bg-gray rounded-[2rem]`,
   css`
     display: flex;
-    align-items: center;
+    align-self: flex-start;
     justify-content: center;
   `,
 ]);
 
-const ThemeImg = styled.img([
-  tw`rounded-[0.5rem] w-[15.2rem] h-[24.32rem]`,
-  tw`mobile:(w-[12rem] h-[19.2rem])`,
-]);
+const ThemeImg = styled.img([tw`p-2 w-full aspect-[1/1.6]`]);
 
-const ThemeContent = styled.div([
-  css`
-    display: flex;
-    flex-direction: column;
-    justify-content: space-between;
-  `,
-]);
+const ThemeContent = styled.div([tw`w-4/5`]);
 
 const ThemeInfo = styled.div([]);
 
 const List = styled.div([
-  tw`mb-2 gap-x-8`,
-  tw`tablet:(gap-x-10)`,
-  tw`mobile:(gap-x-3)`,
+  tw`my-1`,
   css`
     display: flex;
     align-items: center;
@@ -237,6 +224,7 @@ const Text = styled.div([
 const TitleText = styled.div([
   tw`border-[0.1rem] border-white border-solid rounded-[1.5rem] px-2 py-1 h-[8rem] w-[25.6rem]`,
   tw`tablet:(max-w-[35.2rem] w-full)`,
+  tw`mobile:(w-full)`,
   css`
     display: flex;
     align-items: center;

--- a/frontend/tailwind.config.ts
+++ b/frontend/tailwind.config.ts
@@ -112,6 +112,9 @@ export default {
         'orange': '#e3651d',
         'border-default': '#5F6E76',
       },
+      aspectRatio: {
+        '1/6': '1 / 1.618',
+      },
     },
   },
   plugins: [],


### PR DESCRIPTION
## 🤷‍♂️ Description
카드 UI 디자인을 변경했어요.
aspect-ratio 적용을 위해 tailwind 설정은 건드렸어요. 아래와 같이 사용하면 됩니다.

```typescript
const ThemeImg = styled.img([tw`w-full aspect-[9/13] rounded-default`]);
```

aspect-ratio 적용하면서 발생한 이슈는 하단에 작성해두었어요.

https://jumpy-tarsier-1ea.notion.site/74c03e36633546e2b5c9496e7fd08597?pvs=4

<!-- 구현 한 기능에 대해 작성해 주세요. -->

## 📝 Primary Commits

<!-- 세부 구현 사항을 리스트로 작성해주세요. -->

- [X] 카드 UI 디자인을 변경



## 📷 Screenshots
![녹화_2024_01_23_21_34_42_736](https://github.com/boostcampwm2023/web03-LockFestival/assets/100738049/c5fbfa42-d961-4022-b3a4-3bf3e613b517)
<!--스크린샷으로 보여줄 수 있는 이미지가 있다면 첨부해주세요!-->

<!--BE의 경우 API 테스트 결과를 첨부해주세요-->

<!--마지막으로 이슈 생성 시 우측의 옵션들을 체크했는지 확인해주세요!-->

<!-- 이슈번호를 작성해주세요. -->
<!-- 여러 이슈를 입력시 comma(,) 단위로 구분해주세요 -->
<!-- ex) close #10, resolves #123 -->
closes #461 

<!-- ex) -->
<!-- closes #1 --> 

