### PR TITLE
Fix/FE/#457: 이전 채팅 불러 올때 채팅 유지 기능 버그 수정

### DIFF
--- a/frontend/src/pages/ChatRoom/components/ChatPanel/ChatPanel.tsx
+++ b/frontend/src/pages/ChatRoom/components/ChatPanel/ChatPanel.tsx
@@ -99,7 +99,7 @@ const ChatPanel = memo(function ChatPanel({ roomId, sendChat, getPastChat }: Cha
   }, [chatLogData]);
 
   useEffect(() => {
-    if (!isScrollToTop) {
+    if (!isScrollToTop || chatLogData.size === prevChatLogDataSize) {
       return;
     }
 

--- a/frontend/src/pages/ChatRoom/components/ChatPanel/ChatPanel.tsx
+++ b/frontend/src/pages/ChatRoom/components/ChatPanel/ChatPanel.tsx
@@ -105,16 +105,12 @@ const ChatPanel = memo(function ChatPanel({ roomId, sendChat, getPastChat }: Cha
 
     const pastChatSize = chatLogData.size - prevChatLogDataSize;
 
-    if (pastChatSize === 1 || (pastChatSize < PAGING_SIZE && prevChatLogDataSize === 0)) {
-      return;
-    }
-
     if (pastChatSize < PAGING_SIZE && prevChatLogDataSize !== 0) {
-      virtualizer.scrollToIndex(pastChatSize, { align: 'end' });
+      virtualizer.scrollToIndex(pastChatSize, { align: 'start' });
       return;
     }
 
-    if (pastChatSize === PAGING_SIZE) {
+    if (pastChatSize >= PAGING_SIZE) {
       virtualizer.scrollToIndex(PAGING_SIZE, { align: 'start' });
       return;
     }


### PR DESCRIPTION
## 🤷‍♂️ Description
이전 채팅을 불러온 다음 스크롤을 조정하는 로직을 수정했어요.

```js
 useEffect(() => {
    if (!isScrollToTop && chatLogData.size === prevChatLogDataSize) {
      return;
    }

    const pastChatSize = chatLogData.size - prevChatLogDataSize;

    if (pastChatSize < PAGING_SIZE && prevChatLogDataSize !== 0) {
      virtualizer.scrollToIndex(pastChatSize, { align: 'start' });
      return;
    }

    if (pastChatSize >= PAGING_SIZE) {
      virtualizer.scrollToIndex(PAGING_SIZE, { align: 'start' });
      return;
    }
  }, [chatLogData, prevChatLogDataSize]);
```

- chatLogData : 현재 전역 변수에 저장된 채팅 로그 데이터
- prevChatLogDataSize : 스크롤이 최상단으로 올라 갔을 때 이전 채팅을 불러오기 전 현재 채팅로그의 개수를 저장하는 변수

이전 채팅이 50개고, 불러오는 채팅이 50개면 chatLogData.size = 100, prevChatLogDataSize = 50 이 되어야하는데 이전 채팅을 불러오는 동안 chatLogData.size = 50, prevChatLogDataSize = 50 일때 스크롤이 움직이는 경우가 있어 이 때의 스크롤 움직임을 막아 주었더니 나머지 코드를 간단하게 수정할 수 있었습니다.

<!-- 구현 한 기능에 대해 작성해 주세요. -->

## 📝 Primary Commits

<!-- 세부 구현 사항을 리스트로 작성해주세요. -->

- [X] 보고있던 채팅 유지 기능 로직 수정

## 📷 Screenshots
#### 수정하기 전
https://github.com/boostcampwm2023/web03-LockFestival/assets/82202370/9531a0bb-c10e-4186-897f-f6a75627e5c7
#### 수정 후

https://github.com/boostcampwm2023/web03-LockFestival/assets/82202370/9b898cef-f160-446c-ae80-f0f0afc55f5a



<!--스크린샷으로 보여줄 수 있는 이미지가 있다면 첨부해주세요!-->

<!--BE의 경우 API 테스트 결과를 첨부해주세요-->

<!--마지막으로 이슈 생성 시 우측의 옵션들을 체크했는지 확인해주세요!-->

<!-- 이슈번호를 작성해주세요. -->
<!-- 여러 이슈를 입력시 comma(,) 단위로 구분해주세요 -->
<!-- ex) close #10, resolves #123 -->


<!-- ex) -->
<!-- closes #1 --> 

close #474 